### PR TITLE
Demand update and cloning.

### DIFF
--- a/packages/asset-registry/src/blockchain-facade/ConsumingAsset.ts
+++ b/packages/asset-registry/src/blockchain-facade/ConsumingAsset.ts
@@ -31,7 +31,6 @@ export const createAsset = async (
 ): Promise<Asset.Entity> => {
     const consumingAsset = new Entity(null, configuration);
     const offChainStorageProperties = consumingAsset.prepareEntityCreation(
-        assetProperties,
         assetPropertiesOffChain,
         AssetPropertiesOffchainSchema
     );

--- a/packages/asset-registry/src/blockchain-facade/ProducingAsset.ts
+++ b/packages/asset-registry/src/blockchain-facade/ProducingAsset.ts
@@ -62,7 +62,6 @@ export const createAsset = async (
 ): Promise<Entity> => {
     const producingAsset = new Entity(null, configuration);
     const offChainStorageProperties = producingAsset.prepareEntityCreation(
-        assetPropertiesOnChain,
         assetPropertiesOffChain,
         ProducingAssetPropertiesOffchainSchema
     );

--- a/packages/market-matcher/src/test/StrategyBasedMatcherTest.ts
+++ b/packages/market-matcher/src/test/StrategyBasedMatcherTest.ts
@@ -222,14 +222,7 @@ describe('Test StrategyBasedMatcher', async () => {
             endTime: '1559466492732'
         };
 
-        const demandProps: Demand.IDemandOnChainProperties = {
-            url: null,
-            propertiesDocumentHash: null,
-            demandOwner: conf.blockchainProperties.activeUser.address,
-            status: Demand.DemandStatus.ACTIVE
-        };
-
-        await Demand.createDemand(demandProps, demandOffChainProps, conf);
+        await Demand.createDemand(demandOffChainProps, conf);
         assert.equal(await Demand.getDemandListLength(conf), 1);
     });
 

--- a/packages/market/contracts/Trading/MarketDB.sol
+++ b/packages/market/contracts/Trading/MarketDB.sol
@@ -72,6 +72,27 @@ contract MarketDB is AgreementDB {
         _demandId = allDemands.length>0?allDemands.length-1:0;
     }
 
+    /// @notice updates existing demand
+    /// @param _demandId demand id
+	/// @param _propertiesDocumentHash the properties document hash
+	/// @param _documentDBURL the url of the document in a database
+	/// @return operation result
+    function updateDemand
+    (
+        uint _demandId,
+        string calldata _propertiesDocumentHash,
+        string calldata _documentDBURL
+    )
+        external
+        onlyOwner
+        returns (bool)
+    {
+        allDemands[_demandId].propertiesDocumentHash = _propertiesDocumentHash;
+        allDemands[_demandId].documentDBURL = _documentDBURL;
+
+        return true;
+    }
+
 	/// @notice creates a supply
 	/// @param _propertiesDocumentHash the properties document hash
 	/// @param _documentDBURL the url of the document in a database

--- a/packages/market/contracts/Trading/MarketLogic.sol
+++ b/packages/market/contracts/Trading/MarketLogic.sol
@@ -26,6 +26,7 @@ contract MarketLogic is AgreementLogic {
     event createdNewDemand(address _sender, uint indexed _demandId);
     event createdNewSupply(address _sender, uint indexed _supplyId);
     event DemandStatusChanged(address _sender, uint indexed _demandId, uint16 indexed _status);
+    event DemandUpdated(uint indexed _demandId);
 
     /// @notice constructor
     constructor(
@@ -64,6 +65,28 @@ contract MarketLogic is AgreementLogic {
         require(msg.sender == demand.demandOwner, "user is not the owner of this demand");
 
         changeDemandStatus(_demandId, MarketDB.DemandStatus.ARCHIVED);
+    }
+
+    /// @notice Updates existing demand with new properties
+	/// @dev will return an event with the event-Id
+	/// @param _demandId index of the demand in the allDemands-array
+    /// @param _propertiesDocumentHash document-hash with all the properties of the demand
+	/// @param _documentDBURL url-address of the demand
+    function updateDemand(
+        uint _demandId,
+        string calldata _propertiesDocumentHash,
+        string calldata _documentDBURL
+    )
+        external
+        onlyRole(RoleManagement.Role.Trader)
+    {
+        MarketDB.Demand memory demand = db.getDemand(_demandId);
+        require(msg.sender == demand.demandOwner, "user is not the owner of this demand");
+        require(demand.status != MarketDB.DemandStatus.ARCHIVED, "demand cannot be in archived state");
+
+        db.updateDemand(_demandId, _propertiesDocumentHash, _documentDBURL);
+
+        emit DemandUpdated(_demandId);
     }
 
 	/// @notice Function to create a supply

--- a/packages/market/package.json
+++ b/packages/market/package.json
@@ -36,7 +36,7 @@
     "lint-fix": "solium -d contracts --fix",
     "start-ganache": "ganache-cli -m 'chalk park staff buzz chair purchase wise oak receive avoid avoid home' -l 8000000 -e 1000000 -a 20",
     "start-test-backend": "node ../../node_modules/@energyweb/utils-testbackend/dist/js/src/index.js",
-    "test": "mocha dist/js/src/test/ --timeout 60000",
+    "test": "mocha dist/js/src/test/ --timeout 60000 --exit",
     "test-ts": "mocha -r ts-node/register src/test/*.ts --timeout 60000",
     "prettier": "prettier --write --config-precedence file-override './src/**/*'",
     "test-contracts": "concurrently --success first --kill-others -n eth,backend,test \"yarn start-ganache\" \"yarn start-test-backend\" \"wait-on tcp:8545 && yarn test\"",

--- a/packages/market/src/blockchain-facade/Agreement.ts
+++ b/packages/market/src/blockchain-facade/Agreement.ts
@@ -51,14 +51,12 @@ export const createAgreement = async (
     const agreement = new Entity(null, configuration);
 
     const agreementOffChainStorageProperties = agreement.prepareEntityCreation(
-        agreementPropertiesOnChain,
         agreementPropertiesOffchain,
         AgreementOffchainPropertiesSchema,
         agreement.getUrl()
     );
 
     const matcherOffchainStorageProperties = agreement.prepareEntityCreation(
-        agreementPropertiesOnChain,
         matcherPropertiesOffchain,
         MatcherOffChainPropertiesSchema,
         agreement.getMatcherURL()
@@ -227,7 +225,6 @@ export class Entity extends GeneralLib.BlockchainDataModelEntity.Entity
         };
 
         const matcherOffchainStorageProperties = this.prepareEntityCreation(
-            agreementPropsOnChain,
             matcherOffchainProperties,
             MatcherOffChainPropertiesSchema,
             this.getMatcherURL()

--- a/packages/market/src/blockchain-facade/Demand.ts
+++ b/packages/market/src/blockchain-facade/Demand.ts
@@ -172,6 +172,21 @@ export class Entity extends GeneralLib.BlockchainDataModelEntity.Entity
 
         return this;
     }
+
+    async clone(): Promise<Entity> {
+        await this.sync();
+
+        return createDemand(
+            {
+                status: this.status,
+                url: null,
+                propertiesDocumentHash: null,
+                demandOwner: this.demandOwner
+            },
+            this.offChainProperties,
+            this.configuration
+        );
+    }
 }
 
 export const getAllDemandsListLength = async (configuration: GeneralLib.Configuration.Entity) => {

--- a/packages/market/src/blockchain-facade/Supply.ts
+++ b/packages/market/src/blockchain-facade/Supply.ts
@@ -49,7 +49,6 @@ export const createSupply = async (
     const supply = new Entity(null, configuration);
 
     const offChainStorageProperties = supply.prepareEntityCreation(
-        supplyPropertiesOnChain,
         supplyPropertiesOffChain,
         SupplyOffchainpropertiesSchema,
         supply.getUrl()

--- a/packages/market/src/test/MarketFacade.ts
+++ b/packages/market/src/test/MarketFacade.ts
@@ -266,6 +266,17 @@ describe('Market-Facade', () => {
                 }
             } as Partial<Market.Demand.Entity>);
         });
+
+        it('should clone demand', async () => {
+            const demand = await new Market.Demand.Entity('0', conf).sync();
+            const clone = await demand.clone();
+
+            assert.notEqual(clone.id, demand.id);
+            assert.notEqual(clone.propertiesDocumentHash, demand.propertiesDocumentHash);
+            
+            assert.equal(clone.url, demand.url);
+            assert.deepEqual(clone.offChainProperties, demand.offChainProperties);
+        });
     });
 
     describe('Supply-Facade', () => {
@@ -713,20 +724,13 @@ describe('Market-Facade', () => {
                 privateKey: traderPK
             };
 
-            assert.equal(await Market.Demand.getDemandListLength(conf), 1);
+            const amountOfDemands = await Market.Demand.getDemandListLength(conf);
 
             const deleted = await Market.Demand.deleteDemand(0, conf);
             assert.isTrue(deleted);
 
             // Should remain the same
-            assert.equal(await Market.Demand.getDemandListLength(conf), 1);
-        });
-
-        it('should get all demands even after a demand is deleted', async () => {
-            const allDemands = await Market.Demand.getAllDemands(conf);
-
-            assert.equal(allDemands.length, 1);
-            assert.equal(allDemands[0].status, DemandStatus.ARCHIVED);
+            assert.equal(await Market.Demand.getDemandListLength(conf), amountOfDemands);
         });
     });
 });

