### PR TITLE
fix: partial asset type matching

### DIFF
--- a/packages/utils-general/package.json
+++ b/packages/utils-general/package.json
@@ -31,7 +31,7 @@
     "prepare": "scripts/build.js",
     "start-ganache": "ganache-cli -m 'chalk park staff buzz chair purchase wise oak receive avoid avoid home' -g 0 -l 80000000 -e 1000000 -a 20",
     "prettier": "prettier --write --config-precedence file-override './src/**/*'",
-    "test-ts": "mocha -r ts-node/register src/test/*.test.ts",
+    "test": "mocha -r ts-node/register src/test/*.test.ts",
     "clean": "rm -rf build dist"
   },
   "types": "dist/js/src/index.d.ts",

--- a/packages/utils-general/src/blockchain-facade/AssetTypeService.ts
+++ b/packages/utils-general/src/blockchain-facade/AssetTypeService.ts
@@ -88,7 +88,7 @@ export class IRECAssetService implements IAssetService {
     }
 
     includesAssetType(current: string, requested: string[]): boolean {
-        return requested.some(requestedAssetType => current === requestedAssetType);
+        return requested.some(requestedAssetType => current.startsWith(requestedAssetType));
     }
 
     validate(assetTypes: string[]): { areValid: boolean; unknown: string[] } {


### PR DESCRIPTION
This enabled `utils-general` test to be run with the build and fixes the case where 

Demand: Solar
Producing Asset Type: 'Solar;Photovoltaic;Roof mounted';