### PR TITLE
feat(user-registry): User Off-Chain Properties

### DIFF
--- a/packages/asset-registry/src/test/AssetConsumingFacade.ts
+++ b/packages/asset-registry/src/test/AssetConsumingFacade.ts
@@ -73,7 +73,13 @@ describe('AssetConsumingLogic Facade', () => {
         userContractLookupAddr = (userContracts as any).UserContractLookup;
         userLogic = new UserLogic(web3, (userContracts as any).UserLogic);
 
-        await userLogic.setUser(accountDeployment, 'admin', { privateKey: privateKeyDeployment });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountDeployment,
+            'admin', 
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(
             accountDeployment,
@@ -97,9 +103,13 @@ describe('AssetConsumingLogic Facade', () => {
     });
 
     it('should onboard tests-users', async () => {
-        await userLogic.setUser(assetOwnerAddress, 'assetOwner', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            assetOwnerAddress,
+            'assetOwner',
+            { privateKey: privateKeyDeployment }
+        );
         await userLogic.setRoles(
             assetOwnerAddress,
             buildRights([Role.AssetManager, Role.AssetAdmin]),

--- a/packages/asset-registry/src/test/AssetConsumingLogic.ts
+++ b/packages/asset-registry/src/test/AssetConsumingLogic.ts
@@ -78,9 +78,13 @@ describe('AssetConsumingLogic', () => {
 
         userLogic = new UserLogic(web3 as any, (userContracts as any).UserLogic);
 
-        await userLogic.setUser(accountDeployment, 'admin', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountDeployment,
+            'admin',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(
             accountDeployment,
@@ -204,9 +208,13 @@ describe('AssetConsumingLogic', () => {
     it('should onboard tests-users', async () => {
         const userLogicAddress = await userContractLookup.userRegistry();
 
-        await userLogic.setUser(assetOwnerAddress, 'assetOwner', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            assetOwnerAddress,
+            'assetOwner',
+            { privateKey: privateKeyDeployment }
+        );
         await userLogic.setRoles(
             assetOwnerAddress,
             buildRights([Role.AssetManager, Role.AssetAdmin]),

--- a/packages/asset-registry/src/test/AssetConsumingLogic.ts
+++ b/packages/asset-registry/src/test/AssetConsumingLogic.ts
@@ -451,8 +451,9 @@ describe('AssetConsumingLogic', () => {
             fromBlock: tx.blockNumber,
             toBlock: tx.blockNumber
         }))[0];
-        assert.equal(event.event, 'LogNewMeterRead');
+        const TIMESTAMP = moment().unix();
 
+        assert.equal(event.event, 'LogNewMeterRead');
         assert.deepEqual(event.returnValues, {
             0: '0',
             1: '100',

--- a/packages/asset-registry/src/test/AssetContractLookup.ts
+++ b/packages/asset-registry/src/test/AssetContractLookup.ts
@@ -59,9 +59,13 @@ describe('AssetContractLookup', () => {
 
         userLogic = new UserLogic(web3 as any, (userContracts as any).UserLogic);
 
-        await userLogic.setUser(accountDeployment, 'admin', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountDeployment,
+            'admin',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(accountDeployment, 3, {
             privateKey: privateKeyDeployment

--- a/packages/asset-registry/src/test/AssetProducingFacade.ts
+++ b/packages/asset-registry/src/test/AssetProducingFacade.ts
@@ -76,7 +76,13 @@ describe('AssetProducing Facade', () => {
         userContractLookupAddr = (userContracts as any).UserContractLookup;
         userLogic = new UserLogic(web3, (userContracts as any).UserLogic);
 
-        await userLogic.setUser(accountDeployment, 'admin', { privateKey: privateKeyDeployment });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountDeployment,
+            'admin',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(
             accountDeployment,
@@ -100,9 +106,13 @@ describe('AssetProducing Facade', () => {
     });
 
     it('should onboard tests-users', async () => {
-        await userLogic.setUser(assetOwnerAddress, 'assetOwner', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            assetOwnerAddress,
+            'assetOwner',
+            { privateKey: privateKeyDeployment }
+        );
         await userLogic.setRoles(
             assetOwnerAddress,
             buildRights([Role.AssetManager, Role.AssetAdmin]),

--- a/packages/asset-registry/src/test/AssetProducingLogic.ts
+++ b/packages/asset-registry/src/test/AssetProducingLogic.ts
@@ -78,9 +78,13 @@ describe('AssetProducingLogic', () => {
 
         userLogic = new UserLogic(web3 as any, (userContracts as any).UserLogic);
 
-        await userLogic.setUser(accountDeployment, 'admin', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountDeployment,
+            'admin',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(
             accountDeployment,
@@ -210,9 +214,13 @@ describe('AssetProducingLogic', () => {
 
         //  userLogic = new UserLogic(web3, userLogicAddress);
 
-        await userLogic.setUser(assetOwnerAddress, 'assetOwner', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            assetOwnerAddress,
+            'assetOwner',
+            { privateKey: privateKeyDeployment }
+        );
         await userLogic.setRoles(
             assetOwnerAddress,
             buildRights([Role.AssetManager, Role.AssetAdmin]),

--- a/packages/market-matcher/src/test/StrategyBasedMatcherTest.ts
+++ b/packages/market-matcher/src/test/StrategyBasedMatcherTest.ts
@@ -94,7 +94,13 @@ describe('Test StrategyBasedMatcher', async () => {
         userContractLookupAddr = (userContracts as any).UserContractLookup;
 
         userLogic = new UserLogic(web3, (userContracts as any).UserLogic);
-        await userLogic.setUser(accountDeployment, 'admin', { privateKey: privateKeyDeployment });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountDeployment,
+            'admin',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(
             accountDeployment,
@@ -108,19 +114,36 @@ describe('Test StrategyBasedMatcher', async () => {
             { privateKey: privateKeyDeployment }
         );
 
-        await userLogic.setUser(accountTrader, 'trader', { privateKey: privateKeyDeployment });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountTrader,
+            'trader',
+            { privateKey: privateKeyDeployment }
+        );
+
         await userLogic.setRoles(accountTrader, buildRights([Role.Trader]), {
             privateKey: privateKeyDeployment
         });
 
-        await userLogic.setUser(assetOwnerAddress, 'assetOwner', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            assetOwnerAddress,
+            'assetOwner',
+            { privateKey: privateKeyDeployment }
+        );
         await userLogic.setRoles(assetOwnerAddress, buildRights([Role.AssetManager]), {
             privateKey: privateKeyDeployment
         });
 
-        await userLogic.setUser(issuerAccount, 'issuer', { privateKey: privateKeyDeployment });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            issuerAccount,
+            'issuer',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(issuerAccount, buildRights([Role.Issuer]), {
             privateKey: privateKeyDeployment

--- a/packages/market/src/test/MarketFacade.ts
+++ b/packages/market/src/test/MarketFacade.ts
@@ -85,7 +85,13 @@ describe('Market-Facade', () => {
         userContractLookupAddr = (userContracts as any).UserContractLookup;
 
         userLogic = new UserLogic(web3 as any, (userContracts as any).UserLogic);
-        await userLogic.setUser(accountDeployment, 'admin', { privateKey: privateKeyDeployment });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountDeployment,
+            'admin',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(
             accountDeployment,
@@ -99,14 +105,25 @@ describe('Market-Facade', () => {
             { privateKey: privateKeyDeployment }
         );
 
-        await userLogic.setUser(accountTrader, 'trader', { privateKey: privateKeyDeployment });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountTrader,
+            'trader',
+            { privateKey: privateKeyDeployment }
+        );
         await userLogic.setRoles(accountTrader, buildRights([Role.Trader]), {
             privateKey: privateKeyDeployment
         });
 
-        await userLogic.setUser(assetOwnerAddress, 'assetOwner', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            assetOwnerAddress,
+            'assetOwner',
+            { privateKey: privateKeyDeployment }
+        );
+
         await userLogic.setRoles(assetOwnerAddress, buildRights([Role.AssetManager]), {
             privateKey: privateKeyDeployment
         });

--- a/packages/market/src/test/MarketLogic.ts
+++ b/packages/market/src/test/MarketLogic.ts
@@ -101,7 +101,13 @@ describe('MarketLogic', () => {
         const userContracts = await migrateUserRegistryContracts(web3, privateKeyDeployment);
 
         userLogic = new UserLogic(web3 as any, (userContracts as any).UserLogic);
-        await userLogic.setUser(accountDeployment, 'admin', { privateKey: privateKeyDeployment });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountDeployment,
+            'admin',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(accountDeployment, 3, { privateKey: privateKeyDeployment });
 
@@ -241,11 +247,27 @@ describe('MarketLogic', () => {
     });
 
     it('should set right roles to users', async () => {
-        await userLogic.setUser(accountTrader, 'trader', { privateKey: privateKeyDeployment });
-        await userLogic.setUser(accountTrader2, 'trader', { privateKey: privateKeyDeployment });
-        await userLogic.setUser(accountAssetOwner, 'assetOwner', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountTrader,
+            'trader',
+            { privateKey: privateKeyDeployment }
+        );
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountTrader2,
+            'trader',
+            { privateKey: privateKeyDeployment }
+        );
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountAssetOwner,
+            'assetOwner',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(accountTrader, buildRights([Role.Trader]), {
             privateKey: privateKeyDeployment

--- a/packages/market/src/test/MarketLookupContract.ts
+++ b/packages/market/src/test/MarketLookupContract.ts
@@ -51,7 +51,13 @@ describe('MarketContractLookup', () => {
 
         const userLogic = new UserLogic(web3 as any, (userContracts as any).UserLogic);
 
-        await userLogic.setUser(accountDeployment, 'admin', { privateKey: privateKeyDeployment });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountDeployment,
+            'admin',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(
             accountDeployment,

--- a/packages/origin-ui/src/__tests__/AppContainer.test.tsx
+++ b/packages/origin-ui/src/__tests__/AppContainer.test.tsx
@@ -177,7 +177,7 @@ const deployDemo = async () => {
         'documentDBURL',
         ACCOUNTS.ADMIN.address,
         'admin',
-        { privateKey: privateKeyDeployment }
+        { privateKey: adminPK }
     );
     await userLogic.setRoles(
         ACCOUNTS.ADMIN.address,

--- a/packages/origin-ui/src/__tests__/AppContainer.test.tsx
+++ b/packages/origin-ui/src/__tests__/AppContainer.test.tsx
@@ -172,16 +172,26 @@ const deployDemo = async () => {
         logger
     };
 
-    await userLogic.setUser(ACCOUNTS.ADMIN.address, 'admin', { privateKey: adminPK });
+    await userLogic.createUser(
+        'propertiesDocumentHash',
+        'documentDBURL',
+        ACCOUNTS.ADMIN.address,
+        'admin',
+        { privateKey: privateKeyDeployment }
+    );
     await userLogic.setRoles(
         ACCOUNTS.ADMIN.address,
         buildRights([Role.UserAdmin, Role.AssetAdmin]),
         { privateKey: adminPK }
     );
 
-    await userLogic.setUser(ACCOUNTS.ASSET_MANAGER.address, 'Asset Manager organization', {
-        privateKey: adminPK
-    });
+    await userLogic.createUser(
+        'propertiesDocumentHash',
+        'documentDBURL',
+        ACCOUNTS.ASSET_MANAGER.address,
+        'Asset Manager organization',
+        { privateKey: adminPK }
+    );
     await userLogic.setRoles(ACCOUNTS.ASSET_MANAGER.address, buildRights([Role.AssetManager]), {
         privateKey: adminPK
     });

--- a/packages/origin-ui/src/__tests__/AppContainer.test.tsx
+++ b/packages/origin-ui/src/__tests__/AppContainer.test.tsx
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
 import { createRootReducer } from '../reducers';
 import {
+    User,
     migrateUserRegistryContracts,
     UserLogic,
     buildRights,
@@ -172,29 +173,47 @@ const deployDemo = async () => {
         logger
     };
 
-    await userLogic.createUser(
-        'propertiesDocumentHash',
-        'documentDBURL',
-        ACCOUNTS.ADMIN.address,
-        'admin',
-        { privateKey: adminPK }
-    );
-    await userLogic.setRoles(
-        ACCOUNTS.ADMIN.address,
-        buildRights([Role.UserAdmin, Role.AssetAdmin]),
-        { privateKey: adminPK }
-    );
+    const adminPropsOnChain: User.IUserOnChainProperties = {
+        propertiesDocumentHash: null,
+        url: null,
+        id: ACCOUNTS.ADMIN.address,
+        active: true,
+        roles: buildRights([Role.UserAdmin, Role.AssetAdmin]),
+        organization: 'admin'
+    };
+    const adminPropsOffChain: User.IUserOffChainProperties = {
+        firstName: 'Admin',
+        surname: 'User',
+        email: 'admin@example.com',
+        street: '',
+        number: '',
+        zip: '',
+        city: '',
+        country: '',
+        state: ''
+    };
+    await User.createUser(adminPropsOnChain, adminPropsOffChain, conf);
 
-    await userLogic.createUser(
-        'propertiesDocumentHash',
-        'documentDBURL',
-        ACCOUNTS.ASSET_MANAGER.address,
-        'Asset Manager organization',
-        { privateKey: adminPK }
-    );
-    await userLogic.setRoles(ACCOUNTS.ASSET_MANAGER.address, buildRights([Role.AssetManager]), {
-        privateKey: adminPK
-    });
+    const assetManagerPropsOnChain: User.IUserOnChainProperties = {
+        propertiesDocumentHash: null,
+        url: null,
+        id: ACCOUNTS.ASSET_MANAGER.address,
+        active: true,
+        roles: buildRights([Role.AssetManager]),
+        organization: 'Asset Manager organization'
+    };
+    const assetManagerPropsOffChain: User.IUserOffChainProperties = {
+        firstName: 'Asset',
+        surname: 'Manager',
+        email: 'assetmanager@example.com',
+        street: '',
+        number: '',
+        zip: '',
+        city: '',
+        country: '',
+        state: ''
+    };
+    await User.createUser(assetManagerPropsOnChain, assetManagerPropsOffChain, conf);
 
     const assetProducingProps: ProducingAsset.IOnChainProperties = {
         smartMeter: { address: ACCOUNTS.SMART_METER.address },

--- a/packages/origin-ui/src/__tests__/ProducingAssetTable.test.tsx
+++ b/packages/origin-ui/src/__tests__/ProducingAssetTable.test.tsx
@@ -13,14 +13,16 @@ const flushPromises = () => new Promise(setImmediate);
 
 jest.mock('@energyweb/user-registry', () => {
     return {
-      User: class User {
-          sync() {
-              return {
-                  organization: 'Example Organization'
-              }
-          }
-      }
-    }
+        User: {
+            Entity: class Entity {
+                sync() {
+                    return {
+                        organization: 'Example Organization'
+                    }
+                }
+            }
+        }
+    };
 });
 
 describe('ProducingAssetTable', () => {

--- a/packages/origin-ui/src/components/AssetMap.tsx
+++ b/packages/origin-ui/src/components/AssetMap.tsx
@@ -25,7 +25,7 @@ type Props = IOwnProps & IStateProps;
 
 interface State {
     assetHighlighted: Asset.Entity;
-    owner: User;
+    owner: User.Entity;
 }
 
 class AssetMapClass extends React.Component<Props, State> {
@@ -43,7 +43,7 @@ class AssetMapClass extends React.Component<Props, State> {
     async showWindowForAsset(asset: Asset.Entity) {
         this.setState({
             assetHighlighted: asset,
-            owner: await new User(asset.owner.address, this.props.configuration as any).sync()
+            owner: await new User.Entity(asset.owner.address, this.props.configuration as any).sync()
         });
     }
 

--- a/packages/origin-ui/src/components/CertificateDetailView.tsx
+++ b/packages/origin-ui/src/components/CertificateDetailView.tsx
@@ -44,7 +44,7 @@ type Props = IOwnProps & IStateProps;
 
 interface DetailViewState {
     newId: number;
-    owner: User;
+    owner: User.Entity;
     events: EnrichedEvent[];
 }
 
@@ -94,7 +94,7 @@ class CertificateDetailViewClass extends React.Component<Props, DetailViewState>
     async getOwner(props: Props, selectedCertificate: Certificate.Entity, cb) {
         this.setState(
             {
-                owner: await new User(selectedCertificate.owner, props.configuration as any).sync()
+                owner: await new User.Entity(selectedCertificate.owner, props.configuration as any).sync()
             },
             cb
         );
@@ -116,7 +116,7 @@ class CertificateDetailViewClass extends React.Component<Props, DetailViewState>
                         description = 'Logging by Asset #' + event.returnValues._assetId;
                         break;
                     case 'LogCreatedCertificate':
-                        const organization = (await new User(
+                        const organization = (await new User.Entity(
                             event.returnValues.owner,
                             props.configuration as any
                         ).sync()).organization;
@@ -133,16 +133,16 @@ class CertificateDetailViewClass extends React.Component<Props, DetailViewState>
                             '0x0000000000000000000000000000000000000000'
                         ) {
                             label = 'Set Initial Owner';
-                            description = (await new User(
+                            description = (await new User.Entity(
                                 (event as any).returnValues._to,
                                 props.configuration as any
                             ).sync()).organization;
                         } else {
-                            const newOwner = (await new User(
+                            const newOwner = (await new User.Entity(
                                 (event as any).returnValues._to,
                                 props.configuration as any
                             ).sync()).organization;
-                            const oldOwner = (await new User(
+                            const oldOwner = (await new User.Entity(
                                 (event as any).returnValues._from,
                                 props.configuration as any
                             ).sync()).organization;

--- a/packages/origin-ui/src/components/CertificateTable.tsx
+++ b/packages/origin-ui/src/components/CertificateTable.tsx
@@ -60,7 +60,7 @@ interface IStateProps {
     certificates: Certificate.Entity[];
     configuration: Configuration.Entity;
     producingAssets: ProducingAsset.Entity[];
-    currentUser: User;
+    currentUser: User.Entity;
     baseURL: string;
 }
 
@@ -68,7 +68,7 @@ type Props = IOwnProps & IStateProps;
 
 export interface IEnrichedCertificateData {
     certificate: Certificate.Entity;
-    certificateOwner: User;
+    certificateOwner: User.Entity;
     producingAsset: ProducingAsset.Entity;
     acceptedCurrency: string;
     offChainSettlementOptions: TradableEntity.IOffChainSettlementOptions;
@@ -351,7 +351,7 @@ class CertificateTableClass extends PaginatedLoaderFilteredSorted<
                 certificate,
                 producingAsset,
                 assetTypeLabel: ProducingAsset.Type[producingAsset.offChainProperties.assetType],
-                certificateOwner: await new User(certificate.owner, this.props.configuration as any).sync(),
+                certificateOwner: await new User.Entity(certificate.owner, this.props.configuration as any).sync(),
                 offChainSettlementOptions,
                 acceptedCurrency,
                 isOffChainSettlement

--- a/packages/origin-ui/src/components/Certificates.tsx
+++ b/packages/origin-ui/src/components/Certificates.tsx
@@ -29,7 +29,7 @@ import { getBaseURL, getCurrentUser, getDemands } from '../features/selectors';
 
 interface IStateProps {
     demands: Demand.Entity[];
-    currentUser: User;
+    currentUser: User.Entity;
     baseURL: string;
 }
 

--- a/packages/origin-ui/src/components/CertificationRequestsTable.tsx
+++ b/packages/origin-ui/src/components/CertificationRequestsTable.tsx
@@ -24,7 +24,7 @@ interface IOwnProps {
 interface IStateProps {
     configuration: Configuration.Entity;
     producingAssets: ProducingAsset.Entity[];
-    currentUser: User;
+    currentUser: User.Entity;
 }
 
 type Props = IOwnProps & IStateProps;

--- a/packages/origin-ui/src/components/ConsumingAssetDetailView.tsx
+++ b/packages/origin-ui/src/components/ConsumingAssetDetailView.tsx
@@ -47,7 +47,7 @@ type Props = IOwnProps & IStateProps;
 
 export interface IDetailViewState {
     newId: number;
-    owner: User;
+    owner: User.Entity;
     notSoldCertificates: number;
 }
 
@@ -96,7 +96,7 @@ class ConsumingAssetDetailViewClass extends React.Component<Props, IDetailViewSt
                 });
             }
             this.setState({
-                owner: await new User(selectedAsset.owner.address, props.configuration as any).sync()
+                owner: await new User.Entity(selectedAsset.owner.address, props.configuration as any).sync()
             });
         }
     }

--- a/packages/origin-ui/src/components/ConsumingAssetTable.tsx
+++ b/packages/origin-ui/src/components/ConsumingAssetTable.tsx
@@ -130,7 +130,7 @@ class ConsumingAssetTableClass extends PaginatedLoaderFiltered<
     ): Promise<IEnrichedConsumingAssetData[]> {
         const promises = consumingAssets.map(async (asset: ConsumingAsset.Entity) => ({
             asset,
-            organizationName: (await new User(asset.owner.address, this.props.configuration as any).sync())
+            organizationName: (await new User.Entity(asset.owner.address, this.props.configuration as any).sync())
                 .organization
         }));
 

--- a/packages/origin-ui/src/components/DemandTable.tsx
+++ b/packages/origin-ui/src/components/DemandTable.tsx
@@ -44,7 +44,7 @@ interface IStateProps {
     demands: Demand.Entity[];
     producingAssets: ProducingAsset.Entity[];
     consumingAssets: ConsumingAsset.Entity[];
-    currentUser: User;
+    currentUser: User.Entity;
     baseURL: string;
 }
 
@@ -56,7 +56,7 @@ export interface IDemandTableState extends IPaginatedLoaderState {
 
 export interface IEnrichedDemandData {
     demand: Demand.Entity;
-    demandOwner: User;
+    demandOwner: User.Entity;
     consumingAsset?: ConsumingAsset.Entity;
     producingAsset?: ProducingAsset.Entity;
 }
@@ -89,7 +89,7 @@ class DemandTableClass extends PaginatedLoader<Props, IDemandTableState> {
                 demand,
                 producingAsset: null,
                 consumingAsset: null,
-                demandOwner: await new User(demand.demandOwner, this.props.configuration).sync()
+                demandOwner: await new User.Entity(demand.demandOwner, this.props.configuration).sync()
             };
 
             if (demand.offChainProperties) {

--- a/packages/origin-ui/src/components/Header.tsx
+++ b/packages/origin-ui/src/components/Header.tsx
@@ -27,7 +27,7 @@ import { getBaseURL, getCurrentUser } from '../features/selectors';
 import { getAssetsLink, getCertificatesLink, getDemandsLink, getAdminLink } from '../utils/routing';
 
 interface StateProps {
-    currentUser: User;
+    currentUser: User.Entity;
     baseURL: string;
 }
 

--- a/packages/origin-ui/src/components/OnboardDemand.tsx
+++ b/packages/origin-ui/src/components/OnboardDemand.tsx
@@ -27,7 +27,7 @@ import { getConfiguration, getCurrentUser, getProducingAssets } from '../feature
 
 interface IStateProps {
     configuration: Configuration.Entity;
-    currentUser: User;
+    currentUser: User.Entity;
     producingAssets: ProducingAsset.Entity[];
 }
 

--- a/packages/origin-ui/src/components/ProducingAssetDetailView.tsx
+++ b/packages/origin-ui/src/components/ProducingAssetDetailView.tsx
@@ -54,7 +54,7 @@ interface IOwnProps {
 
 interface State {
     newId: number;
-    owner: User;
+    owner: User.Entity;
     notSoldCertificates: number;
 }
 
@@ -102,7 +102,7 @@ class ProducingAssetDetailViewClass extends React.Component<Props, State> {
                     });
                 }
                 this.setState({
-                    owner: await new User(selectedAsset.owner.address, props.configuration as any).sync()
+                    owner: await new User.Entity(selectedAsset.owner.address, props.configuration as any).sync()
                 });
             }
         }

--- a/packages/origin-ui/src/components/ProducingAssetTable.tsx
+++ b/packages/origin-ui/src/components/ProducingAssetTable.tsx
@@ -104,7 +104,7 @@ class ProducingAssetTableClass extends PaginatedLoaderFiltered<
                     certificate.owner === asset.owner.address &&
                     certificate.assetId.toString() === asset.id
             ),
-            organizationName: (await new User.Entity(asset.owner.address, this.props.configuration as any).sync())
+            organizationName: (await new User.Entity(asset.owner.address.toLowerCase(), this.props.configuration as any).sync())
                 .organization
         }));
 

--- a/packages/origin-ui/src/components/ProducingAssetTable.tsx
+++ b/packages/origin-ui/src/components/ProducingAssetTable.tsx
@@ -104,7 +104,7 @@ class ProducingAssetTableClass extends PaginatedLoaderFiltered<
                     certificate.owner === asset.owner.address &&
                     certificate.assetId.toString() === asset.id
             ),
-            organizationName: (await new User.Entity(asset.owner.address.toLowerCase(), this.props.configuration as any).sync())
+            organizationName: (await new User.Entity(asset.owner.address, this.props.configuration as any).sync())
                 .organization
         }));
 

--- a/packages/origin-ui/src/components/ProducingAssetTable.tsx
+++ b/packages/origin-ui/src/components/ProducingAssetTable.tsx
@@ -97,16 +97,19 @@ class ProducingAssetTableClass extends PaginatedLoaderFiltered<
     async enrichProducingAssetData(
         producingAssets: ProducingAsset.Entity[]
     ): Promise<IEnrichedProducingAssetData[]> {
-        const promises = producingAssets.map(async asset => ({
-            asset,
-            notSoldCertificates: this.props.certificates.filter(
-                (certificate: Certificate.Entity) =>
-                    certificate.owner === asset.owner.address &&
-                    certificate.assetId.toString() === asset.id
-            ),
-            organizationName: (await new User.Entity(asset.owner.address, this.props.configuration as any).sync())
-                .organization
-        }));
+        const promises = producingAssets.map(async asset => {
+            const user = await new User.Entity(asset.owner.address, this.props.configuration).sync();
+
+            return {
+                asset,
+                notSoldCertificates: this.props.certificates.filter(
+                    (certificate: Certificate.Entity) =>
+                        certificate.owner === asset.owner.address &&
+                        certificate.assetId.toString() === asset.id
+                ),
+                organizationName: user.organization
+            };
+        });
 
         return Promise.all(promises);
     }

--- a/packages/origin-ui/src/components/ProducingAssetTable.tsx
+++ b/packages/origin-ui/src/components/ProducingAssetTable.tsx
@@ -47,7 +47,7 @@ interface IStateProps {
     configuration: Configuration.Entity;
     certificates: Certificate.Entity[];
     producingAssets: ProducingAsset.Entity[];
-    currentUser: User;
+    currentUser: User.Entity;
     baseURL: string;
 }
 
@@ -104,7 +104,7 @@ class ProducingAssetTableClass extends PaginatedLoaderFiltered<
                     certificate.owner === asset.owner.address &&
                     certificate.assetId.toString() === asset.id
             ),
-            organizationName: (await new User(asset.owner.address, this.props.configuration as any).sync())
+            organizationName: (await new User.Entity(asset.owner.address, this.props.configuration as any).sync())
                 .organization
         }));
 

--- a/packages/origin-ui/src/features/actions.ts
+++ b/packages/origin-ui/src/features/actions.ts
@@ -61,7 +61,7 @@ export const consumingAssetCreatedOrUpdated = (consumingAsset: ConsumingAsset.En
     consumingAsset
 });
 
-export const currentUserUpdated = (user: User): any => ({
+export const currentUserUpdated = (user: User.Entity): any => ({
     type: Actions.currentUserUpdated,
     user
 });

--- a/packages/origin-ui/src/features/contracts/sagas.ts
+++ b/packages/origin-ui/src/features/contracts/sagas.ts
@@ -226,7 +226,7 @@ function* fillOriginContractLookupAddressIfMissing(): SagaIterator {
 
                 let currentUser: User.Entity;
                 if (accounts.length > 0) {
-                    currentUser = new User.Entity(accounts[0].toLowerCase(), configuration);
+                    currentUser = new User.Entity(accounts[0], configuration);
 
                     currentUser = yield apply(currentUser, currentUser.sync, []);
                 }

--- a/packages/origin-ui/src/features/contracts/sagas.ts
+++ b/packages/origin-ui/src/features/contracts/sagas.ts
@@ -226,7 +226,7 @@ function* fillOriginContractLookupAddressIfMissing(): SagaIterator {
 
                 let currentUser: User.Entity;
                 if (accounts.length > 0) {
-                    currentUser = new User.Entity(accounts[0], configuration);
+                    currentUser = new User.Entity(accounts[0].toLowerCase(), configuration);
 
                     currentUser = yield apply(currentUser, currentUser.sync, []);
                 }

--- a/packages/origin-ui/src/features/contracts/sagas.ts
+++ b/packages/origin-ui/src/features/contracts/sagas.ts
@@ -224,9 +224,9 @@ function* fillOriginContractLookupAddressIfMissing(): SagaIterator {
                     configuration.blockchainProperties.web3.eth.getAccounts
                 );
 
-                let currentUser: User;
+                let currentUser: User.Entity;
                 if (accounts.length > 0) {
-                    currentUser = new User(accounts[0], configuration);
+                    currentUser = new User.Entity(accounts[0], configuration);
 
                     currentUser = yield apply(currentUser, currentUser.sync, []);
                 }

--- a/packages/origin-ui/src/types/index.tsx
+++ b/packages/origin-ui/src/types/index.tsx
@@ -29,7 +29,7 @@ export interface IStoreState {
     consumingAssets: ConsumingAsset.Entity[];
     certificates: Certificate.Entity[];
     demands: Demand.Entity[];
-    currentUser: User;
+    currentUser: User.Entity;
     general: IGeneralState;
     contracts: IContractsState;
     router: RouterState;

--- a/packages/origin/src/test/CertificateLogic.ts
+++ b/packages/origin/src/test/CertificateLogic.ts
@@ -111,7 +111,13 @@ describe('CertificateLogic-Facade', () => {
         const userContracts = await migrateUserRegistryContracts(web3 as any, privateKeyDeployment);
         userLogic = new UserLogic(web3 as any, (userContracts as any).UserLogic);
 
-        await userLogic.setUser(accountDeployment, 'admin', { privateKey: privateKeyDeployment });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountDeployment,
+            'admin',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(
             accountDeployment,
@@ -178,11 +184,21 @@ describe('CertificateLogic-Facade', () => {
     });
 
     it('should onboard tests-users', async () => {
-        await userLogic.setUser(accountAssetOwner, 'assetOwner', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountAssetOwner,
+            'assetOwner',
+            { privateKey: privateKeyDeployment }
+        );
 
-        await userLogic.setUser(accountTrader, 'trader', { privateKey: privateKeyDeployment });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            accountTrader,
+            'trader',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(accountTrader, buildRights([Role.Trader]), {
             privateKey: privateKeyDeployment
@@ -191,7 +207,13 @@ describe('CertificateLogic-Facade', () => {
             privateKey: privateKeyDeployment
         });
 
-        await userLogic.setUser(issuerAccount, 'issuer', { privateKey: privateKeyDeployment });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            issuerAccount,
+            'issuer',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(issuerAccount, buildRights([Role.Issuer]), {
             privateKey: privateKeyDeployment
@@ -986,9 +1008,13 @@ describe('CertificateLogic-Facade', () => {
 
         testReceiver = new TestReceiver(web3, testReceiverAddress);
 
-        await userLogic.setUser(testReceiverAddress, 'testReceiverAddress', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            testReceiverAddress,
+            'testReceiverAddress',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(testReceiverAddress, buildRights([Role.AssetManager]), {
             privateKey: privateKeyDeployment
@@ -1094,9 +1120,13 @@ describe('CertificateLogic-Facade', () => {
 
         testReceiver = new TestReceiver(web3, testReceiverAddress);
 
-        await userLogic.setUser(testReceiverAddress, 'testReceiverAddress', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            testReceiverAddress,
+            'testReceiverAddress',
+            { privateKey: privateKeyDeployment }
+        );
 
         await userLogic.setRoles(testReceiverAddress, buildRights([Role.AssetManager]), {
             privateKey: privateKeyDeployment

--- a/packages/origin/src/test/CertificateLogicContracts.ts
+++ b/packages/origin/src/test/CertificateLogicContracts.ts
@@ -99,9 +99,13 @@ describe('CertificateLogic', () => {
 
             userLogic = new UserLogic(web3 as any, (userContracts as any).UserLogic);
 
-            await userLogic.setUser(accountDeployment, 'admin', {
-                privateKey: privateKeyDeployment
-            });
+            await userLogic.createUser(
+                'propertiesDocumentHash',
+                'documentDBURL',
+                accountDeployment,
+                'admin',
+                { privateKey: privateKeyDeployment }
+            );
 
             await userLogic.setRoles(
                 accountDeployment,
@@ -287,13 +291,27 @@ describe('CertificateLogic', () => {
         });
 
         it('should set right roles to users', async () => {
-            await userLogic.setUser(accountTrader, 'trader', { privateKey: privateKeyDeployment });
-            await userLogic.setUser(accountAssetOwner, 'assetOwner', {
-                privateKey: privateKeyDeployment
-            });
-            await userLogic.setUser(testreceiver.web3Contract._address, 'testreceiver', {
-                privateKey: privateKeyDeployment
-            });
+            await userLogic.createUser(
+                'propertiesDocumentHash',
+                'documentDBURL',
+                accountTrader,
+                'trader',
+                { privateKey: privateKeyDeployment }
+            );
+            await userLogic.createUser(
+                'propertiesDocumentHash',
+                'documentDBURL',
+                accountAssetOwner,
+                'assetOwner',
+                { privateKey: privateKeyDeployment }
+            );
+            await userLogic.createUser(
+                'propertiesDocumentHash',
+                'documentDBURL',
+                testreceiver.web3Contract._address,
+                'testreceiver',
+                { privateKey: privateKeyDeployment }
+            );
 
             await userLogic.setRoles(
                 testreceiver.web3Contract._address,
@@ -311,7 +329,13 @@ describe('CertificateLogic', () => {
                 { privateKey: privateKeyDeployment }
             );
 
-            await userLogic.setUser(issuerAccount, 'issuer', { privateKey: privateKeyDeployment });
+            await userLogic.createUser(
+                'propertiesDocumentHash',
+                'documentDBURL',
+                issuerAccount,
+                'issuer',
+                { privateKey: privateKeyDeployment }
+            );
 
             await userLogic.setRoles(issuerAccount, buildRights([Role.Issuer]), {
                 privateKey: privateKeyDeployment
@@ -1894,9 +1918,13 @@ describe('CertificateLogic', () => {
             });
 
             it('should set matcherAccount roles', async () => {
-                await userLogic.setUser(matcherAccount, 'matcherAccount', {
-                    privateKey: privateKeyDeployment
-                });
+                await userLogic.createUser(
+                    'propertiesDocumentHash',
+                    'documentDBURL',
+                    matcherAccount,
+                    'matcherAccount',
+                    { privateKey: privateKeyDeployment }
+                );
                 await userLogic.setRoles(matcherAccount, buildRights([Role.Trader]), {
                     privateKey: privateKeyDeployment
                 });
@@ -2289,10 +2317,14 @@ describe('CertificateLogic', () => {
                 assert.isTrue(failed);
             });
 
-            it('should set approvedAccount roles', async () => {
-                await userLogic.setUser(approvedAccount, 'approvedAccount', {
-                    privateKey: privateKeyDeployment
-                });
+            it('should set approvedAccount roles', async () => 
+                await userLogic.createUser(
+                    'propertiesDocumentHash',
+                    'documentDBURL',
+                    approvedAccount,
+                    'approvedAccount',
+                    { privateKey: privateKeyDeployment }
+                );
                 await userLogic.setRoles(approvedAccount, buildRights([Role.Trader]), {
                     privateKey: privateKeyDeployment
                 });

--- a/packages/origin/src/test/CertificateLogicContracts.ts
+++ b/packages/origin/src/test/CertificateLogicContracts.ts
@@ -2317,7 +2317,7 @@ describe('CertificateLogic', () => {
                 assert.isTrue(failed);
             });
 
-            it('should set approvedAccount roles', async () => 
+            it('should set approvedAccount roles', async () => {
                 await userLogic.createUser(
                     'propertiesDocumentHash',
                     'documentDBURL',

--- a/packages/origin/src/test/EnergyCertificateBundleLogic.ts
+++ b/packages/origin/src/test/EnergyCertificateBundleLogic.ts
@@ -100,9 +100,13 @@ describe('EnergyCertificateBundleLogic', () => {
 
             userLogic = new UserLogic(web3 as any, (userContracts as any).UserLogic);
 
-            await userLogic.setUser(accountDeployment, 'admin', {
-                privateKey: privateKeyDeployment
-            });
+            await userLogic.createUser(
+                'propertiesDocumentHash',
+                'documentDBURL',
+                accountDeployment,
+                'admin',
+                { privateKey: privateKeyDeployment }
+            );
 
             await userLogic.setRoles(
                 accountDeployment,
@@ -110,7 +114,13 @@ describe('EnergyCertificateBundleLogic', () => {
                 { privateKey: privateKeyDeployment }
             );
 
-            await userLogic.setUser(issuerAccount, 'issuer', { privateKey: privateKeyDeployment });
+            await userLogic.createUser(
+                'propertiesDocumentHash',
+                'documentDBURL',
+                issuerAccount,
+                'issuer',
+                { privateKey: privateKeyDeployment }
+            );
 
             await userLogic.setRoles(issuerAccount, buildRights([Role.Issuer]), {
                 privateKey: privateKeyDeployment
@@ -315,10 +325,20 @@ describe('EnergyCertificateBundleLogic', () => {
         });
 
         it('should set right roles to users', async () => {
-            await userLogic.setUser(accountTrader, 'trader', { privateKey: privateKeyDeployment });
-            await userLogic.setUser(accountAssetOwner, 'assetOwner', {
-                privateKey: privateKeyDeployment
-            });
+            await userLogic.createUser(
+                'propertiesDocumentHash',
+                'documentDBURL',
+                accountTrader,
+                'trader',
+                { privateKey: privateKeyDeployment }
+            );
+            await userLogic.createUser(
+                'propertiesDocumentHash',
+                'documentDBURL',
+                accountAssetOwner,
+                'assetOwner',
+                { privateKey: privateKeyDeployment }
+            );
 
             await userLogic.setRoles(accountTrader, buildRights([Role.Trader]), {
                 privateKey: privateKeyDeployment
@@ -1968,9 +1988,13 @@ describe('EnergyCertificateBundleLogic', () => {
             });
 
             it('should reset matcherAccount roles to 0', async () => {
-                await userLogic.setUser(matcherAccount, 'matcherAccount', {
-                    privateKey: privateKeyDeployment
-                });
+                await userLogic.createUser(
+                    'propertiesDocumentHash',
+                    'documentDBURL',
+                    matcherAccount,
+                    'matcherAccount',
+                    { privateKey: privateKeyDeployment }
+                );
                 await userLogic.setRoles(matcherAccount, buildRights([]), {
                     privateKey: privateKeyDeployment
                 });
@@ -1994,9 +2018,13 @@ describe('EnergyCertificateBundleLogic', () => {
             });
 
             it('should reset matcherAccount roles to trader', async () => {
-                await userLogic.setUser(matcherAccount, 'matcherAccount', {
-                    privateKey: privateKeyDeployment
-                });
+                await userLogic.createUser(
+                    'propertiesDocumentHash',
+                    'documentDBURL',
+                    matcherAccount,
+                    'matcherAccount',
+                    { privateKey: privateKeyDeployment }
+                );
                 await userLogic.setRoles(matcherAccount, buildRights([Role.Trader]), {
                     privateKey: privateKeyDeployment
                 });
@@ -2252,9 +2280,13 @@ describe('EnergyCertificateBundleLogic', () => {
             });
 
             it('should reset matcherAccount roles to 0', async () => {
-                await userLogic.setUser(matcherAccount, 'matcherAccount', {
-                    privateKey: privateKeyDeployment
-                });
+                await userLogic.createUser(
+                    'propertiesDocumentHash',
+                    'documentDBURL',
+                    matcherAccount,
+                    'matcherAccount',
+                    { privateKey: privateKeyDeployment }
+                );
                 await userLogic.setRoles(matcherAccount, buildRights([]), {
                     privateKey: privateKeyDeployment
                 });
@@ -2278,9 +2310,13 @@ describe('EnergyCertificateBundleLogic', () => {
             });
 
             it('should reset matcherAccount roles to trader', async () => {
-                await userLogic.setUser(matcherAccount, 'matcherAccount', {
-                    privateKey: privateKeyDeployment
-                });
+                await userLogic.createUser(
+                    'propertiesDocumentHash',
+                    'documentDBURL',
+                    matcherAccount,
+                    'matcherAccount',
+                    { privateKey: privateKeyDeployment }
+                );
                 await userLogic.setRoles(matcherAccount, buildRights([Role.Trader]), {
                     privateKey: privateKeyDeployment
                 });
@@ -2542,9 +2578,13 @@ describe('EnergyCertificateBundleLogic', () => {
             });
 
             it('should set role to approved account', async () => {
-                await userLogic.setUser(approvedAccount, 'approvedAccount', {
-                    privateKey: privateKeyDeployment
-                });
+                await userLogic.createUser(
+                    'propertiesDocumentHash',
+                    'documentDBURL',
+                    approvedAccount,
+                    'approvedAccount',
+                    { privateKey: privateKeyDeployment }
+                );
                 await userLogic.setRoles(approvedAccount, buildRights([Role.Trader]), {
                     privateKey: privateKeyDeployment
                 });
@@ -4283,9 +4323,13 @@ describe('EnergyCertificateBundleLogic', () => {
             });
 
             it('should be able to transfer bundle again + auto retire #2', async () => {
-                await userLogic.setUser(testreceiver.web3Contract._address, 'TestReceiver', {
-                    privateKey: privateKeyDeployment
-                });
+                await userLogic.createUser(
+                    'propertiesDocumentHash',
+                    'documentDBURL',
+                    testreceiver.web3Contract._address,
+                    'TestReceiver',
+                    { privateKey: privateKeyDeployment }
+                );
 
                 await userLogic.setRoles(
                     testreceiver.web3Contract._address,

--- a/packages/user-registry/.gitignore
+++ b/packages/user-registry/.gitignore
@@ -2,3 +2,5 @@
 node_modules
 dist
 build
+schemas
+db.json

--- a/packages/user-registry/.travis.yml
+++ b/packages/user-registry/.travis.yml
@@ -15,5 +15,5 @@ before_script:
 script:
   # - npm run lint
   - npm run deploy-contracts
-  - npm run build-ts
+  - npm run build
   - npm test

--- a/packages/user-registry/contracts/Users/UserDB.sol
+++ b/packages/user-registry/contracts/Users/UserDB.sol
@@ -24,6 +24,8 @@ import "@energyweb/utils-general/contracts/Msc/Owned.sol";
 contract UserDB is Owned {
 
     struct User {
+        string propertiesDocumentHash;
+        string documentDBURL;
         string organization;
         uint roles;
         bool active;
@@ -59,11 +61,15 @@ contract UserDB is Owned {
     }
 
     /// @notice function for creating, editing an user, it cannot be used to set a Role of an user
-    /// @notice if the user does not exists yet it will be creates, otherwise the older userdata will be overwritten
+    /// @notice if the user does not exists yet it will be created, otherwise the older userdata will be overwritten
     /// @dev the onlyOwner-modifier is used, so that only the logic-contract is allowed to write into the storage
     /// @param _user address of the user
     /// @param _organization organization the user is representing
-    function setUser(
+    /// @param _propertiesDocumentHash document-hash with all the properties of the demand
+	/// @param _documentDBURL url-address of the demand
+    function createUser(
+        string calldata _propertiesDocumentHash,
+        string calldata _documentDBURL,
         address _user,
         string calldata _organization
     )
@@ -71,6 +77,8 @@ contract UserDB is Owned {
         onlyOwner
     {
         User storage u = userList[_user];
+        u.propertiesDocumentHash = _propertiesDocumentHash;
+        u.documentDBURL = _documentDBURL;
         u.organization = _organization;
         u.active = true;
     }

--- a/packages/user-registry/contracts/Users/UserLogic.sol
+++ b/packages/user-registry/contracts/Users/UserLogic.sol
@@ -62,11 +62,15 @@ contract UserLogic is RoleManagement, Updatable, RolesInterface {
         db.setRoles(_admin, 2**uint(RoleManagement.Role.UserAdmin));
     }
 
-    /// @notice funciton that can be called to create a new user in the storage-contract, only executable for user-admins!
-    /// @notice if the user does not exists yet it will be creates, otherwise the older userdata will be overwritten
+    /// @notice function that can be called to create a new user in the storage-contract, only executable by user-admins!
+    /// @notice if the user does not exists yet it will be created, otherwise the older userdata will be overwritten
+	/// @param _propertiesDocumentHash document-hash with all the properties of the demand
+	/// @param _documentDBURL url-address of the demand
     /// @param _user address of the user
     /// @param _organization organization the user is representing
-    function setUser(
+    function createUser(
+        string calldata _propertiesDocumentHash,
+        string calldata _documentDBURL,
         address _user,
         string calldata _organization
     )
@@ -74,8 +78,13 @@ contract UserLogic is RoleManagement, Updatable, RolesInterface {
         onlyRole(RoleManagement.Role.UserAdmin)
     {
         bytes memory orgBytes = bytes(_organization);
-        require(orgBytes.length>0, "empty string");
-        db.setUser(_user, _organization);
+        require(orgBytes.length > 0, "empty string");
+        db.createUser(
+            _propertiesDocumentHash,
+            _documentDBURL,
+            _user,
+            _organization
+        );
     }
 
     /// @notice function to set / edit the rights of an user / account, only executable for Top-Admins!
@@ -111,17 +120,21 @@ contract UserLogic is RoleManagement, Updatable, RolesInterface {
 
     /// @notice function to return all the data of an user
     /// @param _user user
-    /// @return returns firstName, surname, organization, street, number, zip, city, country, state, roles and the active-flag
+    /// @return returns user
     function getFullUser(address _user)
         external
         view
         returns (
+            string memory _propertiesDocumentHash,
+            string memory _documentDBURL,
             string memory _organization,
             uint _roles,
             bool _active
         )
     {
         UserDB.User memory user = db.getFullUser(_user);
+        _propertiesDocumentHash = user.propertiesDocumentHash;
+        _documentDBURL = user.documentDBURL;
         _organization = user.organization;
         _roles = user.roles;
         _active = user.active;

--- a/packages/user-registry/package.json
+++ b/packages/user-registry/package.json
@@ -21,9 +21,10 @@
     "test": "test"
   },
   "scripts": {
+    "clean": "rm -rf build schemas db.json dist",
     "build": "./scripts/build.js",
     "build-and-deploy": "npm run build-ts && npm run deploy-contracts",
-    "prebuild-ts": "rm -rf dist/js",
+    "prebuild": "rm -rf dist/js",
     "build-ts": "rm -rf dist/js && tsc",
     "compile": "truffle compile",
     "deploy-contracts": "truffle migrate",
@@ -31,13 +32,18 @@
     "lint-fix": "solium -d contracts --fix && tslint --fix 'src/**/*{.ts,.tsx}'",
     "prepare": "scripts/build.js",
     "start-ganache": "ganache-cli -m 'chalk park staff buzz chair purchase wise oak receive avoid avoid home' -l 8000000 -e 1000000 -a 20",
+    "start-test-backend": "node ../../node_modules/@energyweb/utils-testbackend/dist/js/src/index.js",
     "test": "npm run build && mocha dist/js/src/test/ --timeout 60000",
     "prettier": "prettier --write --config-precedence file-override './src/**/*'",
-    "test-contracts": "concurrently --success first --kill-others -n eth,test \"yarn start-ganache\" \"yarn test\""
+    "test-contracts": "concurrently --success first --kill-others -n eth,test \"yarn start-ganache\" \"yarn start-test-backend\" \"yarn test\"",
+    "prebuild-schemas": "rm -rf dist/schemas && mkdir -p dist/schemas && rm -rf schemas && mkdir schemas",
+    "build-schemas": "npm run prebuild-schemas && npm run build-schema:UserPropertiesOffChain && cp -R schemas dist/schemas",
+    "build-schema:UserPropertiesOffChain": "typescript-json-schema --ignoreErrors --required src/blockchain-facade/Users/User.ts IUserOffChainProperties > schemas/UserOffChainProperties.schema.json"
   },
   "types": "dist/js/src/index.d.ts",
   "dependencies": {
     "@energyweb/utils-general": "1.1.0",
+    "@energyweb/utils-testbackend": "1.1.0",
     "ew-utils-deployment": "0.3.0",
     "typedarray-to-buffer": "3.1.5",
     "web3": "1.0.0-beta.37",
@@ -61,8 +67,8 @@
   },
   "postinstall": "rm -f node_modules/web3/index.d.ts",
   "gitHead": "54beaf7fe6686810de74ca290daf99cbde510f9d",
-  "publishConfig" : {
-    "access" : "public",
+  "publishConfig": {
+    "access": "public",
     "registry": "https://registry.npmjs.org"
   }
 }

--- a/packages/user-registry/scripts/build.js
+++ b/packages/user-registry/scripts/build.js
@@ -50,6 +50,7 @@ async function run() {
   console.log('EW-USER-REGISTRY-LIB: Building...');
 
   await executeCommand('yarn compile', ROOT_DIRECTORY)
+  await executeCommand('yarn build-schemas', ROOT_DIRECTORY)
   await executeCommand('yarn build-ts', ROOT_DIRECTORY)
 
   if (!(await fs.pathExists(`${ROOT_DIRECTORY}/dist/js/src`))) {

--- a/packages/user-registry/src/blockchain-facade/Users/User.ts
+++ b/packages/user-registry/src/blockchain-facade/Users/User.ts
@@ -106,13 +106,13 @@ export class Entity extends BlockchainDataModelEntity.Entity
     }
 
     getUrl(): string {
-        const userLogicInstanceAddress = this.configuration.blockchainProperties.userLogicInstance.web3Contract._address;
+        const userLogicInstanceAddress = this.configuration.blockchainProperties.userLogicInstance.web3Contract._address.toLowerCase();
 
         return `${this.configuration.offChainDataSource.baseUrl}/User/${userLogicInstanceAddress}`;
     }
 
     async sync(): Promise<Entity> {
-        if (this.id != null) {
+        if (this.id !== null) {
             const userData = await this.configuration.blockchainProperties.userLogicInstance.getFullUser(
                 this.id
             );

--- a/packages/user-registry/src/blockchain-facade/Users/User.ts
+++ b/packages/user-registry/src/blockchain-facade/Users/User.ts
@@ -100,6 +100,10 @@ export class Entity extends BlockchainDataModelEntity.Entity
     initialized: boolean;
 
     constructor(accountAddress: string, configuration: Configuration.Entity) {
+        if (accountAddress) {
+            accountAddress = accountAddress.toLowerCase();
+        }
+
         super(accountAddress, configuration);
 
         this.initialized = false;

--- a/packages/user-registry/src/index.ts
+++ b/packages/user-registry/src/index.ts
@@ -1,18 +1,4 @@
-// Copyright 2018 Energy Web Foundation
-// This file is part of the Origin Application brought to you by the Energy Web Foundation,
-// a global non-profit organization focused on accelerating blockchain technology across the energy sector,
-// incorporated in Zug, Switzerland.
-//
-// The Origin Application is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-// This is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY and without an implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details, at <http://www.gnu.org/licenses/>.
-//
-// @authors: slock.it GmbH; Heiko Burkhardt, heiko.burkhardt@slock.it; Martin Kuechler, martin.kuchler@slock.it
+import * as User from './blockchain-facade/Users/User';
 
 export { UserLogic } from './wrappedContracts/UserLogic';
 export { UserContractLookup } from './wrappedContracts/UserContractLookup';
@@ -23,7 +9,6 @@ import UserContractLookupJSON from '../build/contracts/UserContractLookup.json';
 export { UserDBJSON, UserLogicJSON, UserContractLookupJSON };
 
 export { migrateUserRegistryContracts } from './utils/migrateContracts';
-
-export { User, IUserPropertiesOffChain, IUserPropertiesOnChain } from './blockchain-facade/Users/User';
 export { createBlockchainProperties } from './blockchain-facade/BlockchainPropertiesFactory';
 export * from './wrappedContracts/RoleManagement';
+export { User };

--- a/packages/user-registry/src/test/UserLogic.ts
+++ b/packages/user-registry/src/test/UserLogic.ts
@@ -121,8 +121,12 @@ describe('UserLogic', () => {
             await userLogic.getFullUser('0x1000000000000000000000000000000000000005'),
             {
                 0: '',
-                1: '0',
-                2: false,
+                1: '',
+                2: '',
+                3: '0',
+                4: false,
+                _documentDBURL: '',
+                _propertiesDocumentHash: '',
                 _organization: '',
                 _roles: '0',
                 _active: false
@@ -144,16 +148,25 @@ describe('UserLogic', () => {
     });
 
     it('should return correct values for an existing user', async () => {
-        await userLogic.setUser('0x1000000000000000000000000000000000000005', 'TestOrganization', {
-            privateKey: privateKeyDeployment
-        });
+        await userLogic.createUser(
+            'propertiesDocumentHash',
+            'documentDBURL',
+            '0x1000000000000000000000000000000000000005',
+            'TestOrganization', {
+                privateKey: privateKeyDeployment
+            }
+        );
 
         assert.deepEqual(
             await userLogic.getFullUser('0x1000000000000000000000000000000000000005'),
             {
-                0: 'TestOrganization',
-                1: '0',
-                2: true,
+                0: 'propertiesDocumentHash',
+                1: 'documentDBURL',
+                2: 'TestOrganization',
+                3: '0',
+                4: true,
+                _propertiesDocumentHash: 'propertiesDocumentHash',
+                _documentDBURL: 'documentDBURL',
                 _organization: 'TestOrganization',
                 _roles: '0',
                 _active: true
@@ -186,9 +199,13 @@ describe('UserLogic', () => {
         assert.deepEqual(
             await userLogic.getFullUser('0x1000000000000000000000000000000000000005'),
             {
-                0: 'TestOrganization',
-                1: '1',
-                2: true,
+                0: 'propertiesDocumentHash',
+                1: 'documentDBURL',
+                2: 'TestOrganization',
+                3: '1',
+                4: true,
+                _propertiesDocumentHash: 'propertiesDocumentHash',
+                _documentDBURL: 'documentDBURL',
                 _organization: 'TestOrganization',
                 _roles: '1',
                 _active: true
@@ -227,7 +244,7 @@ describe('UserLogic', () => {
 
         const rights = buildRights([Role.AssetManager, Role.Trader]);
 
-        await userLogic.setUser(TEST_ACCOUNT, 'TestOrganization', {
+        await userLogic.createUser('propertiesDocumentHash', 'documentDBURL', TEST_ACCOUNT, 'TestOrganization', {
             privateKey: privateKeyDeployment
         });
 

--- a/packages/user-registry/src/test/UserLogicFacade.ts
+++ b/packages/user-registry/src/test/UserLogicFacade.ts
@@ -22,7 +22,7 @@ import {
     UserContractLookup
 } from '..';
 import { migrateUserRegistryContracts } from '../utils/migrateContracts';
-import { IUserPropertiesOnChain, IUserPropertiesOffChain, User } from '../blockchain-facade/Users/User';
+import { User } from '..';
 import { Configuration } from '@energyweb/utils-general';
 import { logger } from '../blockchain-facade/Logger';
 import Web3 from 'web3';
@@ -68,14 +68,16 @@ describe('UserLogic Facade', () => {
     });
 
     it('should create a user', async () => {
-        const userProps: IUserPropertiesOnChain = {
+        const userPropsOnChain: User.IUserOnChainProperties = {
+            url: null,
+            propertiesDocumentHash: null,
             id: user1,
             active: true,
             roles: RIGHTS,
             organization: 'Testorganization'
         };
 
-        const userPropsOffchain: IUserPropertiesOffChain = {
+        const userPropsOffChain: User.IUserOffChainProperties = {
             firstName: 'John',
             surname: 'Doe',
             email: 'john@doe.com',
@@ -96,63 +98,52 @@ describe('UserLogic Facade', () => {
                     privateKey: privateKeyDeployment
                 }
             },
+            offChainDataSource: {
+                baseUrl: 'http://localhost:3030'
+            },
             logger
         };
 
-        const user = await User.CREATE_USER(userProps, userPropsOffchain, conf);
+        const user = await User.createUser(userPropsOnChain, userPropsOffChain, conf);
 
         delete user.configuration;
+        delete user.offChainProperties;
         delete user.proofs;
+        delete user.propertiesDocumentHash;
+        delete user.url;
 
         assert.deepEqual(
             {
                 id: user1,
                 organization: 'Testorganization',
                 roles: RIGHTS,
-                active: true
+                active: true,
+                initialized: true
             } as any,
             user
         );
     });
 
     it('should return correct user', async () => {
-        const user = await new User(user1, conf).sync();
+        const user = await new User.Entity(user1, conf).sync();
 
         delete user.configuration;
+        delete user.offChainProperties;
+        delete user.proofs;
+        delete user.propertiesDocumentHash;
+        delete user.url;
 
         assert.deepEqual(user, {
             id: user1,
-            proofs: [],
             organization: 'Testorganization',
             roles: RIGHTS,
-            active: true
-        });
-
-        const emptyAccount = await new User(user2, conf).sync();
-        delete emptyAccount.configuration;
-
-        assert.deepEqual(emptyAccount, {
-            id: user2,
-            proofs: [],
-            organization: '',
-            roles: 0,
-            active: false
-        });
-
-        const adminAccount = await new User(accountDeployment, conf).sync();
-        delete adminAccount.configuration;
-
-        assert.deepEqual(adminAccount, {
-            id: accountDeployment,
-            proofs: [],
-            organization: '',
-            roles: 1,
-            active: false
+            active: true,
+            initialized: true
         });
     });
 
     it('isRole should work correctly', async () => {
-        const user = await new User(user1, conf).sync();
+        const user = await new User.Entity(user1, conf).sync();
 
         assert.ok(user.isRole(Role.AssetManager));
         assert.ok(user.isRole(Role.Trader));
@@ -160,5 +151,21 @@ describe('UserLogic Facade', () => {
         assert.notOk(user.isRole(Role.AssetAdmin));
         assert.notOk(user.isRole(Role.Matcher));
         assert.notOk(user.isRole(Role.UserAdmin));
+    });
+
+    it('Should get offChainProperties correctly', async () => {
+        const user = await new User.Entity(user1, conf).sync();
+
+        assert.deepEqual(user.offChainProperties, {
+            city: 'Shelbyville',
+            country: 'US',
+            email: 'john@doe.com',
+            firstName: 'John',
+            number: '101',
+            state: 'FL',
+            street: 'Evergreen Terrace',
+            surname: 'Doe',
+            zip: '14789'
+        });
     });
 });

--- a/packages/user-registry/src/test/UserLogicFacade.ts
+++ b/packages/user-registry/src/test/UserLogicFacade.ts
@@ -115,7 +115,7 @@ describe('UserLogic Facade', () => {
 
         assert.deepEqual(
             {
-                id: user1,
+                id: user1.toLowerCase(),
                 organization: 'Testorganization',
                 roles: RIGHTS,
                 active: true,

--- a/packages/user-registry/src/test/UserLogicFacade.ts
+++ b/packages/user-registry/src/test/UserLogicFacade.ts
@@ -104,10 +104,11 @@ describe('UserLogic Facade', () => {
             logger
         };
 
-        const user = await User.createUser(userPropsOnChain, userPropsOffChain, conf);
+        await User.createUser(userPropsOnChain, userPropsOffChain, conf);
+
+        const user = await new User.Entity(user1, conf).sync();
 
         delete user.configuration;
-        delete user.offChainProperties;
         delete user.proofs;
         delete user.propertiesDocumentHash;
         delete user.url;
@@ -118,28 +119,11 @@ describe('UserLogic Facade', () => {
                 organization: 'Testorganization',
                 roles: RIGHTS,
                 active: true,
-                initialized: true
+                initialized: true,
+                offChainProperties: userPropsOffChain
             } as any,
             user
         );
-    });
-
-    it('should return correct user', async () => {
-        const user = await new User.Entity(user1, conf).sync();
-
-        delete user.configuration;
-        delete user.offChainProperties;
-        delete user.proofs;
-        delete user.propertiesDocumentHash;
-        delete user.url;
-
-        assert.deepEqual(user, {
-            id: user1,
-            organization: 'Testorganization',
-            roles: RIGHTS,
-            active: true,
-            initialized: true
-        });
     });
 
     it('isRole should work correctly', async () => {

--- a/packages/user-registry/src/wrappedContracts/UserDB.ts
+++ b/packages/user-registry/src/wrappedContracts/UserDB.ts
@@ -69,8 +69,19 @@ export class UserDB extends GeneralFunctions {
         return await this.send(method, txParams);
     }
 
-    async setUser(_user: string, _organization: string, txParams?: SpecialTx) {
-        const method = this.web3Contract.methods.setUser(_user, _organization);
+    async createUser(
+        _propertiesDocumentHash: string,
+        _documentDBURL: string,
+        _user: string,
+        _organization: string, 
+        txParams?: SpecialTx
+    ) {
+        const method = this.web3Contract.methods.createUser(
+            _propertiesDocumentHash,
+            _documentDBURL,
+            _user,
+            _organization
+        );
 
         return await this.send(method, txParams);
     }

--- a/packages/user-registry/src/wrappedContracts/UserLogic.ts
+++ b/packages/user-registry/src/wrappedContracts/UserLogic.ts
@@ -79,8 +79,19 @@ export class UserLogic extends GeneralFunctions {
         return await this.send(method, txParams);
     }
 
-    async setUser(_user: string, _organization: string, txParams?: SpecialTx) {
-        const method = this.web3Contract.methods.setUser(_user, _organization);
+    async createUser(
+        _propertiesDocumentHash: string,
+        _documentDBURL: string,
+        _user: string,
+        _organization: string,
+        txParams?: SpecialTx
+    ) {
+        const method = this.web3Contract.methods.createUser(
+            _propertiesDocumentHash,
+            _documentDBURL,
+            _user,
+            _organization
+        );
 
         return await this.send(method, txParams);
     }

--- a/packages/utils-demo/src/demo.ts
+++ b/packages/utils-demo/src/demo.ts
@@ -19,7 +19,7 @@ import Web3 from 'web3';
 
 import { deployERC20TestToken } from 'ew-erc-test-contracts';
 import { Configuration, AssetType, Currency, Compliance, TimeFrame } from '@energyweb/utils-general';
-import { UserLogic, Role, buildRights } from '@energyweb/user-registry';
+import { User, UserLogic, Role, buildRights } from '@energyweb/user-registry';
 import { AssetProducingRegistryLogic, AssetConsumingRegistryLogic } from '@energyweb/asset-registry';
 import { Demand, Supply, Agreement, MarketLogic } from '@energyweb/market';
 import { CertificateLogic } from '@energyweb/origin';
@@ -67,18 +67,6 @@ export const marketDemo = async (demoFile?: string) => {
     const certificateLogic = new CertificateLogic(web3, contractConfig.certificateLogic);
     const marketLogic = new MarketLogic(web3, contractConfig.marketLogic);
 
-    // set the admin account as an asset admin
-    await userLogic.createUser(
-        'propertiesDocumentHash',
-        'documentDBURL',
-        adminAccount.address,
-        'admin',
-        { privateKey: adminPK }
-    );
-    await userLogic.setRoles(adminAccount.address, buildRights([Role.UserAdmin, Role.AssetAdmin]), {
-        privateKey: adminPK
-    });
-
     // initialize variables for storing timeframe and currency
     let timeFrame;
     let currency;
@@ -104,6 +92,29 @@ export const marketDemo = async (demoFile?: string) => {
         },
         logger
     };
+
+    const userPropsOnChain: User.IUserOnChainProperties = {
+        propertiesDocumentHash: null,
+        url: null,
+        id: adminAccount.address,
+        active: true,
+        roles: buildRights([Role.UserAdmin, Role.AssetAdmin]),
+        organization: 'admin'
+    };
+
+    const userPropsOffChain: User.IUserOffChainProperties = {
+        firstName: 'Admin',
+        surname: 'User',
+        email: 'admin@example.com',
+        street: '',
+        number: '',
+        zip: '',
+        city: '',
+        country: '',
+        state: ''
+    };
+
+    await User.createUser(userPropsOnChain, userPropsOffChain, conf);
 
     const actionsArray = demoConfig.flow;
 

--- a/packages/utils-demo/src/demo.ts
+++ b/packages/utils-demo/src/demo.ts
@@ -68,7 +68,13 @@ export const marketDemo = async (demoFile?: string) => {
     const marketLogic = new MarketLogic(web3, contractConfig.marketLogic);
 
     // set the admin account as an asset admin
-    await userLogic.setUser(adminAccount.address, 'admin', { privateKey: adminPK });
+    await userLogic.createUser(
+        'propertiesDocumentHash',
+        'documentDBURL',
+        adminAccount.address,
+        'admin',
+        { privateKey: adminPK }
+    );
     await userLogic.setRoles(adminAccount.address, buildRights([Role.UserAdmin, Role.AssetAdmin]), {
         privateKey: adminPK
     });

--- a/packages/utils-demo/src/market.ts
+++ b/packages/utils-demo/src/market.ts
@@ -19,7 +19,7 @@ import Web3 from 'web3';
 
 import { deployERC20TestToken, Erc20TestToken } from 'ew-erc-test-contracts';
 import { Configuration, AssetType, TimeFrame, Compliance, Currency } from '@energyweb/utils-general';
-import { UserLogic, Role, buildRights } from '@energyweb/user-registry';
+import { User, UserLogic, Role, buildRights } from '@energyweb/user-registry';
 import { AssetProducingRegistryLogic, AssetConsumingRegistryLogic } from '@energyweb/asset-registry';
 import { CertificateLogic } from '@energyweb/origin';
 import { Demand, Supply, Agreement, MarketLogic } from '@energyweb/market';
@@ -67,18 +67,6 @@ export const marketDemo = async (demoFile?: string) => {
     const certificateLogic = new CertificateLogic(web3, contractConfig.certificateLogic);
     const marketLogic = new MarketLogic(web3, contractConfig.marketLogic);
 
-    // set the admin account as an asset admin
-    await userLogic.createUser(
-        'propertiesDocumentHash',
-        'documentDBURL',
-        adminAccount.address,
-        'admin',
-        { privateKey: adminPK }
-    );
-    await userLogic.setRoles(adminAccount.address, buildRights([Role.UserAdmin, Role.AssetAdmin]), {
-        privateKey: adminPK
-    });
-
     // initialize variables for storing timeframe and currency
     let timeFrame;
     let currency;
@@ -104,6 +92,30 @@ export const marketDemo = async (demoFile?: string) => {
         },
         logger
     };
+
+
+    const userPropsOnChain: User.IUserOnChainProperties = {
+        propertiesDocumentHash: null,
+        url: null,
+        id: adminAccount.address,
+        active: true,
+        roles: buildRights([Role.UserAdmin, Role.AssetAdmin]),
+        organization: 'admin'
+    };
+
+    const userPropsOffChain: User.IUserOffChainProperties = {
+        firstName: 'Admin',
+        surname: 'User',
+        email: 'admin@example.com',
+        street: '',
+        number: '',
+        zip: '',
+        city: '',
+        country: '',
+        state: ''
+    };
+
+    await User.createUser(userPropsOnChain, userPropsOffChain, conf);
 
     const actionsArray = demoConfig.flow;
 

--- a/packages/utils-demo/src/market.ts
+++ b/packages/utils-demo/src/market.ts
@@ -68,7 +68,13 @@ export const marketDemo = async (demoFile?: string) => {
     const marketLogic = new MarketLogic(web3, contractConfig.marketLogic);
 
     // set the admin account as an asset admin
-    await userLogic.setUser(adminAccount.address, 'admin', { privateKey: adminPK });
+    await userLogic.createUser(
+        'propertiesDocumentHash',
+        'documentDBURL',
+        adminAccount.address,
+        'admin',
+        { privateKey: adminPK }
+    );
     await userLogic.setRoles(adminAccount.address, buildRights([Role.UserAdmin, Role.AssetAdmin]), {
         privateKey: adminPK
     });

--- a/packages/utils-demo/src/onboarding.ts
+++ b/packages/utils-demo/src/onboarding.ts
@@ -16,7 +16,7 @@
 
 import * as Asset from '@energyweb/asset-registry';
 import * as GeneralLib from '@energyweb/utils-general';
-import { User, IUserPropertiesOnChain, IUserPropertiesOffChain } from '@energyweb/user-registry';
+import { User } from '@energyweb/user-registry';
 
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
@@ -35,14 +35,16 @@ export const onboardDemo = async (
 
     switch (action.type) {
         case 'CREATE_ACCOUNT':
-            const userPropsOnChain: IUserPropertiesOnChain = {
+            const userPropsOnChain: User.IUserOnChainProperties = {
+                propertiesDocumentHash: null,
+                url: null,
                 id: action.data.address,
                 active: true,
                 roles: action.data.rights,
                 organization: action.data.organization
             };
 
-            const userPropsOffchain: IUserPropertiesOffChain = {
+            const userPropsOffChain: User.IUserOffChainProperties = {
                 firstName: action.data.firstName,
                 surname: action.data.surname,
                 email: action.data.email,
@@ -54,7 +56,7 @@ export const onboardDemo = async (
                 state: action.data.state
             };
 
-            await User.CREATE_USER(userPropsOnChain, userPropsOffchain, conf);
+            await User.createUser(userPropsOnChain, userPropsOffChain, conf);
 
             conf.logger.info('Onboarded a new user: ' + action.data.address);
             conf.logger.verbose(

--- a/packages/utils-general/src/blockchain-facade/BlockchainDataModelEntity.ts
+++ b/packages/utils-general/src/blockchain-facade/BlockchainDataModelEntity.ts
@@ -109,15 +109,9 @@ export abstract class Entity {
 
     async getOffChainProperties(hash: string, url?: string, debug?: boolean): Promise<any> {
         if (this.configuration.offChainDataSource) {
-            console.log(this.id)
             const axiosurl = url ? url : this.getUrl();
-            const data = (await axios.get(`${axiosurl}/${this.id}`)).data;
+            const data = (await axios.get(`${axiosurl}/${this.id.toLowerCase()}`)).data;
             const offChainProperties = data.properties;
-
-            console.log({
-                data,
-                url: `${axiosurl}/${this.id}`
-            });
             this.generateAndAddProofs(data.properties, debug, data.salts);
 
             this.verifyOffChainProperties(hash, offChainProperties, data.schema, debug);

--- a/packages/utils-general/src/blockchain-facade/BlockchainDataModelEntity.ts
+++ b/packages/utils-general/src/blockchain-facade/BlockchainDataModelEntity.ts
@@ -80,7 +80,7 @@ export abstract class Entity {
         if (this.configuration.offChainDataSource) {
             const axiosurl = url ? url : this.getUrl();
 
-            await axios.put(`${axiosurl}/${this.id}`, {
+            await axios.put(`${axiosurl}/${this.id.toLowerCase()}`, {
                 properties,
                 salts: offChainStorageProperties.salts,
                 schema: offChainStorageProperties.schema
@@ -109,9 +109,15 @@ export abstract class Entity {
 
     async getOffChainProperties(hash: string, url?: string, debug?: boolean): Promise<any> {
         if (this.configuration.offChainDataSource) {
+            console.log(this.id)
             const axiosurl = url ? url : this.getUrl();
             const data = (await axios.get(`${axiosurl}/${this.id}`)).data;
             const offChainProperties = data.properties;
+
+            console.log({
+                data,
+                url: `${axiosurl}/${this.id}`
+            });
             this.generateAndAddProofs(data.properties, debug, data.salts);
 
             this.verifyOffChainProperties(hash, offChainProperties, data.schema, debug);
@@ -139,7 +145,7 @@ export abstract class Entity {
 
             if (theProof) {
                 if (!PreciseProofs.verifyProof(rootHash, theProof, schema)) {
-                    throw new Error(`Proof for property ${key} is invalid.`);
+                    throw new Error(`Proof ${JSON.stringify(theProof)} for property ${key} is invalid.`);
                 }
             } else {
                 throw new Error(`Could not find proof for property ${key}`);

--- a/packages/utils-testbackend/src/api.ts
+++ b/packages/utils-testbackend/src/api.ts
@@ -13,6 +13,7 @@ export async function startAPI() {
 
     const storage = new CustomStorage(
         [
+            ENTITY.USER,
             ENTITY.TRADABLE_ENTITY,
             ENTITY.PRODUCING_ASSET,
             ENTITY.PRODUCING_ASSET_NOT_BOUND,
@@ -96,6 +97,8 @@ export async function startAPI() {
             res.send('success');
         });
     }
+
+    createRoutesForEntityBoundToContract(app, ENTITY.USER);
     createRoutesForEntityBoundToContract(app, ENTITY.TRADABLE_ENTITY);
     createRoutesForEntityBoundToContract(app, ENTITY.PRODUCING_ASSET);
     createRoutesForEntityBoundToContract(app, ENTITY.DEMAND);

--- a/packages/utils-testbackend/src/api.ts
+++ b/packages/utils-testbackend/src/api.ts
@@ -10,6 +10,7 @@ export async function startAPI() {
     const app = express();
 
     app.use(cors());
+    app.set('case sensitive routing', false);
 
     const storage = new CustomStorage(
         [

--- a/packages/utils-testbackend/src/enums/Entity.ts
+++ b/packages/utils-testbackend/src/enums/Entity.ts
@@ -1,4 +1,5 @@
 export enum ENTITY {
+    USER = 'User',
     TRADABLE_ENTITY = 'TradableEntity',
     PRODUCING_ASSET = 'ProducingAsset',
     PRODUCING_ASSET_NOT_BOUND = 'ProducingAssetNotBound',


### PR DESCRIPTION
Enables storing off-chain user information onto the backend.

- Introduces the generic `Entity` structure from `utils-general` into the `User` class
- Renames `userLogic.setUser()` function to `userLogic.createUser()` to better reflect the actions of the function

Previously, none of the off-chain user information was stored, it was just defined. This PR fixes this problem.