--- a/packages/market/src/test/MarketLogic.ts
+++ b/packages/market/src/test/MarketLogic.ts
@@ -72,7 +72,7 @@ describe('MarketLogic', () => {
     const matcherAccount = web3.eth.accounts.privateKeyToAccount(matcherPK).address;
 
     const testStatusChange = async (
-        demandId: number,
+        demandId: string,
         status: DemandStatus,
         hasChanged: boolean,
         user: string = traderPK
@@ -206,7 +206,7 @@ describe('MarketLogic', () => {
     it('should throw an error when trying to access a non existing demand', async () => {
         let failed = false;
         try {
-            await marketLogic.getDemand(0);
+            await marketLogic.getDemand('0');
         } catch (ex) {
             failed = true;
         }
@@ -315,7 +315,7 @@ describe('MarketLogic', () => {
     });
 
     it('should get a demand', async () => {
-        const demand = await marketLogic.getDemand(0);
+        const demand = await marketLogic.getDemand('0');
         demand[2] = demand[2].toLowerCase();
         demand._owner = demand._owner.toLowerCase();
 
@@ -789,7 +789,7 @@ describe('MarketLogic', () => {
         });
     });
 
-    it('should fail when trying to change matcherproperties with wrong account (assetAdmin)', async () => {
+    it('should fail when trying to change matcher properties with wrong account (assetAdmin)', async () => {
         let failed = false;
         try {
             const agreement = await marketLogic.setMatcherProperties(0, 'newProps', 'newURl', {
@@ -803,7 +803,7 @@ describe('MarketLogic', () => {
         assert.isTrue(failed);
     });
 
-    it('should fail when trying to change matcherproperties with wrong account (assetOwner)', async () => {
+    it('should fail when trying to change matcher properties with wrong account (assetOwner)', async () => {
         let failed = false;
         try {
             const agreement = await marketLogic.setMatcherProperties(0, 'newProps', 'newURl', {
@@ -817,7 +817,7 @@ describe('MarketLogic', () => {
         assert.isTrue(failed);
     });
 
-    it('should change matcherproperties ', async () => {
+    it('should change matcher properties ', async () => {
         await assetRegistry.addMatcher(0, matcherAccount, { privateKey: assetOwnerPK });
         //      const agreement = await marketLogic.setMatcherProperties(0, 'newProps', 'newURl', { privateKey:  });
         let failed = false;
@@ -1054,7 +1054,7 @@ describe('MarketLogic', () => {
         });
     });
 
-    it('should fail when trying to set Matcherproperties when the agreement is not finihsed yet', async () => {
+    it('should fail when trying to set matcher properties when the agreement is not finished yet', async () => {
         let failed = false;
         try {
             await marketLogic.setMatcherProperties(2, 'newProps', 'newDB', {
@@ -1072,7 +1072,7 @@ describe('MarketLogic', () => {
         await marketLogic.approveAgreementSupply(2, { privateKey: assetOwnerPK });
     });
 
-    it('should change matcherpropertes', async () => {
+    it('should change matcher properties', async () => {
         await marketLogic.setMatcherProperties(2, 'newMatcherProps', 'newMatcherDB', {
             privateKey: matcherPK
         });
@@ -1152,7 +1152,7 @@ describe('MarketLogic', () => {
     it('should fail to delete a demand as non-trader', async () => {
         let failed = false;
         try {
-            await marketLogic.deleteDemand(1, {
+            await marketLogic.deleteDemand('1', {
                 privateKey: assetOwnerPK
             });
         } catch (ex) {
@@ -1166,7 +1166,7 @@ describe('MarketLogic', () => {
     it('should not be able to delete a demand as trader non-owner', async () => {
         let failed = false;
         try {
-            await marketLogic.deleteDemand(1, {
+            await marketLogic.deleteDemand('1', {
                 privateKey: trader2PK
             });
         } catch (ex) {
@@ -1178,7 +1178,7 @@ describe('MarketLogic', () => {
     });
 
     it('should be able to delete a demand as trader owner', async () => {
-        const txDelete = await marketLogic.deleteDemand(1, {
+        const txDelete = await marketLogic.deleteDemand('1', {
             privateKey: traderPK
         });
 
@@ -1188,7 +1188,7 @@ describe('MarketLogic', () => {
         });
         assert.equal(archivedDemandStatusEvents.length, 1);
 
-        const demandAfter = await marketLogic.getDemand(1);
+        const demandAfter = await marketLogic.getDemand('1');
         assert.deepEqual(demandAfter, {
             0: 'propertiesDocumentHash_2',
             1: 'documentDBURL_2',
@@ -1205,13 +1205,13 @@ describe('MarketLogic', () => {
     });
 
     it('should not emit event when status not changed', async () => {
-        await testStatusChange(0, DemandStatus.ACTIVE, false);
+        await testStatusChange('0', DemandStatus.ACTIVE, false);
     });
 
     it('should not be able to change demand status when no demand owner', async () => {
         let failed = false;
         try {
-            await testStatusChange(0, DemandStatus.PAUSED, false, trader2PK);
+            await testStatusChange('0', DemandStatus.PAUSED, false, trader2PK);
         } catch (e) {
             failed = true;
         }
@@ -1220,20 +1220,20 @@ describe('MarketLogic', () => {
     });
 
     it('should be able to set demand status to paused when current status is active', async () => {
-        await testStatusChange(0, DemandStatus.PAUSED, true);
+        await testStatusChange('0', DemandStatus.PAUSED, true);
     });
 
     it('should be able to set demand status to active when current status is paused', async () => {
-        await testStatusChange(0, DemandStatus.ACTIVE, true);
+        await testStatusChange('0', DemandStatus.ACTIVE, true);
     });
 
     it('should be able to set demand status to archived when current status is active', async () => {
-        await testStatusChange(0, DemandStatus.ARCHIVED, true);
+        await testStatusChange('0', DemandStatus.ARCHIVED, true);
     });
 
     it('should be not able to set demand status to active or paused when current status is archived', async () => {
-        await testStatusChange(0, DemandStatus.ACTIVE, false);
-        await testStatusChange(0, DemandStatus.PAUSED, false);
+        await testStatusChange('0', DemandStatus.ACTIVE, false);
+        await testStatusChange('0', DemandStatus.PAUSED, false);
     });
 
     it('should be able to update url and hash', async () => {

--- a/packages/market/src/wrappedContracts/MarketLogic.ts
+++ b/packages/market/src/wrappedContracts/MarketLogic.ts
@@ -11,7 +11,8 @@ const SUPPORTED_EVENTS = [
     'LogAgreementFullySigned',
     'LogAgreementCreated',
     'LogChangeOwner',
-    'DemandStatusChanged'
+    'DemandStatusChanged',
+    'DemandUpdated'
 ];
 
 export class MarketLogic extends GeneralFunctions {
@@ -88,6 +89,17 @@ export class MarketLogic extends GeneralFunctions {
 
     async deleteDemand(_demandId: number, txParams?: SpecialTx) {
         const method = this.web3Contract.methods.deleteDemand(_demandId);
+
+        return await this.send(method, txParams);
+    }
+
+    async updateDemand(
+        _demandId: number,
+        _propertiesDocumentHash: string,
+        _documentDBURL: string,
+        txParams?: SpecialTx
+    ) {
+        const method = this.web3Contract.methods.updateDemand(_demandId, _propertiesDocumentHash, _documentDBURL);
 
         return await this.send(method, txParams);
     }

--- a/packages/market/src/wrappedContracts/MarketLogic.ts
+++ b/packages/market/src/wrappedContracts/MarketLogic.ts
@@ -83,18 +83,18 @@ export class MarketLogic extends GeneralFunctions {
         return await this.send(method, txParams);
     }
 
-    async getDemand(_demandId: number, txParams?: SpecialTx) {
+    async getDemand(_demandId: string, txParams?: SpecialTx) {
         return await this.web3Contract.methods.getDemand(_demandId).call(txParams);
     }
 
-    async deleteDemand(_demandId: number, txParams?: SpecialTx) {
+    async deleteDemand(_demandId: string, txParams?: SpecialTx) {
         const method = this.web3Contract.methods.deleteDemand(_demandId);
 
         return await this.send(method, txParams);
     }
 
     async updateDemand(
-        _demandId: number,
+        _demandId: string,
         _propertiesDocumentHash: string,
         _documentDBURL: string,
         txParams?: SpecialTx
@@ -215,7 +215,7 @@ export class MarketLogic extends GeneralFunctions {
         return await this.web3Contract.methods.getAllDemandListLength().call(txParams);
     }
 
-    async changeDemandStatus(_demandId: number, _status: DemandStatus, txParams?: SpecialTx) {
+    async changeDemandStatus(_demandId: string, _status: DemandStatus, txParams?: SpecialTx) {
         const method = this.web3Contract.methods.changeDemandStatus(_demandId, _status);
 
         return this.send(method, txParams);

--- a/packages/origin-ui/src/components/CertificateTable.tsx
+++ b/packages/origin-ui/src/components/CertificateTable.tsx
@@ -565,18 +565,7 @@ class CertificateTableClass extends PaginatedLoaderFilteredSorted<Props, ICertif
                 endTime: ''
             };
 
-            const onChainProperties: Demand.IDemandOnChainProperties = {
-                demandOwner: asset.owner.address,
-                propertiesDocumentHash: '',
-                url: '',
-                status: Demand.DemandStatus.ACTIVE
-            };
-
-            await Demand.createDemand(
-                onChainProperties,
-                offChainProperties,
-                this.props.configuration
-            );
+            await Demand.createDemand(offChainProperties, this.props.configuration);
         }
     }
 

--- a/packages/origin-ui/src/components/OnboardDemand.tsx
+++ b/packages/origin-ui/src/components/OnboardDemand.tsx
@@ -392,7 +392,7 @@ class OnboardDemandClass extends React.Component<IStateProps, IState> {
         }
 
         try {
-            await Demand.createDemand(onChainProps, offChainProps, this.props.configuration);
+            await Demand.createDemand(offChainProps, this.props.configuration);
 
             showNotification('Demand created', NotificationType.Success);
         } catch (error) {

--- a/packages/user-registry/src/blockchain-facade/Users/User.ts
+++ b/packages/user-registry/src/blockchain-facade/Users/User.ts
@@ -113,7 +113,6 @@ export const createUser = async (
     const user = new Entity(null, configuration);
 
     const offChainStorageProperties = user.prepareEntityCreation(
-        userPropertiesOnChain,
         userPropertiesOffChain,
         UserOffChainPropertiesSchema,
         user.getUrl()

--- a/packages/utils-demo/src/demo.ts
+++ b/packages/utils-demo/src/demo.ts
@@ -165,16 +165,8 @@ export const marketDemo = async (demoFile?: string) => {
                     endTime: action.data.endTime
                 };
 
-                const demandProps: Demand.IDemandOnChainProperties = {
-                    url: '',
-                    propertiesDocumentHash: '',
-                    demandOwner: action.data.trader,
-                    status: Demand.DemandStatus.ACTIVE
-                };
-
                 try {
                     const demand = await Demand.createDemand(
-                        demandProps,
                         demandOffchainProps,
                         conf
                     );

--- a/packages/utils-demo/src/market.ts
+++ b/packages/utils-demo/src/market.ts
@@ -198,16 +198,8 @@ export const marketDemo = async (demoFile?: string) => {
                     endTime: action.data.endTime
                 };
 
-                const demandProps: Demand.IDemandOnChainProperties = {
-                    url: '',
-                    propertiesDocumentHash: '',
-                    demandOwner: action.data.trader,
-                    status: Demand.DemandStatus.ACTIVE
-                };
-
                 try {
                     const demand = await Demand.createDemand(
-                        demandProps,
                         demandOffchainProps,
                         conf
                     );


### PR DESCRIPTION
`Demand` facade object has now two extra methods:
- `clone` - for easy demand cloning
- `update` - for off-chain properties update 

Refactorings:
- on-chain props object not required anymore to create a demand
- demand object uses now strongly typed `MarketLogic`
- MarketLogic now requires `string` based id property 