### PR TITLE
[FIX] Solar Simulator: Asset timezone + event listener

### DIFF
--- a/packages/event-listener/src/email/mandrill.adapter.ts
+++ b/packages/event-listener/src/email/mandrill.adapter.ts
@@ -36,6 +36,13 @@ export class MandrillEmailAdapter implements IEmailAdapter {
 
         const result: any = await this.sendMandrill(message);
 
+        if (result === null) {
+            return {
+                success: true,
+                error: null
+            };
+        }
+
         return {
             success: result[0].status === 'sent',
             error: result[0].reject_reason ? `Mandrill Error: ${JSON.stringify(result[0])}` : null

--- a/packages/solar-simulator/src/consumerService.ts
+++ b/packages/solar-simulator/src/consumerService.ts
@@ -125,8 +125,8 @@ async function getEnergyMeasurements(
         for (const asset of CONFIG.assets) {
             const energyMeasurements: IEnergyMeasurement[] = await getEnergyMeasurements(
                 asset.id,
-                previousTime,
-                now
+                previousTime.tz(asset.timezone),
+                now.tz(asset.timezone)
             );
 
             for (const energyMeasurement of energyMeasurements) {
@@ -137,7 +137,7 @@ async function getEnergyMeasurements(
                 const roundedEnergy: number = Math.round(energyMeasurement.energy);
 
                 const previousRead: number = await getProducingAssetSmartMeterRead(asset.id);
-                const time = moment(energyMeasurement.measurementTime);
+                const time = moment(energyMeasurement.measurementTime).tz(asset.timezone);
 
                 await saveProducingAssetSmartMeterRead(
                     previousRead + roundedEnergy,


### PR DESCRIPTION
- Fixes the timezone in which the smart meter readings are saved for an asset
- Fixes an issue with the event listener where Mandrill returns null