### PR TITLE
feat(origin-ui): remove contract address from URL

### DIFF
--- a/packages/origin-ui/src/__tests__/AppContainer.test.tsx
+++ b/packages/origin-ui/src/__tests__/AppContainer.test.tsx
@@ -29,7 +29,7 @@ describe('Application[E2E]', () => {
 
         const rendered = mount(
             <WrapperComponent store={store} history={history}>
-                <Route path="/:contractAddress/" component={AppContainer} />
+                <Route path="/" component={AppContainer} />
             </WrapperComponent>
         );
 

--- a/packages/origin-ui/src/__tests__/AppContainer.test.tsx
+++ b/packages/origin-ui/src/__tests__/AppContainer.test.tsx
@@ -12,18 +12,14 @@ let ganacheServer;
 let apiServer;
 
 describe('Application[E2E]', () => {
-    let CONTRACT;
-
     beforeAll(async () => {
         apiServer = await startAPI();
         ganacheServer = await startGanache();
-        const { deployResult } = await deployDemo();
-
-        CONTRACT = deployResult.marketContractLookup;
+        await deployDemo();
     });
 
     it('correctly navigates to producing asset details', async () => {
-        const { store, history } = setupStore([`/${CONTRACT}/assets/?rpc=http://localhost:8545`], {
+        const { store, history } = setupStore([`/assets/?rpc=http://localhost:8545`], {
             mockUserFetcher: false
         });
 

--- a/packages/origin-ui/src/__tests__/DemandForm.test.tsx
+++ b/packages/origin-ui/src/__tests__/DemandForm.test.tsx
@@ -117,6 +117,6 @@ describe('DemandForm', () => {
 
         await refresh();
 
-        expect(store.getState().router.location.pathname).toBe(`//demands/view/3123`);
+        expect(store.getState().router.location.pathname).toBe(`/demands/view/3123`);
     });
 });

--- a/packages/origin-ui/src/components/AppContainer.tsx
+++ b/packages/origin-ui/src/components/AppContainer.tsx
@@ -8,13 +8,8 @@ import './AppContainer.scss';
 import { Demands } from './Demand/Demands';
 import { AccountChangedModal } from '../elements/Modal/AccountChangedModal';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { ErrorComponent } from './ErrorComponent';
 import { LoadingComponent } from './LoadingComponent';
-import {
-    TSetMarketContractLookupAddress,
-    setMarketContractLookupAddress
-} from '../features/contracts/actions';
 import { getBaseURL } from '../features/selectors';
 import { getAssetsLink, getCertificatesLink, getDemandsLink } from '../utils/routing';
 import { getError, getLoading } from '../features/general/selectors';
@@ -25,11 +20,7 @@ interface IStateProps {
     loading: boolean;
 }
 
-interface IDispatchProps {
-    setMarketContractLookupAddress: TSetMarketContractLookupAddress;
-}
-
-type Props = IStateProps & IDispatchProps;
+type Props = IStateProps;
 
 class AppContainerClass extends React.Component<Props> {
     render(): JSX.Element {
@@ -65,13 +56,6 @@ export const AppContainer = withRouter(
             baseURL: getBaseURL(),
             error: getError(state),
             loading: getLoading(state)
-        }),
-        dispatch =>
-            bindActionCreators(
-                {
-                    setMarketContractLookupAddress
-                },
-                dispatch
-            )
+        })
     )(AppContainerClass)
 );

--- a/packages/origin-ui/src/components/AppContainer.tsx
+++ b/packages/origin-ui/src/components/AppContainer.tsx
@@ -32,12 +32,6 @@ interface IDispatchProps {
 type Props = IStateProps & IDispatchProps;
 
 class AppContainerClass extends React.Component<Props> {
-    async componentDidMount(): Promise<void> {
-        const contractAddress = this.props.match.params.contractAddress;
-
-        this.props.setMarketContractLookupAddress(contractAddress);
-    }
-
     render(): JSX.Element {
         const { baseURL, error, loading } = this.props;
 

--- a/packages/origin-ui/src/components/AppContainer.tsx
+++ b/packages/origin-ui/src/components/AppContainer.tsx
@@ -1,22 +1,6 @@
-// Copyright 2018 Energy Web Foundation
-// This file is part of the Origin Application brought to you by the Energy Web Foundation,
-// a global non-profit organization focused on accelerating blockchain technology across the energy sector,
-// incorporated in Zug, Switzerland.
-//
-// The Origin Application is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-// This is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY and without an implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details, at <http://www.gnu.org/licenses/>.
-//
-// @authors: slock.it GmbH; Heiko Burkhardt, heiko.burkhardt@slock.it; Martin Kuechler, martin.kuchler@slock.it
-
 import * as React from 'react';
 import { Certificates } from './Certificates';
-import { Route, Switch, withRouter, RouteComponentProps } from 'react-router-dom';
+import { Route, Switch, withRouter } from 'react-router-dom';
 import { IStoreState } from '../types';
 import { Header } from './Header';
 import { Asset } from './Asset';
@@ -35,10 +19,6 @@ import { getBaseURL } from '../features/selectors';
 import { getAssetsLink, getCertificatesLink, getDemandsLink } from '../utils/routing';
 import { getError, getLoading } from '../features/general/selectors';
 
-interface IMatchParams {
-    contractAddress?: string;
-}
-
 interface IStateProps {
     baseURL: string;
     error: string;
@@ -49,7 +29,7 @@ interface IDispatchProps {
     setMarketContractLookupAddress: TSetMarketContractLookupAddress;
 }
 
-type Props = RouteComponentProps<IMatchParams> & IStateProps & IDispatchProps;
+type Props = IStateProps & IDispatchProps;
 
 class AppContainerClass extends React.Component<Props> {
     async componentDidMount(): Promise<void> {
@@ -88,7 +68,7 @@ class AppContainerClass extends React.Component<Props> {
 export const AppContainer = withRouter(
     connect(
         (state: IStoreState): IStateProps => ({
-            baseURL: getBaseURL(state),
+            baseURL: getBaseURL(),
             error: getError(state),
             loading: getLoading(state)
         }),

--- a/packages/origin-ui/src/components/Asset.tsx
+++ b/packages/origin-ui/src/components/Asset.tsx
@@ -1,19 +1,3 @@
-// Copyright 2018 Energy Web Foundation
-// This file is part of the Origin Application brought to you by the Energy Web Foundation,
-// a global non-profit organization focused on accelerating blockchain technology across the energy sector,
-// incorporated in Zug, Switzerland.
-//
-// The Origin Application is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-// This is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY and without an implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details, at <http://www.gnu.org/licenses/>.
-//
-// @authors: slock.it GmbH; Heiko Burkhardt, heiko.burkhardt@slock.it; Martin Kuechler, martin.kuchler@slock.it
-
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Route, NavLink, Redirect, withRouter, RouteComponentProps } from 'react-router-dom';
@@ -23,7 +7,6 @@ import { PageContent } from '../elements/PageContent/PageContent';
 import { ProducingAssetDetailView } from './ProducingAssetDetailView';
 import { ConsumingAssetDetailView } from './ConsumingAssetDetailView';
 import { AssetMap } from './AssetMap';
-import { IStoreState } from '../types';
 import { getBaseURL } from '../features/selectors';
 import { getAssetsLink } from '../utils/routing';
 
@@ -151,8 +134,8 @@ class AssetClass extends React.Component<Props> {
 
 export const Asset = withRouter(
     connect(
-        (state: IStoreState): IStateProps => ({
-            baseURL: getBaseURL(state)
+        (): IStateProps => ({
+            baseURL: getBaseURL()
         })
     )(AssetClass)
 );

--- a/packages/origin-ui/src/components/AssetMap.tsx
+++ b/packages/origin-ui/src/components/AssetMap.tsx
@@ -162,6 +162,6 @@ class AssetMapClass extends React.Component<Props, IState> {
 
 export const AssetMap = connect((state: IStoreState, ownProps: IOwnProps) => ({
     assets: ownProps.assets || getProducingAssets(state),
-    baseURL: getBaseURL(state),
+    baseURL: getBaseURL(),
     configuration: getConfiguration(state)
 }))(AssetMapClass);

--- a/packages/origin-ui/src/components/CertificateDetailView.tsx
+++ b/packages/origin-ui/src/components/CertificateDetailView.tsx
@@ -318,7 +318,7 @@ class CertificateDetailViewClass extends React.Component<Props, IDetailViewState
 
 export const CertificateDetailView = connect(
     (state: IStoreState): IStateProps => ({
-        baseURL: getBaseURL(state),
+        baseURL: getBaseURL(),
         certificates: getCertificates(state),
         configuration: getConfiguration(state),
         producingAssets: getProducingAssets(state)

--- a/packages/origin-ui/src/components/CertificateTable.tsx
+++ b/packages/origin-ui/src/components/CertificateTable.tsx
@@ -840,7 +840,7 @@ class CertificateTableClass extends PaginatedLoaderFilteredSorted<Props, ICertif
 
 export const CertificateTable = connect(
     (state: IStoreState, ownProps: IOwnProps): IStateProps => ({
-        baseURL: getBaseURL(state),
+        baseURL: getBaseURL(),
         certificates: ownProps.certificates || getCertificates(state),
         configuration: getConfiguration(state),
         currentUser: getCurrentUser(state),

--- a/packages/origin-ui/src/components/Certificates.tsx
+++ b/packages/origin-ui/src/components/Certificates.tsx
@@ -195,7 +195,7 @@ class CertificatesClass extends React.Component<Props> {
 
 export const Certificates = connect(
     (state: IStoreState): IStateProps => ({
-        baseURL: getBaseURL(state),
+        baseURL: getBaseURL(),
         currentUser: getCurrentUser(state),
         demands: getDemands(state)
     })

--- a/packages/origin-ui/src/components/ConsumingAssetDetailView.tsx
+++ b/packages/origin-ui/src/components/ConsumingAssetDetailView.tsx
@@ -230,7 +230,7 @@ class ConsumingAssetDetailViewClass extends React.Component<Props, IDetailViewSt
 
 export const ConsumingAssetDetailView = connect(
     (state: IStoreState): IStateProps => ({
-        baseURL: getBaseURL(state),
+        baseURL: getBaseURL(),
         certificates: getCertificates(state),
         configuration: getConfiguration(state),
         consumingAssets: getConsumingAssets(state)

--- a/packages/origin-ui/src/components/ConsumingAssetTable.tsx
+++ b/packages/origin-ui/src/components/ConsumingAssetTable.tsx
@@ -169,6 +169,6 @@ export const ConsumingAssetTable = connect(
     (state: IStoreState): IStateProps => ({
         configuration: getConfiguration(state),
         consumingAssets: getConsumingAssets(state),
-        baseURL: getBaseURL(state)
+        baseURL: getBaseURL()
     })
 )(ConsumingAssetTableClass);

--- a/packages/origin-ui/src/components/Demand/DemandForm.tsx
+++ b/packages/origin-ui/src/components/Demand/DemandForm.tsx
@@ -667,7 +667,7 @@ class DemandFormClass extends React.Component<Props, IState> {
 export const DemandForm = withRouter(
     connect(
         (state: IStoreState): IStateProps => ({
-            baseURL: getBaseURL(state),
+            baseURL: getBaseURL(),
             currentUser: getCurrentUser(state),
             configuration: getConfiguration(state)
         })

--- a/packages/origin-ui/src/components/Demand/DemandTable.tsx
+++ b/packages/origin-ui/src/components/Demand/DemandTable.tsx
@@ -330,7 +330,7 @@ export const DemandTable = withRouter(
             configuration: getConfiguration(state),
             demands: getDemands(state),
             currentUser: getCurrentUser(state),
-            baseURL: getBaseURL(state)
+            baseURL: getBaseURL()
         })
     )(DemandTableClass)
 );

--- a/packages/origin-ui/src/components/Demand/Demands.tsx
+++ b/packages/origin-ui/src/components/Demand/Demands.tsx
@@ -3,7 +3,6 @@ import { PageContent } from '../../elements/PageContent/PageContent';
 import { DemandTable } from './DemandTable';
 import { connect } from 'react-redux';
 import { getDemandsLink } from '../../utils/routing';
-import { IStoreState } from '../../types';
 import { getBaseURL } from '../../features/selectors';
 import { DemandForm } from './DemandForm';
 import { NavLink, Route, Redirect } from 'react-router-dom';
@@ -107,7 +106,7 @@ class DemandsClass extends React.Component<Props> {
 }
 
 export const Demands = connect(
-    (state: IStoreState): IStateProps => ({
-        baseURL: getBaseURL(state)
+    (): IStateProps => ({
+        baseURL: getBaseURL()
     })
 )(DemandsClass);

--- a/packages/origin-ui/src/components/Header.tsx
+++ b/packages/origin-ui/src/components/Header.tsx
@@ -1,36 +1,17 @@
-// Copyright 2018 Energy Web Foundation
-// This file is part of the Origin Application brought to you by the Energy Web Foundation,
-// a global non-profit organization focused on accelerating blockchain technology across the energy sector,
-// incorporated in Zug, Switzerland.
-//
-// The Origin Application is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-// This is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY and without an implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details, at <http://www.gnu.org/licenses/>.
-//
-// @authors: slock.it GmbH; Heiko Burkhardt, heiko.burkhardt@slock.it; Martin Kuechler, martin.kuchler@slock.it
-
 import * as React from 'react';
 import { NavLink, withRouter, RouteComponentProps } from 'react-router-dom';
 import { User } from '@energyweb/user-registry';
 import logo from '../../assets/logo.svg';
 import { AccountCircle } from '@material-ui/icons';
-import { Configuration } from '@energyweb/utils-general';
-
 import './Header.scss';
 import { connect } from 'react-redux';
 import { IStoreState } from '../types';
-import { getBaseURL, getConfiguration } from '../features/selectors';
+import { getBaseURL } from '../features/selectors';
 import { getAssetsLink, getCertificatesLink, getDemandsLink } from '../utils/routing';
 import { AccountDetailsModal } from '../elements/Modal/AccountDetailsModal';
 import { getCurrentUser } from '../features/users/selectors';
 
 interface IStateProps {
-    configuration: Configuration.Entity;
     currentUser: User.Entity;
     baseURL: string;
 }
@@ -51,7 +32,7 @@ class HeaderClass extends React.Component<Props, IHeaderState> {
     }
 
     render() {
-        const { baseURL, currentUser, configuration } = this.props;
+        const { baseURL, currentUser } = this.props;
 
         return (
             <div className="HeaderWrapper">
@@ -82,8 +63,6 @@ class HeaderClass extends React.Component<Props, IHeaderState> {
 
                 {currentUser && (
                     <AccountDetailsModal
-                        conf={configuration}
-                        currentUser={currentUser}
                         showModal={this.state.showAccountDetailsModal}
                         callback={() => this.setState({ showAccountDetailsModal: false })}
                     />
@@ -95,7 +74,6 @@ class HeaderClass extends React.Component<Props, IHeaderState> {
 
 export const Header = withRouter(
     connect((state: IStoreState) => ({
-        configuration: getConfiguration(state),
         baseURL: getBaseURL(),
         currentUser: getCurrentUser(state)
     }))(HeaderClass)

--- a/packages/origin-ui/src/components/Header.tsx
+++ b/packages/origin-ui/src/components/Header.tsx
@@ -96,7 +96,7 @@ class HeaderClass extends React.Component<Props, IHeaderState> {
 export const Header = withRouter(
     connect((state: IStoreState) => ({
         configuration: getConfiguration(state),
-        baseURL: getBaseURL(state),
+        baseURL: getBaseURL(),
         currentUser: getCurrentUser(state)
     }))(HeaderClass)
 );

--- a/packages/origin-ui/src/components/ProducingAssetDetailView.tsx
+++ b/packages/origin-ui/src/components/ProducingAssetDetailView.tsx
@@ -344,7 +344,7 @@ class ProducingAssetDetailViewClass extends React.Component<Props, IState> {
 
 export const ProducingAssetDetailView = connect(
     (state: IStoreState): IStateProps => ({
-        baseURL: getBaseURL(state),
+        baseURL: getBaseURL(),
         certificates: getCertificates(state),
         configuration: getConfiguration(state),
         producingAssets: getProducingAssets(state)

--- a/packages/origin-ui/src/components/ProducingAssetTable.tsx
+++ b/packages/origin-ui/src/components/ProducingAssetTable.tsx
@@ -285,6 +285,6 @@ export const ProducingAssetTable = connect(
         producingAssets: getProducingAssets(state),
         users: getUsers(state),
         currentUser: getCurrentUser(state),
-        baseURL: getBaseURL(state)
+        baseURL: getBaseURL()
     })
 )(ProducingAssetTableClass);

--- a/packages/origin-ui/src/features/contracts/actions.ts
+++ b/packages/origin-ui/src/features/contracts/actions.ts
@@ -4,7 +4,10 @@ export enum ContractsActions {
 
 export interface ISetMarketContractLookupAddressAction {
     type: ContractsActions.setMarketContractLookupAddress;
-    payload: string;
+    payload: {
+        address: string;
+        userDefined?: boolean;
+    };
 }
 
 export const setMarketContractLookupAddress = (
@@ -15,5 +18,8 @@ export const setMarketContractLookupAddress = (
 });
 
 export type TSetMarketContractLookupAddress = typeof setMarketContractLookupAddress;
+
+export const MARKET_CONTRACT_LOOKUP_ADDRESS_STORAGE_KEY =
+    'CONTRACTS_MARKET_CONTRACT_LOOKUP_ADDRESS';
 
 export type IContractsAction = ISetMarketContractLookupAddressAction;

--- a/packages/origin-ui/src/features/contracts/reducer.ts
+++ b/packages/origin-ui/src/features/contracts/reducer.ts
@@ -11,7 +11,7 @@ const defaultState: IContractsState = {
 export default function reducer(state = defaultState, action: IContractsAction): IContractsState {
     switch (action.type) {
         case ContractsActions.setMarketContractLookupAddress:
-            return { ...state, marketContractLookupAddress: action.payload };
+            return { ...state, marketContractLookupAddress: action.payload.address };
 
         default:
             return state;

--- a/packages/origin-ui/src/features/contracts/sagas.ts
+++ b/packages/origin-ui/src/features/contracts/sagas.ts
@@ -1,7 +1,6 @@
-import { call, put, select, take, all, fork, apply, takeEvery, cancel } from 'redux-saga/effects';
+import { call, put, select, take, all, fork, apply, cancel } from 'redux-saga/effects';
 import { SagaIterator, eventChannel } from 'redux-saga';
-import { ContractsActions, setMarketContractLookupAddress } from './actions';
-import { getMarketContractLookupAddress } from './selectors';
+import { setMarketContractLookupAddress } from './actions';
 import { getSearch } from 'connected-react-router';
 import { getConfiguration } from '../selectors';
 import * as queryString from 'query-string';
@@ -22,7 +21,6 @@ import {
 import { ProducingAsset, ConsumingAsset } from '@energyweb/asset-registry';
 import { BACKEND_URL, getMarketContractLookupAddressFromAPI } from '../../utils/api';
 import { setError, setLoading } from '../general/actions';
-import { getLoading } from '../general/selectors';
 import { updateCurrentUserId } from '../users/actions';
 import { producingAssetCreatedOrUpdated } from '../producingAssets/actions';
 import { certificateCreatedOrUpdated } from '../certificates/actions';
@@ -194,91 +192,81 @@ function* initEventHandler() {
 }
 
 function* fillMarketContractLookupAddressIfMissing(): SagaIterator {
-    yield takeEvery(ContractsActions.setMarketContractLookupAddress, function*() {
-        let marketContractLookupAddress: string | undefined = yield select(
-            getMarketContractLookupAddress
+    const marketContractLookupAddress: string = yield call(getMarketContractLookupAddressFromAPI);
+
+    if (marketContractLookupAddress) {
+        yield put(setMarketContractLookupAddress(marketContractLookupAddress));
+    } else {
+        yield put(setError(ERROR.WRONG_NETWORK_OR_CONTRACT_ADDRESS));
+        yield put(setLoading(false));
+
+        return;
+    }
+
+    const routerSearch: string = yield select(getSearch);
+
+    let configuration: Configuration.Entity;
+    try {
+        configuration = yield call(initConf, marketContractLookupAddress, routerSearch);
+
+        yield put(configurationUpdated(configuration));
+
+        yield put(setLoading(false));
+    } catch (error) {
+        console.error('ContractsSaga::WrongNetwork', error);
+        yield put(setError(ERROR.WRONG_NETWORK_OR_CONTRACT_ADDRESS));
+        yield put(setLoading(false));
+
+        yield cancel();
+    }
+
+    try {
+        const accounts: string[] = yield call(
+            configuration.blockchainProperties.web3.eth.getAccounts
         );
 
-        const loading: boolean = yield select(getLoading);
+        yield put(updateCurrentUserId(accounts[0]));
+    } catch (error) {
+        console.error('ContractsSaga::UserDoesntExist', error);
+    }
 
-        if (marketContractLookupAddress && marketContractLookupAddress !== 'undefined' && loading) {
-            const routerSearch: string = yield select(getSearch);
+    const producingAssets: ProducingAsset.Entity[] = yield apply(
+        ProducingAsset,
+        ProducingAsset.getAllAssets,
+        [configuration]
+    );
 
-            let configuration: Configuration.Entity;
-            try {
-                configuration = yield call(initConf, marketContractLookupAddress, routerSearch);
+    for (const asset of producingAssets) {
+        yield put(producingAssetCreatedOrUpdated(asset));
+    }
 
-                yield put(configurationUpdated(configuration));
+    const consumingAssets: ConsumingAsset.Entity[] = yield apply(
+        ConsumingAsset,
+        ConsumingAsset.getAllAssets,
+        [configuration]
+    );
 
-                yield put(setLoading(false));
-            } catch (error) {
-                console.error('ContractsSaga::WrongNetwork', error);
-                yield put(setError(ERROR.WRONG_NETWORK_OR_CONTRACT_ADDRESS));
-                yield put(setLoading(false));
+    for (const asset of consumingAssets) {
+        yield put(consumingAssetCreatedOrUpdated(asset));
+    }
 
-                yield cancel();
-            }
+    const demands: Demand.Entity[] = yield apply(Demand, Demand.getAllDemands, [configuration]);
 
-            try {
-                const accounts: string[] = yield call(
-                    configuration.blockchainProperties.web3.eth.getAccounts
-                );
+    for (const demand of demands) {
+        yield put(demandCreated(demand));
+    }
 
-                yield put(updateCurrentUserId(accounts[0]));
-            } catch (error) {
-                console.error('ContractsSaga::UserDoesntExist', error);
-            }
+    const certificates: Certificate.Entity[] = yield apply(
+        Certificate,
+        Certificate.getAllCertificates,
+        [configuration]
+    );
 
-            const producingAssets: ProducingAsset.Entity[] = yield apply(
-                ProducingAsset,
-                ProducingAsset.getAllAssets,
-                [configuration]
-            );
+    for (const certificate of certificates) {
+        yield put(certificateCreatedOrUpdated(certificate));
+    }
 
-            for (const asset of producingAssets) {
-                yield put(producingAssetCreatedOrUpdated(asset));
-            }
-
-            const consumingAssets: ConsumingAsset.Entity[] = yield apply(
-                ConsumingAsset,
-                ConsumingAsset.getAllAssets,
-                [configuration]
-            );
-
-            for (const asset of consumingAssets) {
-                yield put(consumingAssetCreatedOrUpdated(asset));
-            }
-
-            const demands: Demand.Entity[] = yield apply(Demand, Demand.getAllDemands, [
-                configuration
-            ]);
-
-            for (const demand of demands) {
-                yield put(demandCreated(demand));
-            }
-
-            const certificates: Certificate.Entity[] = yield apply(
-                Certificate,
-                Certificate.getAllCertificates,
-                [configuration]
-            );
-
-            for (const certificate of certificates) {
-                yield put(certificateCreatedOrUpdated(certificate));
-            }
-
-            yield call(initEventHandler);
-        } else {
-            marketContractLookupAddress = yield call(getMarketContractLookupAddressFromAPI);
-
-            if (marketContractLookupAddress) {
-                yield put(setMarketContractLookupAddress(marketContractLookupAddress));
-            } else {
-                yield put(setError(ERROR.WRONG_NETWORK_OR_CONTRACT_ADDRESS));
-                yield put(setLoading(false));
-            }
-        }
-    });
+    yield call(initEventHandler);
 }
 
 export function* contractsSaga(): SagaIterator {

--- a/packages/origin-ui/src/features/contracts/sagas.ts
+++ b/packages/origin-ui/src/features/contracts/sagas.ts
@@ -2,8 +2,8 @@ import { call, put, select, take, all, fork, apply, takeEvery, cancel } from 're
 import { SagaIterator, eventChannel } from 'redux-saga';
 import { ContractsActions, setMarketContractLookupAddress } from './actions';
 import { getMarketContractLookupAddress } from './selectors';
-import { push, getSearch } from 'connected-react-router';
-import { constructBaseURL, getConfiguration } from '../selectors';
+import { getSearch } from 'connected-react-router';
+import { getConfiguration } from '../selectors';
 import * as queryString from 'query-string';
 import * as Winston from 'winston';
 import { Certificate } from '@energyweb/origin';
@@ -273,8 +273,6 @@ function* fillMarketContractLookupAddressIfMissing(): SagaIterator {
 
             if (marketContractLookupAddress) {
                 yield put(setMarketContractLookupAddress(marketContractLookupAddress));
-
-                yield put(push(constructBaseURL(marketContractLookupAddress)));
             } else {
                 yield put(setError(ERROR.WRONG_NETWORK_OR_CONTRACT_ADDRESS));
                 yield put(setLoading(false));

--- a/packages/origin-ui/src/features/selectors.ts
+++ b/packages/origin-ui/src/features/selectors.ts
@@ -1,9 +1,4 @@
 import { IStoreState } from '../types';
-import { getMarketContractLookupAddress } from './contracts/selectors';
-
-export const constructBaseURL = (marketContractLookupAddress: string) => {
-    return `/${marketContractLookupAddress}`;
-};
 
 export const getConfiguration = (state: IStoreState) => state.configuration;
 
@@ -13,6 +8,6 @@ export const getProducingAssets = (state: IStoreState) => state.producingAssets.
 
 export const getConsumingAssets = (state: IStoreState) => state.consumingAssets;
 
-export const getBaseURL = (state: IStoreState) => {
-    return constructBaseURL(getMarketContractLookupAddress(state));
+export const getBaseURL = () => {
+    return '';
 };

--- a/packages/origin-ui/src/index.tsx
+++ b/packages/origin-ui/src/index.tsx
@@ -41,7 +41,7 @@ ReactDOM.render(
         <MuiPickersUtilsProvider utils={MomentUtils}>
             <Provider store={store}>
                 <ConnectedRouter history={history}>
-                    <Route path="/:contractAddress?" component={AppContainer} />
+                    <Route path="/" component={AppContainer} />
                 </ConnectedRouter>
             </Provider>
         </MuiPickersUtilsProvider>

--- a/packages/origin-ui/src/utils/api.ts
+++ b/packages/origin-ui/src/utils/api.ts
@@ -3,15 +3,19 @@ import axios from 'axios';
 export const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3030';
 
 export async function getMarketContractLookupAddressFromAPI(): Promise<string> {
-    const response = await axios.get(`${BACKEND_URL}/MarketContractLookup`);
+    try {
+        const response = await axios.get(`${BACKEND_URL}/MarketContractLookup`);
 
-    if (!response.data) {
+        if (!response.data) {
+            return null;
+        }
+
+        const marketContracts = response.data;
+
+        if (marketContracts.length > 0) {
+            return marketContracts[marketContracts.length - 1];
+        }
+    } catch {
         return null;
-    }
-
-    const marketContracts = response.data;
-
-    if (marketContracts.length > 0) {
-        return marketContracts[marketContracts.length - 1];
     }
 }


### PR DESCRIPTION
![screenshot-localhost_3000-2019 10 04-13_14_32](https://user-images.githubusercontent.com/4950658/66203636-210ef280-e6a9-11e9-987d-77873769e0b6.png)

If you set it to wrong address and become stuck, you can use:
```
localStorage.clear()
```

in devtools, or just clear all site data. Setting custom market contract lookup is for advanced users.