### PR TITLE
fix: align to resolution when check in range

### DIFF
--- a/packages/market/src/blockchain-facade/Demand.ts
+++ b/packages/market/src/blockchain-facade/Demand.ts
@@ -320,6 +320,12 @@ export const calculateTotalEnergyDemand = (
     return energyPerTimeFrame * durationInTimeFrame;
 };
 
+export const alignToResolution = (timeStamp: number, resolution: Resolution) =>
+    moment
+        .unix(timeStamp)
+        .startOf(resolution as moment.unitOfTime.StartOf)
+        .unix();
+
 export const calculateMissingEnergyDemand = async (
     demand: IDemand,
     config: Configuration.Entity
@@ -356,7 +362,11 @@ export const calculateMissingEnergyDemand = async (
         })
     );
 
-    const filledDemandInRange = TS.inRange(filledDemandsTimeSeries, startTime, endTime);
+    const filledDemandInRange = TS.inRange(
+        filledDemandsTimeSeries,
+        alignToResolution(startTime, resolution),
+        alignToResolution(endTime, resolution)
+    );
 
     return TS.aggregateByTime(demandTimeSeries.concat(filledDemandInRange));
 };

--- a/packages/market/src/test/unit/Demand.test.ts
+++ b/packages/market/src/test/unit/Demand.test.ts
@@ -1,4 +1,4 @@
-import { Configuration, TimeFrame } from '@energyweb/utils-general';
+import { Configuration, TimeFrame, Unit } from '@energyweb/utils-general';
 import { Arg, Substitute } from '@fluffy-spoon/substitute';
 import { assert } from 'chai';
 import moment from 'moment';
@@ -184,6 +184,28 @@ describe('Demand unit tests', () => {
             assert.equal(missingEnergy[0].value, energyPerTimeFrame - fillAmount);
             assert.equal(missingEnergy[1].value, energyPerTimeFrame);
             assert.equal(missingEnergy[2].value, energyPerTimeFrame);
+        });
+
+        it('should return demand time-series respecting filled events in hourly resolution', async () => {
+            const deliveries = 1;
+
+            const start = moment();
+            const end = start.clone().add(1, 'hour');
+            const energyPerTimeFrame = 1 * Unit.MWh;
+
+            const fillAmount = 1 * Unit.MWh;
+
+            const blockOne = start.unix();
+
+            const blockOneEvent = { blockNumber: 1, value: fillAmount };
+
+            const config = createConfig([blockOne], [blockOneEvent]);
+            const demand = createDemand(start, end, TimeFrame.hourly, energyPerTimeFrame);
+
+            const missingEnergy = await calculateMissingEnergyDemand(demand, config);
+
+            assert.equal(missingEnergy.length, deliveries);
+            assert.equal(missingEnergy[0].value, energyPerTimeFrame - fillAmount);
         });
     });
 });


### PR DESCRIPTION
This PR fixes the issue when inRange filter for TS was used with wrong startTime and endTime when calculating missingEnergy.