### PR TITLE
chore(monorepo): replace powerInW with energy

### DIFF
--- a/packages/market-matcher/src/MatchableDemand.ts
+++ b/packages/market-matcher/src/MatchableDemand.ts
@@ -26,7 +26,7 @@ export class MatchableDemand {
         return new Validator<MatchingErrorReason>()
             .validate(this.isActive, MatchingErrorReason.NON_ACTIVE_DEMAND)
             .validate(
-                offChainProperties.targetWhPerPeriod <= Number(certificate.powerInW),
+                offChainProperties.targetWhPerPeriod <= Number(certificate.energy),
                 MatchingErrorReason.NOT_ENOUGH_ENERGY
             )
             .validate(

--- a/packages/market-matcher/src/Matcher.ts
+++ b/packages/market-matcher/src/Matcher.ts
@@ -72,13 +72,13 @@ export class Matcher {
     }
 
     private async executeMatching(certificate: Certificate.ICertificate, demand: Demand.IDemand) {
-        const requiredPower = demand.offChainProperties.targetWhPerPeriod;
+        const requiredEnergy = demand.offChainProperties.targetWhPerPeriod;
 
-        if (certificate.powerInW === requiredPower) {
+        if (certificate.energy === requiredEnergy) {
             return this.certificateService.matchDemand(certificate, demand);
         }
-        if (requiredPower > 0 && certificate.powerInW > requiredPower) {
-            return this.certificateService.splitCertificate(certificate, requiredPower);
+        if (requiredEnergy > 0 && certificate.energy > requiredEnergy) {
+            return this.certificateService.splitCertificate(certificate, requiredEnergy);
         }
 
         return false;
@@ -115,13 +115,13 @@ export class Matcher {
             const missingEnergyForPeriod = await matchingAgreement.missingEnergyForDemand(demand);
 
             this.logger.debug(
-                `Certificate's available power ${certificate.powerInW}, missingEnergyForPeriod ${missingEnergyForPeriod}`
+                `Certificate's available energy ${certificate.energy}, missingEnergyForPeriod ${missingEnergyForPeriod}`
             );
 
-            if (certificate.powerInW === missingEnergyForPeriod) {
+            if (certificate.energy === missingEnergyForPeriod) {
                 return this.certificateService.matchAgreement(certificate, agreement);
             }
-            if (missingEnergyForPeriod > 0 && certificate.powerInW > missingEnergyForPeriod) {
+            if (missingEnergyForPeriod > 0 && certificate.energy > missingEnergyForPeriod) {
                 return this.certificateService.splitCertificate(
                     certificate,
                     missingEnergyForPeriod

--- a/packages/market-matcher/src/test/Matcher.test.ts
+++ b/packages/market-matcher/src/test/Matcher.test.ts
@@ -541,7 +541,7 @@ describe.only('Test StrategyBasedMatcher', async () => {
 
             await certificate.publishForSale(1, Currency.USD);
 
-            assert.equal(certificate.powerInW, energy);
+            assert.equal(certificate.energy, energy);
         }).timeout(10000);
 
         it('should create a demand', async () => {

--- a/packages/market-matcher/src/test/unit/MatchableDemand.test.ts
+++ b/packages/market-matcher/src/test/unit/MatchableDemand.test.ts
@@ -40,7 +40,7 @@ describe('MatchableDemand tests', () => {
                 price: options.price || energyPrice,
                 currency: options.currency || currency
             });
-            certificate.powerInW.returns(options.energy || certificateEnergy);
+            certificate.energy.returns(options.energy || certificateEnergy);
             certificate.pricePerUnit(Unit.MWh).returns(options.price || energyPrice);
 
             const producingAssetOffChainProperties = Substitute.for<
@@ -84,7 +84,7 @@ describe('MatchableDemand tests', () => {
             assert.equal(reason[0], MatchingErrorReason.NON_ACTIVE_DEMAND);
         });
 
-        it('should not match active demand with exceeding power', () => {
+        it('should not match active demand with exceeding energy', () => {
             const { demand, certificate, producingAsset } = createMatchingMocks({
                 energy: certificateEnergy - 1
             });
@@ -197,7 +197,7 @@ describe('MatchableDemand tests', () => {
             assert.equal(reason[0], MatchingErrorReason.NON_ACTIVE_DEMAND);
         });
 
-        it('should not match active demand with exceeding power', () => {
+        it('should not match active demand with exceeding energy', () => {
             const { demand, supply } = createMatchingMocks({
                 energy: supplyEnergy - 1
             });

--- a/packages/market/contracts/Trading/MarketLogic.sol
+++ b/packages/market/contracts/Trading/MarketLogic.sol
@@ -100,7 +100,7 @@ contract MarketLogic is AgreementLogic {
             te.owner, demand.demandOwner, _entityId
         );
 
-        emit DemandPartiallyFilled(_demandId, _entityId, te.powerInW);
+        emit DemandPartiallyFilled(_demandId, _entityId, te.energy);
     }
 
 	/// @notice Function to create a supply

--- a/packages/origin-ui/src/components/CertificateDetailView.tsx
+++ b/packages/origin-ui/src/components/CertificateDetailView.tsx
@@ -230,7 +230,7 @@ class CertificateDetailViewClass extends React.Component<Props, IDetailViewState
 
                     {
                         label: 'Certified Energy (kWh)',
-                        data: (selectedCertificate.powerInW / 1000).toLocaleString()
+                        data: (selectedCertificate.energy / 1000).toLocaleString()
                     },
                     {
                         label: 'Creation Date',

--- a/packages/origin-ui/src/components/CertificateTable.tsx
+++ b/packages/origin-ui/src/components/CertificateTable.tsx
@@ -466,7 +466,7 @@ class CertificateTableClass extends PaginatedLoaderFilteredSorted<Props, ICertif
                 currency: Currency.USD,
                 otherGreenAttributes: asset.offChainProperties.otherGreenAttributes,
                 typeOfPublicSupport: asset.offChainProperties.typeOfPublicSupport,
-                targetWhPerPeriod: certificate.powerInW,
+                targetWhPerPeriod: certificate.energy,
                 registryCompliance: asset.offChainProperties.complianceRegistry,
                 startTime: '',
                 endTime: ''
@@ -490,9 +490,7 @@ class CertificateTableClass extends PaginatedLoaderFilteredSorted<Props, ICertif
         const maxCertificateEnergyInkWh =
             this.props.certificates.reduce(
                 (a, b) =>
-                    parseInt(b.powerInW.toString(), 10) > a
-                        ? parseInt(b.powerInW.toString(), 10)
-                        : a,
+                    parseInt(b.energy.toString(), 10) > a ? parseInt(b.energy.toString(), 10) : a,
                 0
             ) / 1000;
 
@@ -569,7 +567,7 @@ class CertificateTableClass extends PaginatedLoaderFilteredSorted<Props, ICertif
                 }
             },
             {
-                property: `${FILTER_SPECIAL_TYPES.DIVIDE}::${RECORD_INDICATOR}certificate.powerInW::1000`,
+                property: `${FILTER_SPECIAL_TYPES.DIVIDE}::${RECORD_INDICATOR}certificate.energy::1000`,
                 label: 'Certified Energy (kWh)',
                 input: {
                     type: CustomFilterInputType.slider,
@@ -607,7 +605,7 @@ class CertificateTableClass extends PaginatedLoaderFilteredSorted<Props, ICertif
                 .map(i => i.certificate);
 
             const energy =
-                selectedCertificates.reduce((a, b) => a + parseInt(b.powerInW.toString(), 10), 0) /
+                selectedCertificates.reduce((a, b) => a + parseInt(b.energy.toString(), 10), 0) /
                 1000;
 
             return `${selectedIndexes.length} selected (${energy} kWh)`;
@@ -715,7 +713,7 @@ class CertificateTableClass extends PaginatedLoaderFilteredSorted<Props, ICertif
             {
                 id: 'energy',
                 label: 'Certified energy (kWh)',
-                sortProperties: [['certificate.powerInW', (value: string) => parseInt(value, 10)]]
+                sortProperties: [['certificate.energy', (value: string) => parseInt(value, 10)]]
             }
         ] as const).filter(column => !this.hiddenColumns.includes(column.id));
     }
@@ -738,7 +736,7 @@ class CertificateTableClass extends PaginatedLoaderFilteredSorted<Props, ICertif
                 ? formatCurrency(enrichedData.offChainSettlementOptions.price / 100)
                 : enrichedData.certificate.onChainDirectPurchasePrice.toLocaleString(),
             currency: enrichedData.acceptedCurrency,
-            energy: (enrichedData.certificate.powerInW / 1000).toLocaleString()
+            energy: (enrichedData.certificate.energy / 1000).toLocaleString()
         }));
     }
 

--- a/packages/origin-ui/src/components/ConsumingAssetDetailView.tsx
+++ b/packages/origin-ui/src/components/ConsumingAssetDetailView.tsx
@@ -74,7 +74,7 @@ class ConsumingAssetDetailViewClass extends React.Component<Props, IDetailViewSt
                         .map((certificate: Certificate.Entity) =>
                             certificate.owner === selectedAsset.owner.address &&
                             certificate.assetId.toString() === selectedAsset.id
-                                ? certificate.powerInW
+                                ? certificate.energy
                                 : 0
                         )
                         .reduce((a, b) => a + b)

--- a/packages/origin-ui/src/components/ProducingAssetDetailView.tsx
+++ b/packages/origin-ui/src/components/ProducingAssetDetailView.tsx
@@ -80,7 +80,7 @@ class ProducingAssetDetailViewClass extends React.Component<Props, IState> {
                             .map((certificate: Certificate.Entity) =>
                                 certificate.owner === selectedAsset.owner.address &&
                                 certificate.assetId.toString() === selectedAsset.id
-                                    ? certificate.powerInW
+                                    ? certificate.energy
                                     : 0
                             )
                             .reduce((a, b) => a + b)

--- a/packages/origin-ui/src/elements/Modal/BuyCertificateBulkModal.tsx
+++ b/packages/origin-ui/src/elements/Modal/BuyCertificateBulkModal.tsx
@@ -82,7 +82,7 @@ export class BuyCertificateBulkModal extends React.Component<
     }
 
     render() {
-        const totalWh = this.props.certificates.reduce((a, b) => a + Number(b.powerInW), 0);
+        const totalWh = this.props.certificates.reduce((a, b) => a + Number(b.energy), 0);
 
         return (
             <Dialog open={this.state.show} onClose={this.handleClose}>

--- a/packages/origin-ui/src/elements/Modal/BuyCertificateModal.tsx
+++ b/packages/origin-ui/src/elements/Modal/BuyCertificateModal.tsx
@@ -62,7 +62,7 @@ export class BuyCertificateModal extends React.Component<
     async componentDidUpdate(prevProps: IBuyCertificateModalProps) {
         if (this.props.certificate && this.props.certificate !== prevProps.certificate) {
             this.setState({
-                kwh: this.props.certificate.powerInW / 1000,
+                kwh: this.props.certificate.energy / 1000,
                 validation: {
                     kwh: true
                 }
@@ -111,7 +111,7 @@ export class BuyCertificateModal extends React.Component<
                 const kwhValid =
                     !isNaN(kwh) &&
                     kwh >= 0.001 &&
-                    kwh <= this.props.certificate.powerInW / 1000 &&
+                    kwh <= this.props.certificate.energy / 1000 &&
                     countDecimals(kwh) <= 3;
 
                 this.setState({

--- a/packages/origin-ui/src/elements/Modal/ClaimCertificateBulkModal.tsx
+++ b/packages/origin-ui/src/elements/Modal/ClaimCertificateBulkModal.tsx
@@ -54,7 +54,7 @@ class ClaimCertificateBulkModalClass extends React.Component<Props> {
     }
 
     render() {
-        const totalWh = this.props.certificates.reduce((a, b) => a + Number(b.powerInW), 0);
+        const totalWh = this.props.certificates.reduce((a, b) => a + Number(b.energy), 0);
 
         return (
             <Dialog open={this.props.showModal} onClose={this.handleClose}>

--- a/packages/origin-ui/src/elements/Modal/PublishForSaleModal.tsx
+++ b/packages/origin-ui/src/elements/Modal/PublishForSaleModal.tsx
@@ -62,7 +62,7 @@ class PublishForSaleModal extends React.Component<
         this.state = {
             show: props.showModal,
             minKwh,
-            kwh: props.certificate ? props.certificate.powerInW / 1000 : minKwh,
+            kwh: props.certificate ? props.certificate.energy / 1000 : minKwh,
             price: 1,
             currency: this.availableCurrencies[0],
             erc20TokenAddress: '',
@@ -91,7 +91,7 @@ class PublishForSaleModal extends React.Component<
             )).timestamp;
 
             this.setState({
-                kwh: this.props.certificate.powerInW / 1000,
+                kwh: this.props.certificate.energy / 1000,
                 certCreationDate: moment.unix(timestamp).toString()
             });
         }
@@ -132,7 +132,7 @@ class PublishForSaleModal extends React.Component<
                 const kwhValid =
                     !isNaN(kwh) &&
                     kwh >= this.state.minKwh &&
-                    kwh <= this.props.certificate.powerInW / 1000 &&
+                    kwh <= this.props.certificate.energy / 1000 &&
                     countDecimals(kwh) <= 3;
 
                 this.setState({

--- a/packages/origin/contracts/Interfaces/CertificateInterface.sol
+++ b/packages/origin/contracts/Interfaces/CertificateInterface.sol
@@ -32,15 +32,15 @@ interface CertificateInterface {
 
     /// @notice splits a certificate
     /// @param _certificateId the id of the certificate to be splitted
-    /// @param _power the power to be splitted from the parent certificate
-    function splitCertificate(uint _certificateId, uint _power) external;
+    /// @param _energy the energy to be splitted from the parent certificate
+    function splitCertificate(uint _certificateId, uint _energy) external;
 
     /// @notice Splits a certificate and publishes the first split certificate for sale
     /// @param _certificateId The id of the certificate
-    /// @param _power The amount of power in W for the 1st certificate
+    /// @param _energy The amount of energy in Wh for the 1st certificate
     /// @param _price the purchase price
     /// @param _tokenAddress the address of the ERC20 token address
-    function splitAndPublishForSale(uint _certificateId, uint _power, uint _price, address _tokenAddress) external;
+    function splitAndPublishForSale(uint _certificateId, uint _energy, uint _price, address _tokenAddress) external;
 
     /// @notice gets the certificate
     /// @param _certificateId the id of the certificate

--- a/packages/origin/contracts/Origin/CertificateDB.sol
+++ b/packages/origin/contracts/Origin/CertificateDB.sol
@@ -67,13 +67,13 @@ contract CertificateDB is TradableEntityDB, CertificateSpecificDB {
 
     /// @notice creates a certificate with the provided parameters
     /// @param _assetId the asset-id that produced energy thus created the certificate
-    /// @param _powerInW the power in wh
+    /// @param _energy the energy in wh
     /// @param _assetOwner the assetOwner -> owner of the new certificate
     /// @param _lastSmartMeterReadFileHash the filehash of the last meterreading
     /// @param _maxOwnerChanges the maximal amount of owner changes
     function createCertificateRaw(
         uint _assetId,
-        uint _powerInW,
+        uint _energy,
         address _assetOwner,
         string memory _lastSmartMeterReadFileHash,
         uint _maxOwnerChanges
@@ -85,7 +85,7 @@ contract CertificateDB is TradableEntityDB, CertificateSpecificDB {
         TradableEntityContract.TradableEntity memory tradableEntity = TradableEntityContract.TradableEntity({
             assetId: _assetId,
             owner: _assetOwner,
-            powerInW: _powerInW,
+            energy: _energy,
             forSale: false,
             acceptedToken: address(0x0),
             onChainDirectPurchasePrice: 0,
@@ -110,11 +110,11 @@ contract CertificateDB is TradableEntityDB, CertificateSpecificDB {
 
     /// @notice Creates 2 new children certificates
     /// @param _parentId the id of the parent certificate
-    /// @param _power the power that should be splitted
+    /// @param _energy the energy that should be splitted
     /// @return The ids of the certificate
     function createChildCertificate(
         uint _parentId,
-        uint _power
+        uint _energy
     )
         public
         onlyOwner
@@ -126,7 +126,7 @@ contract CertificateDB is TradableEntityDB, CertificateSpecificDB {
         TradableEntityContract.TradableEntity memory childOneEntity = TradableEntityContract.TradableEntity({
             assetId: parent.tradableEntity.assetId,
             owner: parent.tradableEntity.owner,
-            powerInW: _power,
+            energy: _energy,
             forSale: parent.tradableEntity.forSale,
             acceptedToken: address(0x0),
             onChainDirectPurchasePrice: 0,
@@ -151,7 +151,7 @@ contract CertificateDB is TradableEntityDB, CertificateSpecificDB {
         TradableEntityContract.TradableEntity memory childTwoEntity = TradableEntityContract.TradableEntity({
             assetId: parent.tradableEntity.assetId,
             owner: parent.tradableEntity.owner,
-            powerInW: parent.tradableEntity.powerInW - _power,
+            energy: parent.tradableEntity.energy - _energy,
             forSale: parent.tradableEntity.forSale,
             acceptedToken: address(0x0),
             onChainDirectPurchasePrice: 0,

--- a/packages/origin/contracts/Origin/CertificateSpecificContract.sol
+++ b/packages/origin/contracts/Origin/CertificateSpecificContract.sol
@@ -68,7 +68,7 @@ contract CertificateSpecificContract is TradableEntityLogic {
 
     function createTradableEntity(
         uint _assetId,
-        uint _powerInW
+        uint energy
     )
         internal
         returns (uint);

--- a/packages/origin/contracts/Origin/EnergyCertificateBundleLogic.sol
+++ b/packages/origin/contracts/Origin/EnergyCertificateBundleLogic.sol
@@ -37,7 +37,7 @@ import "../../contracts/Origin/CertificateSpecificContract.sol";
 contract EnergyCertificateBundleLogic is TradableEntityContract, CertificateSpecificContract {
 
     /// @notice Logs the creation of an event
-    event LogCreatedBundle(uint indexed _bundleId, uint powerInW, address owner);
+    event LogCreatedBundle(uint indexed _bundleId, uint energy, address owner);
     /// @notice Logs the request of an retirement of a bundle
     event LogBundleRetired(uint indexed _bundleId);
     /// @notice Logs when the ownership of a bundle has changed
@@ -113,15 +113,15 @@ contract EnergyCertificateBundleLogic is TradableEntityContract, CertificateSpec
 
     /// @notice creates a new bundle
     /// @param _assetId the id of the producing asset
-    /// @param _powerInW the power that has been produced
+    /// @param _energy the energy that has been produced
     function createTradableEntity(
         uint _assetId,
-        uint _powerInW
+        uint _energy
     )
         internal
         returns (uint)
     {
-        return createBundle(_assetId, _powerInW);
+        return createBundle(_assetId, _energy);
     }
 
     /// @notice Request a bundle to retire. Only bundle owner can retire
@@ -176,9 +176,9 @@ contract EnergyCertificateBundleLogic is TradableEntityContract, CertificateSpec
 
     /// @notice Creates a bundle. Checks in the AssetRegistry if requested wh are available.
     /// @param _assetId The id of the asset that generated the energy for the bundle
-    /// @param _powerInW The amount of Watts the bundle holds
+    /// @param _energy The amount of Watts the bundle holds
     /// @return the id of the new bundle
-    function createBundle(uint _assetId, uint _powerInW)
+    function createBundle(uint _assetId, uint _energy)
         internal
         returns (uint)
     {
@@ -188,7 +188,7 @@ contract EnergyCertificateBundleLogic is TradableEntityContract, CertificateSpec
         TradableEntityContract.TradableEntity memory tradableEntity = TradableEntityContract.TradableEntity({
             assetId: _assetId,
             owner: asset.assetGeneral.owner,
-            powerInW: _powerInW,
+            energy: _energy,
             forSale: false,
             acceptedToken: address(0x0),
             onChainDirectPurchasePrice: 0,
@@ -212,7 +212,7 @@ contract EnergyCertificateBundleLogic is TradableEntityContract, CertificateSpec
 
         emit Transfer(address(0),  asset.assetGeneral.owner, bundleId);
 
-        emit LogCreatedBundle(bundleId, _powerInW, asset.assetGeneral.owner);
+        emit LogCreatedBundle(bundleId, _energy, asset.assetGeneral.owner);
         return bundleId;
 
     }

--- a/packages/origin/contracts/Origin/EnergyDB.sol
+++ b/packages/origin/contracts/Origin/EnergyDB.sol
@@ -58,13 +58,13 @@ contract EnergyDB is TradableEntityDB, TradableEntityContract {
     /// @notice creates a new TradableEntity-entry
     /// @param _assetId the asset-id that produced the energy
     /// @param _owner the asset-owner (= the new entity-owner)
-    /// @param _powerInW the amount of energy produced
+    /// @param _energy the amount of energy produced
     /// @param _acceptedToken the accepted ERC20-Token
     /// @param _onChainDirectPurchasePrice the price set onchain for direct purchase (using an ERC20 contract)
     function createTradableEntityEntry(
         uint _assetId,
         address _owner,
-        uint _powerInW,
+        uint _energy,
         address _acceptedToken,
         uint _onChainDirectPurchasePrice
     )
@@ -76,7 +76,7 @@ contract EnergyDB is TradableEntityDB, TradableEntityContract {
         TradableEntity memory te = TradableEntity({
             assetId: _assetId,
             owner: _owner,
-            powerInW: _powerInW,
+            energy: _energy,
             forSale: false,
             acceptedToken: _acceptedToken,
             onChainDirectPurchasePrice: _onChainDirectPurchasePrice,

--- a/packages/origin/contracts/Origin/TradableEntityContract.sol
+++ b/packages/origin/contracts/Origin/TradableEntityContract.sol
@@ -22,7 +22,7 @@ contract TradableEntityContract {
     struct TradableEntity {
         uint assetId;
         address owner;
-        uint powerInW;
+        uint energy;
         bool forSale;
         address acceptedToken;
         uint onChainDirectPurchasePrice;

--- a/packages/origin/src/blockchain-facade/Certificate.ts
+++ b/packages/origin/src/blockchain-facade/Certificate.ts
@@ -23,7 +23,7 @@ export interface ICertificate extends TradableEntity.IOnChainProperties {
 
     pricePerUnit(unit: Unit): number;
     sync(): Promise<ICertificate>;
-    splitCertificate(power: number): Promise<TransactionReceipt>;
+    splitCertificate(energy: number): Promise<TransactionReceipt>;
     transferFrom(_to: string): Promise<TransactionReceipt>;
 }
 
@@ -139,7 +139,7 @@ export class Entity extends TradableEntity.Entity implements ICertificate {
 
             this.assetId = cert.tradableEntity.assetId;
             this.owner = cert.tradableEntity.owner;
-            this.powerInW = Number(cert.tradableEntity.powerInW);
+            this.energy = Number(cert.tradableEntity.energy);
             this.forSale = cert.tradableEntity.forSale;
             this.acceptedToken = cert.tradableEntity.acceptedToken;
             this.onChainDirectPurchasePrice = cert.tradableEntity.onChainDirectPurchasePrice;
@@ -224,17 +224,17 @@ export class Entity extends TradableEntity.Entity implements ICertificate {
         }
     }
 
-    async splitCertificate(power: number): Promise<TransactionReceipt> {
+    async splitCertificate(energy: number): Promise<TransactionReceipt> {
         if (this.configuration.blockchainProperties.activeUser.privateKey) {
             return this.configuration.blockchainProperties.certificateLogicInstance.splitCertificate(
                 this.id,
-                power,
+                energy,
                 { privateKey: this.configuration.blockchainProperties.activeUser.privateKey }
             );
         } else {
             return this.configuration.blockchainProperties.certificateLogicInstance.splitCertificate(
                 this.id,
-                power,
+                energy,
                 { from: this.configuration.blockchainProperties.activeUser.address }
             );
         }
@@ -256,7 +256,7 @@ export class Entity extends TradableEntity.Entity implements ICertificate {
             throw Error('Please specify either an ERC20 token address or a currency.');
         }
 
-        const certificateEnergy = Number(this.powerInW);
+        const certificateEnergy = Number(this.energy);
         const saleParams = {
             onChainPrice: isErc20Sale ? Math.floor(price) : 0,
             tokenAddress: isErc20Sale
@@ -309,7 +309,7 @@ export class Entity extends TradableEntity.Entity implements ICertificate {
         const isOffChainSettlement = Number(this.acceptedToken) === 0x0;
         const price = isOffChainSettlement ? this.offChainSettlementOptions.price : this.onChainDirectPurchasePrice;
 
-        return price / this.powerInW * unit;
+        return price / this.energy * unit;
     }
 
     async getCertificateOwner(): Promise<string> {

--- a/packages/origin/src/blockchain-facade/TradableEntity.ts
+++ b/packages/origin/src/blockchain-facade/TradableEntity.ts
@@ -22,7 +22,7 @@ import { TransactionReceipt } from 'web3/types';
 export interface IOnChainProperties {
     assetId: number;
     owner: string;
-    powerInW: number;
+    energy: number;
     forSale: boolean;
     acceptedToken?: number;
     onChainDirectPurchasePrice: number;
@@ -107,7 +107,7 @@ export abstract class Entity extends BlockchainDataModelEntity.Entity
     implements IOnChainProperties {
     assetId: number;
     owner: string;
-    powerInW: number;
+    energy: number;
     forSale: boolean;
     acceptedToken?: number;
     onChainDirectPurchasePrice: number;

--- a/packages/origin/src/test/CertificateLogic.test.ts
+++ b/packages/origin/src/test/CertificateLogic.test.ts
@@ -315,7 +315,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -432,7 +432,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountTrader,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -478,7 +478,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -513,7 +513,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -556,7 +556,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: erc20TestTokenAddress,
             onChainDirectPurchasePrice: '100',
@@ -640,7 +640,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountTrader,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -683,7 +683,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -721,7 +721,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: ['3', '4'],
             owner: accountAssetOwner,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -752,7 +752,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 60,
+            energy: 60,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -775,7 +775,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 40,
+            energy: 40,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -819,7 +819,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 60,
+            energy: 60,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -862,7 +862,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -929,7 +929,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: testReceiverAddress,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -972,7 +972,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -1039,7 +1039,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: testReceiverAddress,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -1153,14 +1153,14 @@ describe('CertificateLogic-Facade', () => {
             conf
         ).sync();
 
-        assert.equal(certificateOne.powerInW, 200);
+        assert.equal(certificateOne.energy, 200);
 
         const certificateTwo = await new Certificate.Entity(
             (STARTING_CERTIFICATE_LENGTH + 1).toString(),
             conf
         ).sync();
 
-        assert.equal(certificateTwo.powerInW, 382);
+        assert.equal(certificateTwo.energy, 382);
     });
 
     it('issuer should not be able to issue certificates twice for the same certification request', async () => {
@@ -1274,7 +1274,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 100,
+            energy: 100,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -1314,7 +1314,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 30,
+            energy: 30,
             forSale: true,
             acceptedToken: '0x1230000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '10',
@@ -1342,7 +1342,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 70,
+            energy: 70,
             forSale: false,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -1377,7 +1377,7 @@ describe('CertificateLogic-Facade', () => {
             assetId: '0',
             children: [],
             owner: accountAssetOwner,
-            powerInW: 70,
+            energy: 70,
             forSale: true,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: '0',
@@ -1404,7 +1404,7 @@ describe('CertificateLogic-Facade', () => {
         );
         const INITIAL_CERTIFICATION_REQUESTS_LENGTH = (await certificateLogic.getCertificationRequests())
             .length;
-        const CERTIFICATE_POWER = 100;
+        const CERTIFICATE_ENERGY = 100;
         const CERTIFICATE_PRICE = 7;
         const TRADER_STARTING_TOKEN_BALANCE = Number(await erc20TestToken.balanceOf(accountTrader));
         const ASSET_OWNER_STARTING_TOKEN_BALANCE = Number(
@@ -1415,7 +1415,7 @@ describe('CertificateLogic-Facade', () => {
 
         await assetRegistry.saveSmartMeterRead(
             0,
-            LAST_SMART_METER_READ + CERTIFICATE_POWER,
+            LAST_SMART_METER_READ + CERTIFICATE_ENERGY,
             '',
             0,
             {
@@ -1446,7 +1446,7 @@ describe('CertificateLogic-Facade', () => {
 
         setActiveUser(traderPK);
 
-        await parentCertificate.buyCertificate(CERTIFICATE_POWER / 2);
+        await parentCertificate.buyCertificate(CERTIFICATE_ENERGY / 2);
 
         assert.equal(
             await erc20TestToken.balanceOf(accountAssetOwner),
@@ -1468,7 +1468,7 @@ describe('CertificateLogic-Facade', () => {
 
         assert.equal(firstChildCertificate.status, Certificate.Status.Active);
         assert.equal(firstChildCertificate.forSale, false);
-        assert.equal(firstChildCertificate.powerInW, CERTIFICATE_POWER / 2);
+        assert.equal(firstChildCertificate.energy, CERTIFICATE_ENERGY / 2);
 
         const secondChildCertificate = await new Certificate.Entity(
             (STARTING_CERTIFICATE_LENGTH + 2).toString(),
@@ -1477,10 +1477,10 @@ describe('CertificateLogic-Facade', () => {
 
         assert.equal(secondChildCertificate.status, Certificate.Status.Active);
         assert.equal(secondChildCertificate.forSale, true);
-        assert.equal(secondChildCertificate.powerInW, CERTIFICATE_POWER / 2);
+        assert.equal(secondChildCertificate.energy, CERTIFICATE_ENERGY / 2);
     });
 
-    it('should fail to split and buy and split certificate when trying to buy higher power than certificate has', async () => {
+    it('should fail to split and buy and split certificate when trying to buy higher ENERGY than certificate has', async () => {
         const STARTING_CERTIFICATE_LENGTH = Number(
             await Certificate.getCertificateListLength(conf)
         );
@@ -1490,14 +1490,14 @@ describe('CertificateLogic-Facade', () => {
         );
         const INITIAL_CERTIFICATION_REQUESTS_LENGTH = (await certificateLogic.getCertificationRequests())
             .length;
-        const CERTIFICATE_POWER = 100;
+        const CERTIFICATE_ENERGY = 100;
         const CERTIFICATE_PRICE = 7;
 
         setActiveUser(assetOwnerPK);
 
         await assetRegistry.saveSmartMeterRead(
             0,
-            LAST_SMART_METER_READ + CERTIFICATE_POWER,
+            LAST_SMART_METER_READ + CERTIFICATE_ENERGY,
             '',
             0,
             {
@@ -1521,7 +1521,7 @@ describe('CertificateLogic-Facade', () => {
         await parentCertificate.publishForSale(CERTIFICATE_PRICE, Currency.EUR);
 
         try {
-            await parentCertificate.buyCertificate(CERTIFICATE_POWER * 2);
+            await parentCertificate.buyCertificate(CERTIFICATE_ENERGY * 2);
         } catch (error) {
             assert.include(
                 error.message,
@@ -1545,14 +1545,14 @@ describe('CertificateLogic-Facade', () => {
         );
         const INITIAL_CERTIFICATION_REQUESTS_LENGTH = (await certificateLogic.getCertificationRequests())
             .length;
-        const CERTIFICATE_POWER = 100;
+        const CERTIFICATE_ENERGY = 100;
         const CERTIFICATE_PRICE = 7;
 
         setActiveUser(assetOwnerPK);
 
         await assetRegistry.saveSmartMeterRead(
             0,
-            LAST_SMART_METER_READ + CERTIFICATE_POWER,
+            LAST_SMART_METER_READ + CERTIFICATE_ENERGY,
             '',
             0,
             {
@@ -1577,7 +1577,7 @@ describe('CertificateLogic-Facade', () => {
 
         setActiveUser(traderPK);
 
-        await parentCertificate.buyCertificate(CERTIFICATE_POWER);
+        await parentCertificate.buyCertificate(CERTIFICATE_ENERGY);
 
         parentCertificate = await parentCertificate.sync();
 
@@ -1596,7 +1596,7 @@ describe('CertificateLogic-Facade', () => {
         );
         const INITIAL_CERTIFICATION_REQUESTS_LENGTH = (await certificateLogic.getCertificationRequests())
             .length;
-        const CERTIFICATE_POWER = 100;
+        const CERTIFICATE_ENERGY = 100;
         const CERTIFICATE_PRICE = 7;
         const CERTIFICATE_CURRENCY = Currency.EUR;
         const TRADER_STARTING_TOKEN_BALANCE = Number(await erc20TestToken.balanceOf(accountTrader));
@@ -1608,7 +1608,7 @@ describe('CertificateLogic-Facade', () => {
 
         await assetRegistry.saveSmartMeterRead(
             0,
-            LAST_SMART_METER_READ + CERTIFICATE_POWER,
+            LAST_SMART_METER_READ + CERTIFICATE_ENERGY,
             '',
             0,
             {
@@ -1648,7 +1648,7 @@ describe('CertificateLogic-Facade', () => {
 
         setActiveUser(traderPK);
 
-        await parentCertificate.buyCertificate(CERTIFICATE_POWER / 2);
+        await parentCertificate.buyCertificate(CERTIFICATE_ENERGY / 2);
 
         assert.equal(
             await erc20TestToken.balanceOf(accountAssetOwner),
@@ -1667,7 +1667,7 @@ describe('CertificateLogic-Facade', () => {
 
         assert.equal(firstChildCertificate.status, Certificate.Status.Active);
         assert.equal(firstChildCertificate.forSale, false);
-        assert.equal(firstChildCertificate.powerInW, CERTIFICATE_POWER / 2);
+        assert.equal(firstChildCertificate.energy, CERTIFICATE_ENERGY / 2);
         assert.equal(firstChildCertificate.onChainDirectPurchasePrice, 0);
         assert.deepEqual(
             await firstChildCertificate.getOffChainSettlementOptions(),
@@ -1681,7 +1681,7 @@ describe('CertificateLogic-Facade', () => {
 
         assert.equal(secondChildCertificate.status, Certificate.Status.Active);
         assert.equal(secondChildCertificate.forSale, true);
-        assert.equal(secondChildCertificate.powerInW, CERTIFICATE_POWER / 2);
+        assert.equal(secondChildCertificate.energy, CERTIFICATE_ENERGY / 2);
         assert.equal(secondChildCertificate.onChainDirectPurchasePrice, 0);
         assert.deepEqual(
             await secondChildCertificate.getOffChainSettlementOptions(),
@@ -1699,14 +1699,14 @@ describe('CertificateLogic-Facade', () => {
         );
         const INITIAL_CERTIFICATION_REQUESTS_LENGTH = (await certificateLogic.getCertificationRequests())
             .length;
-        const CERTIFICATE_POWER = 100;
+        const CERTIFICATE_ENERGY = 100;
         const CERTIFICATE_PRICE = 7;
 
         setActiveUser(assetOwnerPK);
 
         await assetRegistry.saveSmartMeterRead(
             0,
-            LAST_SMART_METER_READ + CERTIFICATE_POWER,
+            LAST_SMART_METER_READ + CERTIFICATE_ENERGY,
             '',
             0,
             {
@@ -1727,7 +1727,7 @@ describe('CertificateLogic-Facade', () => {
 
         await assetRegistry.saveSmartMeterRead(
             0,
-            LAST_SMART_METER_READ + CERTIFICATE_POWER * 2,
+            LAST_SMART_METER_READ + CERTIFICATE_ENERGY * 2,
             '',
             0,
             {

--- a/packages/origin/src/test/CertificateLogicContracts.test.ts
+++ b/packages/origin/src/test/CertificateLogicContracts.test.ts
@@ -450,7 +450,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -508,7 +508,7 @@ describe('CertificateLogic', () => {
                 const tradableEntityParent = certParent.tradableEntity;
                 assert.equal(tradableEntityParent.assetId, 0);
                 assert.equal(tradableEntityParent.owner, accountAssetOwner);
-                assert.equal(tradableEntityParent.powerInW, 100);
+                assert.equal(tradableEntityParent.energy, 100);
                 assert.equal(
                     tradableEntityParent.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -532,7 +532,7 @@ describe('CertificateLogic', () => {
                 const tradableEntityChildOne = certChildOne.tradableEntity;
                 assert.equal(tradableEntityChildOne.assetId, 0);
                 assert.equal(tradableEntityChildOne.owner, accountAssetOwner);
-                assert.equal(tradableEntityChildOne.powerInW, 40);
+                assert.equal(tradableEntityChildOne.energy, 40);
                 assert.equal(
                     tradableEntityChildOne.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -556,7 +556,7 @@ describe('CertificateLogic', () => {
                 const tradableEntityChildTwo = certChildTwo.tradableEntity;
                 assert.equal(tradableEntityChildTwo.assetId, 0);
                 assert.equal(tradableEntityChildTwo.owner, accountAssetOwner);
-                assert.equal(tradableEntityChildTwo.powerInW, 60);
+                assert.equal(tradableEntityChildTwo.energy, 60);
                 assert.equal(
                     tradableEntityChildTwo.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -745,7 +745,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountTrader);
-                assert.equal(tradableEntity.powerInW, 40);
+                assert.equal(tradableEntity.energy, 40);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -821,7 +821,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountTrader);
-                assert.equal(tradableEntity.powerInW, 40);
+                assert.equal(tradableEntity.energy, 40);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -964,7 +964,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -1159,7 +1159,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -1229,7 +1229,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -1322,7 +1322,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -1472,7 +1472,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -1541,7 +1541,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -1794,7 +1794,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3241,7 +3241,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(tradableEntity.acceptedToken, erc20Test.web3Contract._address);
                 assert.equal(tradableEntity.onChainDirectPurchasePrice, 100);
                 assert.equal(
@@ -3254,7 +3254,7 @@ describe('CertificateLogic', () => {
                 const tradableEntity = await certificateLogic.getTradableEntity(15);
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(tradableEntity.acceptedToken, erc20Test.web3Contract._address);
                 assert.equal(tradableEntity.onChainDirectPurchasePrice, 100);
                 assert.equal(
@@ -3327,7 +3327,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountTrader);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3355,7 +3355,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountTrader);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3436,7 +3436,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3464,7 +3464,7 @@ describe('CertificateLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'

--- a/packages/origin/src/test/EnergyCertificateBundleLogic.test.ts
+++ b/packages/origin/src/test/EnergyCertificateBundleLogic.test.ts
@@ -465,7 +465,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -614,7 +614,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountTrader);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -735,7 +735,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountTrader);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -868,7 +868,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -1136,7 +1136,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -1523,7 +1523,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -1700,7 +1700,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -1834,7 +1834,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -1926,7 +1926,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -2020,7 +2020,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -2128,7 +2128,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -2222,7 +2222,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -2311,7 +2311,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountTrader);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -2417,7 +2417,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -2580,7 +2580,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -2673,7 +2673,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -2833,7 +2833,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -2916,7 +2916,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -2948,7 +2948,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3028,7 +3028,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountTrader);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3111,7 +3111,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3143,7 +3143,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3239,7 +3239,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3322,7 +3322,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3354,7 +3354,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3450,7 +3450,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3533,7 +3533,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3599,7 +3599,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x1000000000000000000000000000000000000006'
@@ -3659,7 +3659,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x1000000000000000000000000000000000000006'
@@ -3713,7 +3713,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountTrader);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3776,7 +3776,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountTrader);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3894,7 +3894,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -3931,7 +3931,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x1000000000000000000000000000000000000006'
@@ -3986,7 +3986,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -4065,7 +4065,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -4175,7 +4175,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -4212,7 +4212,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, accountAssetOwner);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x1000000000000000000000000000000000000006'
@@ -4267,7 +4267,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'
@@ -4331,7 +4331,7 @@ describe('EnergyCertificateBundleLogic', () => {
 
                 assert.equal(tradableEntity.assetId, 0);
                 assert.equal(tradableEntity.owner, testreceiver.web3Contract._address);
-                assert.equal(tradableEntity.powerInW, 100);
+                assert.equal(tradableEntity.energy, 100);
                 assert.equal(
                     tradableEntity.acceptedToken,
                     '0x0000000000000000000000000000000000000000'

--- a/packages/origin/src/wrappedContracts/CertificateDB.ts
+++ b/packages/origin/src/wrappedContracts/CertificateDB.ts
@@ -131,7 +131,7 @@ export class CertificateDB extends GeneralFunctions {
 
     async createCertificateRaw(
         _assetId: number,
-        _powerInW: number,
+        _energy: number,
         _assetOwner: string,
         _lastSmartMeterReadFileHash: string,
         _maxOwnerChanges: number,
@@ -139,7 +139,7 @@ export class CertificateDB extends GeneralFunctions {
     ) {
         const method = this.web3Contract.methods.createCertificateRaw(
             _assetId,
-            _powerInW,
+            _energy,
             _assetOwner,
             _lastSmartMeterReadFileHash,
             _maxOwnerChanges
@@ -280,8 +280,8 @@ export class CertificateDB extends GeneralFunctions {
         return await this.send(method, txParams);
     }
 
-    async createChildCertificate(_parentId: number, _power: number, txParams?: SpecialTx) {
-        const method = this.web3Contract.methods.createChildCertificate(_parentId, _power);
+    async createChildCertificate(_parentId: number, _energy: number, txParams?: SpecialTx) {
+        const method = this.web3Contract.methods.createChildCertificate(_parentId, _energy);
 
         return await this.send(method, txParams);
     }

--- a/packages/origin/src/wrappedContracts/CertificateLogic.ts
+++ b/packages/origin/src/wrappedContracts/CertificateLogic.ts
@@ -204,8 +204,8 @@ export class CertificateLogic extends CertificateSpecificContract {
         return await this.send(method, txParams);
     }
 
-    async splitCertificate(_certificateId: number, _power: number, txParams?: SpecialTx) {
-        const method = this.web3Contract.methods.splitCertificate(_certificateId, _power);
+    async splitCertificate(_certificateId: number, _energy: number, txParams?: SpecialTx) {
+        const method = this.web3Contract.methods.splitCertificate(_certificateId, _energy);
 
         return await this.send(method, txParams);
     }
@@ -281,8 +281,8 @@ export class CertificateLogic extends CertificateSpecificContract {
         return await this.web3Contract.methods.owner().call(txParams);
     }
 
-    async splitAndBuyCertificate(_certificateId: number, _power: number, txParams?: SpecialTx) {
-        const method = this.web3Contract.methods.splitAndBuyCertificate(_certificateId, _power);
+    async splitAndBuyCertificate(_certificateId: number, _energy: number, txParams?: SpecialTx) {
+        const method = this.web3Contract.methods.splitAndBuyCertificate(_certificateId, _energy);
 
         return await this.send(method, txParams);
     }

--- a/packages/origin/src/wrappedContracts/EnergyCertificateBundleLogic.ts
+++ b/packages/origin/src/wrappedContracts/EnergyCertificateBundleLogic.ts
@@ -215,8 +215,8 @@ export class EnergyCertificateBundleLogic extends CertificateSpecificContract {
         return await this.web3Contract.methods.getBundle(_bundleId).call(txParams);
     }
 
-    async createTradableEntity(_assetId: number, _powerInW: number, txParams?: SpecialTx) {
-        const method = this.web3Contract.methods.createTradableEntity(_assetId, _powerInW);
+    async createTradableEntity(_assetId: number, _energy: number, txParams?: SpecialTx) {
+        const method = this.web3Contract.methods.createTradableEntity(_assetId, _energy);
 
         return await this.send(method, txParams);
     }

--- a/packages/origin/src/wrappedContracts/EnergyDB.ts
+++ b/packages/origin/src/wrappedContracts/EnergyDB.ts
@@ -107,7 +107,7 @@ export class EnergyDB extends GeneralFunctions {
     async createTradableEntityEntry(
         _assetId: number,
         _owner: string,
-        _powerInW: number,
+        _energy: number,
         _acceptedToken: string,
         _onChainDirectPurchasePrice: number,
         txParams?: SpecialTx
@@ -115,7 +115,7 @@ export class EnergyDB extends GeneralFunctions {
         const method = this.web3Contract.methods.createTradableEntityEntry(
             _assetId,
             _owner,
-            _powerInW,
+            _energy,
             _acceptedToken,
             _onChainDirectPurchasePrice
         );

--- a/packages/utils-demo/src/certificate.ts
+++ b/packages/utils-demo/src/certificate.ts
@@ -191,7 +191,7 @@ export const certificateDemo = async (
 
                 for (const cId of certificate.children) {
                     const c = await new Certificate.Entity(cId.toString(), conf).sync();
-                    conf.logger.info('Child Certificate #' + cId + ' - PowerInW: ' + c.powerInW);
+                    conf.logger.info('Child Certificate #' + cId + ' - energy: ' + c.energy);
                 }
             } catch (e) {
                 conf.logger.error('Could not split certificates\n' + e);


### PR DESCRIPTION
Certificates currently have a property called `powerInW`, which is misnamed, as it contains `energy` (in Wh) and not power.

This PR fixes this misnaming.