### PR TITLE
feat: certificate buying flow for matcher

### DIFF
--- a/packages/event-listener/src/test/deployDemo.ts
+++ b/packages/event-listener/src/test/deployDemo.ts
@@ -64,6 +64,10 @@ export class Demo {
             MATCHER: {
                 address: '0x3409c66069b3C4933C654beEAA136cc5ce6D7BD0'.toLowerCase(),
                 privateKey: '0x554f3c1470e9f66ed2cf1dc260d2f4de77a816af2883679b1dc68c551e8fa5ed'
+            },
+            TRADER: {
+                address: '0xb00f0793d0ce69d7b07db16f92dc982cd6bdf651',
+                privateKey: '0xca77c9b06fde68bcbcc09f603c958620613f4be79f3abb4b2032131d0229462e'
             }
         };
 
@@ -244,6 +248,28 @@ export class Demo {
         };
         await User.createUser(marketLogicPropsOnChain, marketLogicPropsOffChain, this.conf);
 
+        const traderOnChain: User.IUserOnChainProperties = {
+            propertiesDocumentHash: null,
+            url: null,
+            id: this.ACCOUNTS.TRADER.address,
+            active: true,
+            roles: buildRights([Role.Trader]),
+            organization: 'Trader'
+        };
+        const traderOffChain: User.IUserOffChainProperties = {
+            firstName: 'Trader',
+            surname: 'Trader',
+            email: 'marketlogicmatcher@example.com',
+            street: '',
+            number: '',
+            zip: '',
+            city: '',
+            country: '',
+            state: '',
+            notifications: true
+        };
+        await User.createUser(traderOnChain, traderOffChain, this.conf);
+
         const assetProducingProps: ProducingAsset.IOnChainProperties = {
             smartMeter: { address: this.ACCOUNTS.SMART_METER.address },
             owner: { address: this.ACCOUNTS.ASSET_MANAGER.address },
@@ -285,6 +311,8 @@ export class Demo {
     }
 
     async deploySmartMeterRead(smRead: number): Promise<void> {
+        this.conf.blockchainProperties.activeUser = this.ACCOUNTS.ASSET_MANAGER;
+
         await this.assetProducingRegistryLogic.saveSmartMeterRead(
             0,
             smRead,
@@ -305,6 +333,8 @@ export class Demo {
     }
 
     async publishForSale(certificateId: number) {
+        this.conf.blockchainProperties.activeUser = this.ACCOUNTS.ASSET_MANAGER;
+
         const deployedCertificate = await new Certificate.Entity(
             certificateId.toString(),
             this.conf
@@ -314,7 +344,7 @@ export class Demo {
     }
 
     async deployDemand() {
-        this.conf.blockchainProperties.activeUser = this.ACCOUNTS.ASSET_MANAGER;
+        this.conf.blockchainProperties.activeUser = this.ACCOUNTS.TRADER;
 
         const demandOffChainProps: Demand.IDemandOffChainProperties = {
             timeFrame: TimeFrame.hourly,

--- a/packages/event-listener/src/test/e2e/EventService.test.ts
+++ b/packages/event-listener/src/test/e2e/EventService.test.ts
@@ -12,7 +12,7 @@ describe('Event Service Tests', async () => {
         path: '.env.test'
     });
 
-    let demo: any;
+    let demo: Demo;
 
     before(async () => {
         demo = new Demo(process.env.WEB3, process.env.DEPLOY_KEY);

--- a/packages/event-listener/src/test/e2e/OriginListener.test.ts
+++ b/packages/event-listener/src/test/e2e/OriginListener.test.ts
@@ -47,10 +47,10 @@ describe('Origin Listener Tests', async () => {
         path: '.env.test'
     });
 
-    let demo: any;
+    let demo: Demo;
     let listener: IOriginEventListener;
-    let emailService: any;
-    let store: any;
+    let emailService: EmailServiceProvider;
+    let store: OriginEventsStore;
 
     let currentSmRead = 0;
 

--- a/packages/market-matcher/src/CertificateMatcher.ts
+++ b/packages/market-matcher/src/CertificateMatcher.ts
@@ -1,0 +1,176 @@
+import { Certificate } from '@energyweb/origin';
+import { inject, injectable } from 'tsyringe';
+import { Configuration } from '@energyweb/utils-general';
+import * as Winston from 'winston';
+import { ProducingAsset } from '@energyweb/asset-registry';
+import { Demand, Supply } from '@energyweb/market';
+import { IEntityStore } from './EntityStore';
+import { IStrategy } from './strategy/IStrategy';
+import { CertificateService } from './CertificateService';
+import { MatchableDemand } from './MatchableDemand';
+import { MatchableAgreement } from './MatchableAgreement';
+import { reasonsToString } from './MatchingErrorReason';
+
+@injectable()
+export class CertificateMatcher {
+    constructor(
+        @inject('config') private config: Configuration.Entity,
+        @inject('entityStore') private entityStore: IEntityStore,
+        @inject('certificateService') private certificateService: CertificateService,
+        @inject('strategy') private strategy: IStrategy,
+        @inject('logger') private logger: Winston.Logger
+    ) {}
+
+    public async match(certificate: Certificate.Entity) {
+        try {
+            const matchingResult =
+                (await this.matchWithAgreements(certificate)) ||
+                (await this.matchWithDemands(certificate));
+
+            this.logger.info(
+                `[Certificate #${certificate.id}] Completed processing with result ${matchingResult}`
+            );
+
+            return matchingResult;
+        } catch (e) {
+            this.logger.error(
+                `[Certificate #${certificate.id}] Processing certificate failed with ${e.message}`
+            );
+        }
+
+        return false;
+    }
+
+    private async matchWithAgreements(certificate: Certificate.ICertificate) {
+        this.logger.info(`[Certificate #${certificate.id}] Started matching with agreements`);
+
+        const matchingAgreements = await this.findMatchingAgreements(certificate);
+        const demands = await Promise.all(
+            matchingAgreements.map(async ({ agreement }) =>
+                this.entityStore.getDemandById(agreement.demandId.toString())
+            )
+        );
+
+        return this.executeForDemands(certificate, demands, true);
+    }
+
+    private async matchWithDemands(certificate: Certificate.ICertificate) {
+        this.logger.info(`[Certificate #${certificate.id}] Started matching with demands`);
+
+        if (!certificate.forSale) {
+            this.logger.verbose(`[Certificate #${certificate.id}] Not on sale. Skipping.`);
+            return false;
+        }
+
+        const matchingDemands = await this.findMatchingDemands(certificate);
+        const demands = matchingDemands.map(({ demand }) => demand);
+
+        return this.executeForDemands(certificate, demands, false);
+    }
+
+    private async executeForDemands(
+        certificate: Certificate.ICertificate,
+        demands: Demand.IDemand[],
+        fromAgreement: boolean
+    ) {
+        if (!demands.length) {
+            return false;
+        }
+
+        for (const demand of demands) {
+            const res = await this.certificateService.executeMatching(
+                certificate,
+                demand,
+                fromAgreement
+            );
+            if (res) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async findMatchingAgreements(
+        certificate: Certificate.ICertificate
+    ): Promise<MatchableAgreement[]> {
+        const agreements = this.entityStore
+            .getAgreements()
+            .map(agreement => new MatchableAgreement(agreement));
+
+        this.logger.verbose(
+            `[Certificate #${certificate.id}] Found ${(agreements || []).length} agreements`
+        );
+
+        const matchingAgreements: MatchableAgreement[] = [];
+
+        for (const agreement of agreements) {
+            const supply = await new Supply.Entity(
+                agreement.agreement.supplyId.toString(),
+                this.config
+            ).sync();
+            const demand = await new Demand.Entity(
+                agreement.agreement.demandId.toString(),
+                this.config
+            ).sync();
+            const { result, reason } = await agreement.matchesCertificate(
+                certificate,
+                supply,
+                demand
+            );
+
+            this.logger.verbose(
+                `[Certificate #${certificate.id}] Result of matching with agreement for Demand #${
+                    agreement.agreement.demandId
+                } and Supply #${
+                    agreement.agreement.supplyId
+                } is ${result} with reason ${reasonsToString(reason)}`
+            );
+
+            if (result) {
+                matchingAgreements.push(agreement);
+            }
+        }
+
+        this.logger.verbose(
+            `[Certificate #${certificate.id}] Found ${matchingAgreements.length} matching agreements`
+        );
+
+        return this.strategy.executeForAgreements(matchingAgreements);
+    }
+
+    private async findMatchingDemands(
+        certificate: Certificate.ICertificate
+    ): Promise<MatchableDemand[]> {
+        const producingAsset = await new ProducingAsset.Entity(
+            certificate.assetId.toString(),
+            this.config
+        ).sync();
+
+        const demands = this.entityStore.getDemands().map(demand => new MatchableDemand(demand));
+
+        this.logger.verbose(
+            `[Certificate #${certificate.id}] Found ${(demands || []).length} demands`
+        );
+
+        const matchingDemands: MatchableDemand[] = [];
+
+        for (const demand of demands) {
+            const { result, reason } = await demand.matchesCertificate(certificate, producingAsset);
+            this.logger.verbose(
+                `[Certificate #${certificate.id}] Result of matching with demand ${
+                    demand.demand.id
+                } is ${result} with reason ${reasonsToString(reason)}`
+            );
+            if (result) {
+                matchingDemands.push(demand);
+            }
+        }
+
+        this.logger.verbose(
+            `[Certificate #${certificate.id}] Found ${matchingDemands.length} matching demands`
+        );
+
+        return matchingDemands;
+    }
+}

--- a/packages/market-matcher/src/DemandMatcher.ts
+++ b/packages/market-matcher/src/DemandMatcher.ts
@@ -1,0 +1,97 @@
+import { ProducingAsset } from '@energyweb/asset-registry';
+import { Demand } from '@energyweb/market';
+import { Certificate } from '@energyweb/origin';
+import { Configuration } from '@energyweb/utils-general';
+import { inject, injectable } from 'tsyringe';
+import * as Winston from 'winston';
+
+import { CertificateService } from './CertificateService';
+import { IEntityStore } from './EntityStore';
+import { MatchableDemand } from './MatchableDemand';
+import { reasonsToString } from './MatchingErrorReason';
+import { IStrategy } from './strategy/IStrategy';
+
+@injectable()
+export class DemandMatcher {
+    constructor(
+        @inject('config') private config: Configuration.Entity,
+        @inject('entityStore') private entityStore: IEntityStore,
+        @inject('certificateService') private certificateService: CertificateService,
+        @inject('strategy') private strategy: IStrategy,
+        @inject('logger') private logger: Winston.Logger
+    ) {}
+
+    public async match(demand: Demand.Entity) {
+        try {
+            this.logger.verbose(`[Demand #${demand.id}] Started matching with certificates`);
+
+            const certificates = await this.findMatchingCertificates(demand);
+
+            let matched = false;
+
+            for (const certificate of certificates) {
+                const matchingResult = await this.certificateService.executeMatching(
+                    certificate,
+                    demand,
+                    false
+                );
+                if (matchingResult) {
+                    matched = true;
+                    break;
+                }
+            }
+            this.logger.info(`[Demand #${demand.id}] Completed processing with result ${matched}`);
+
+            return matched;
+        } catch (e) {
+            this.logger.error(`[Demand #${demand.id}] Processing failed with ${e.message}`);
+        }
+
+        return true;
+    }
+
+    private async findMatchingCertificates(demand: Demand.Entity) {
+        const matchableDemand = new MatchableDemand(demand);
+
+        const certificates = await Promise.all(
+            this.entityStore
+                .getCertificates()
+                .filter(certificate => certificate.forSale)
+                .map(async (certificate: Certificate.Entity) => {
+                    const producingAsset = await new ProducingAsset.Entity(
+                        certificate.assetId.toString(),
+                        this.config
+                    ).sync();
+
+                    return { certificate, producingAsset };
+                })
+        );
+
+        this.logger.verbose(
+            `[Demand #${demand.id}] Found ${(certificates || []).length} certificates on-sale`
+        );
+
+        const matchingCertificates: Certificate.ICertificate[] = [];
+
+        for (const { certificate, producingAsset } of certificates) {
+            const { result, reason } = await matchableDemand.matchesCertificate(
+                certificate,
+                producingAsset
+            );
+            this.logger.verbose(
+                `[Demand #${demand.id}] Result of matching with certificate ${
+                    certificate.id
+                } is ${result} with reason ${reasonsToString(reason)}`
+            );
+            if (result) {
+                matchingCertificates.push(certificate);
+            }
+        }
+
+        this.logger.verbose(
+            `[Demand #${demand.id}] Found ${matchingCertificates.length} matching certificates`
+        );
+
+        return this.strategy.executeForCertificates(matchingCertificates);
+    }
+}

--- a/packages/market-matcher/src/EntityStore.ts
+++ b/packages/market-matcher/src/EntityStore.ts
@@ -249,7 +249,7 @@ export class EntityStore implements IEntityStore {
 
     private registerDemand(demand: Demand.Entity) {
         if (this.demands.has(demand.id)) {
-            this.logger.error(`[Demand ${demand.id}] Already registered`);
+            this.logger.verbose(`[Demand ${demand.id}] Already registered`);
             return;
         }
 
@@ -269,7 +269,7 @@ export class EntityStore implements IEntityStore {
 
     private registerSupply(supply: Supply.Entity) {
         if (this.supplies.has(supply.id)) {
-            this.logger.error(`Supply with ID ${supply.id} has already been registered.`);
+            this.logger.verbose(`Supply with ID ${supply.id} has already been registered.`);
             return;
         }
 
@@ -279,7 +279,7 @@ export class EntityStore implements IEntityStore {
 
     private registerAgreement(agreement: Agreement.Entity) {
         if (this.agreements.has(agreement.id)) {
-            this.logger.error(`[Agreement ${agreement.id}] Already registered`);
+            this.logger.verbose(`[Agreement ${agreement.id}] Already registered`);
             return;
         }
 
@@ -289,7 +289,7 @@ export class EntityStore implements IEntityStore {
 
     private registerCertificate(certificate: Certificate.Entity) {
         if (this.certificates.has(certificate.id)) {
-            this.logger.error(`[Certificate ${certificate.id}] Already registered`);
+            this.logger.verbose(`[Certificate ${certificate.id}] Already registered`);
             return;
         }
 

--- a/packages/market-matcher/src/Matcher.ts
+++ b/packages/market-matcher/src/Matcher.ts
@@ -1,34 +1,21 @@
-import { ProducingAsset } from '@energyweb/asset-registry';
-import { Demand, Supply } from '@energyweb/market';
+import { Demand } from '@energyweb/market';
 import { Certificate } from '@energyweb/origin';
-import { Configuration, Unit } from '@energyweb/utils-general';
 import { Subject } from 'rxjs';
 import { concatMap } from 'rxjs/operators';
 import { inject, injectable } from 'tsyringe';
-import * as Winston from 'winston';
 
-import { CertificateService } from './CertificateService';
+import { CertificateMatcher } from './CertificateMatcher';
+import { DemandMatcher } from './DemandMatcher';
 import { IEntityStore } from './EntityStore';
-import { MatchableAgreement } from './MatchableAgreement';
-import { MatchableDemand } from './MatchableDemand';
-import { IStrategy } from './strategy/IStrategy';
-import { reasonsToString } from './MatchingErrorReason';
-
-type MatchingExecutor = (
-    certificate: Certificate.ICertificate,
-    demand: Demand.IDemand
-) => Promise<boolean>;
 
 @injectable()
 export class Matcher {
     private matchingQueue = new Subject();
 
     constructor(
-        @inject('config') private config: Configuration.Entity,
-        @inject('entityStore') private entityStore: IEntityStore,
-        @inject('certificateService') private certificateService: CertificateService,
-        @inject('strategy') private strategy: IStrategy,
-        @inject('logger') private logger: Winston.Logger
+        @inject('certificateMatcher') private certificateMatcher: CertificateMatcher,
+        @inject('demandMatcher') private demandMatcher: DemandMatcher,
+        @inject('entityStore') private entityStore: IEntityStore
     ) {}
 
     public async init() {
@@ -44,265 +31,8 @@ export class Matcher {
 
     private async match(entity: Certificate.Entity | Demand.Entity) {
         if (entity instanceof Certificate.Entity) {
-            return this.matchCertificate(entity as Certificate.Entity);
+            return this.certificateMatcher.match(entity as Certificate.Entity);
         }
-        return this.matchDemand(entity as Demand.Entity);
-    }
-
-    private async matchDemand(demand: Demand.Entity) {
-        try {
-            this.logger.verbose(`[Demand #${demand.id}] Started matching with certificates`);
-
-            const certificates = await this.findMatchingCertificates(demand);
-            const matchDemand = this.certificateService.matchDemandFromAgreement.bind(
-                this.certificateService
-            );
-
-            let matched = false;
-
-            for (const certificate of certificates) {
-                const matchingResult = await this.executeMatching(certificate, demand, matchDemand);
-                if (matchingResult) {
-                    matched = true;
-                    break;
-                }
-            }
-            this.logger.info(`[Demand #${demand.id}] Completed processing with result ${matched}`);
-
-            return matched;
-        } catch (e) {
-            this.logger.error(`[Demand #${demand.id}] Processing failed with ${e.message}`);
-        }
-
-        return true;
-    }
-
-    private async executeMatching(
-        certificate: Certificate.ICertificate,
-        demand: Demand.IDemand,
-        matchingExecutor: MatchingExecutor
-    ) {
-        this.logger.verbose(
-            `[Certificate #${certificate.id}] Executing matching with demand #${demand.id}`
-        );
-
-        const { value: requiredEnergy } = await demand.missingEnergyInCurrentPeriod();
-
-        this.logger.verbose(
-            `[Certificate #${certificate.id}] Missing energy from demand #${
-                demand.id
-            } is ${requiredEnergy / Unit.kWh}KWh`
-        );
-
-        this.logger.verbose(
-            `[Certificate #${certificate.id}] Available energy: ${certificate.energy / Unit.kWh}KWh`
-        );
-
-        if (certificate.energy <= requiredEnergy) {
-            return matchingExecutor(certificate, demand);
-        }
-        return this.certificateService.splitCertificate(certificate, requiredEnergy);
-    }
-
-    private async matchCertificate(certificate: Certificate.Entity) {
-        try {
-            const matchingResult =
-                (await this.matchWithAgreements(certificate)) ||
-                (await this.matchWithDemands(certificate));
-
-            this.logger.info(
-                `[Certificate #${certificate.id}] Completed processing with result ${matchingResult}`
-            );
-
-            return matchingResult;
-        } catch (e) {
-            this.logger.error(
-                `[Certificate #${certificate.id}] Processing certificate failed with ${e.message}`
-            );
-        }
-
-        return false;
-    }
-
-    private isOnSale(certificate: Certificate.ICertificate) {
-        return certificate.forSale;
-    }
-
-    private async matchWithAgreements(certificate: Certificate.ICertificate) {
-        this.logger.info(`[Certificate #${certificate.id}] Started matching with agreements`);
-
-        const matchingAgreements = await this.findMatchingAgreements(certificate);
-        const demands = await Promise.all(
-            matchingAgreements.map(async ({ agreement }) =>
-                this.entityStore.getDemandById(agreement.demandId.toString())
-            )
-        );
-        const matchingExecutor = this.certificateService.matchDemandFromAgreement.bind(
-            this.certificateService
-        );
-
-        return this.executeForDemands(certificate, demands, matchingExecutor);
-    }
-
-    private async matchWithDemands(certificate: Certificate.ICertificate) {
-        this.logger.info(`[Certificate #${certificate.id}] Started matching with demands`);
-
-        if (!this.isOnSale(certificate)) {
-            this.logger.verbose(`[Certificate #${certificate.id}] Not on sale. Skipping.`);
-            return false;
-        }
-
-        const matchingDemands = await this.findMatchingDemands(certificate);
-        const demands = matchingDemands.map(({ demand }) => demand);
-        const matchingExecutor = this.certificateService.matchDemand.bind(this.certificateService);
-
-        return this.executeForDemands(certificate, demands, matchingExecutor);
-    }
-
-    private async executeForDemands(
-        certificate: Certificate.ICertificate,
-        demands: Demand.IDemand[],
-        matchingExecutor: MatchingExecutor
-    ) {
-        if (!demands.length) {
-            return false;
-        }
-
-        for (const demand of demands) {
-            const res = await this.executeMatching(certificate, demand, matchingExecutor);
-            if (res) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private async findMatchingAgreements(
-        certificate: Certificate.ICertificate
-    ): Promise<MatchableAgreement[]> {
-        const agreements = this.entityStore
-            .getAgreements()
-            .map(agreement => new MatchableAgreement(agreement));
-
-        this.logger.verbose(
-            `[Certificate #${certificate.id}] Found ${(agreements || []).length} agreements`
-        );
-
-        const matchingAgreements: MatchableAgreement[] = [];
-
-        for (const agreement of agreements) {
-            const supply = await new Supply.Entity(
-                agreement.agreement.supplyId.toString(),
-                this.config
-            ).sync();
-            const demand = await new Demand.Entity(
-                agreement.agreement.demandId.toString(),
-                this.config
-            ).sync();
-            const { result, reason } = await agreement.matchesCertificate(
-                certificate,
-                supply,
-                demand
-            );
-
-            this.logger.verbose(
-                `[Certificate #${certificate.id}] Result of matching with agreement for Demand #${
-                    agreement.agreement.demandId
-                } and Supply #${
-                    agreement.agreement.supplyId
-                } is ${result} with reason ${reasonsToString(reason)}`
-            );
-
-            if (result) {
-                matchingAgreements.push(agreement);
-            }
-        }
-
-        this.logger.verbose(
-            `[Certificate #${certificate.id}] Found ${matchingAgreements.length} matching agreements`
-        );
-
-        return this.strategy.executeForAgreements(matchingAgreements);
-    }
-
-    private async findMatchingDemands(
-        certificate: Certificate.ICertificate
-    ): Promise<MatchableDemand[]> {
-        const producingAsset = await new ProducingAsset.Entity(
-            certificate.assetId.toString(),
-            this.config
-        ).sync();
-
-        const demands = this.entityStore.getDemands().map(demand => new MatchableDemand(demand));
-
-        this.logger.verbose(
-            `[Certificate #${certificate.id}] Found ${(demands || []).length} demands`
-        );
-
-        const matchingDemands: MatchableDemand[] = [];
-
-        for (const demand of demands) {
-            const { result, reason } = await demand.matchesCertificate(certificate, producingAsset);
-            this.logger.verbose(
-                `[Certificate #${certificate.id}] Result of matching with demand ${
-                    demand.demand.id
-                } is ${result} with reason ${reasonsToString(reason)}`
-            );
-            if (result) {
-                matchingDemands.push(demand);
-            }
-        }
-
-        this.logger.verbose(
-            `[Certificate #${certificate.id}] Found ${matchingDemands.length} matching demands`
-        );
-
-        return matchingDemands;
-    }
-
-    private async findMatchingCertificates(demand: Demand.Entity) {
-        const matchableDemand = new MatchableDemand(demand);
-
-        const certificates = await Promise.all(
-            this.entityStore
-                .getCertificates()
-                .filter(this.isOnSale.bind(this))
-                .map(async (certificate: Certificate.Entity) => {
-                    const producingAsset = await new ProducingAsset.Entity(
-                        certificate.assetId.toString(),
-                        this.config
-                    ).sync();
-
-                    return { certificate, producingAsset };
-                })
-        );
-
-        this.logger.verbose(
-            `[Demand #${demand.id}] Found ${(certificates || []).length} certificates on-sale`
-        );
-
-        const matchingCertificates: Certificate.ICertificate[] = [];
-
-        for (const { certificate, producingAsset } of certificates) {
-            const { result, reason } = await matchableDemand.matchesCertificate(
-                certificate,
-                producingAsset
-            );
-            this.logger.verbose(
-                `[Demand #${demand.id}] Result of matching with certificate ${
-                    certificate.id
-                } is ${result} with reason ${reasonsToString(reason)}`
-            );
-            if (result) {
-                matchingCertificates.push(certificate);
-            }
-        }
-
-        this.logger.verbose(
-            `[Demand #${demand.id}] Found ${matchingCertificates.length} matching certificates`
-        );
-
-        return this.strategy.executeForCertificates(matchingCertificates);
+        return this.demandMatcher.match(entity as Demand.Entity);
     }
 }

--- a/packages/market-matcher/src/index.ts
+++ b/packages/market-matcher/src/index.ts
@@ -12,6 +12,8 @@ import { EntityStore, IEntityStore } from './EntityStore';
 import { IStrategy } from './strategy/IStrategy';
 import { LowestPriceStrategy } from './strategy/LowestPriceStrategy';
 import { CertificateService } from './CertificateService';
+import { DemandMatcher } from './DemandMatcher';
+import { CertificateMatcher } from './CertificateMatcher';
 
 export interface IMatcherConfig {
     web3Url: string;
@@ -59,6 +61,12 @@ export async function startMatcher(config: IMatcherConfig) {
                 useClass: CertificateService
             });
             container.register<Winston.Logger>('logger', { useValue: logger });
+            container.register<CertificateMatcher>('certificateMatcher', {
+                useClass: CertificateMatcher
+            });
+            container.register<DemandMatcher>('demandMatcher', {
+                useClass: DemandMatcher
+            });
 
             const matcher = container.resolve<Matcher>(Matcher);
             await matcher.init();

--- a/packages/market/contracts/Trading/MarketLogic.sol
+++ b/packages/market/contracts/Trading/MarketLogic.sol
@@ -96,9 +96,7 @@ contract MarketLogic is AgreementLogic {
         address originLogicRegistry = originContractLookup.originLogicRegistry();
 
         TradableEntityContract.TradableEntity memory te = TradableEntityDB(originLogicRegistry).getTradableEntity(_entityId);
-        CertificateLogic(originLogicRegistry).transferFrom(
-            te.owner, demand.demandOwner, _entityId
-        );
+        CertificateLogic(originLogicRegistry).buyCertificateFor(_entityId, demand.demandOwner);
 
         emit DemandPartiallyFilled(_demandId, _entityId, te.energy);
     }

--- a/packages/market/contracts/Trading/MarketLogic.sol
+++ b/packages/market/contracts/Trading/MarketLogic.sol
@@ -101,6 +101,30 @@ contract MarketLogic is AgreementLogic {
         emit DemandPartiallyFilled(_demandId, _entityId, te.energy);
     }
 
+    /// @notice Matches a tradable entity to a demand from the agreement
+	/// @dev will return an event with the event-Id
+	/// @param _demandId index of the demand in the allDemands-array
+    /// @param _entityId ID of the tradable entity
+    function fillAgreement(
+        uint _demandId,
+        uint _entityId
+    )
+        external
+        onlyRole(RoleManagement.Role.Matcher)
+    {
+        MarketDB.Demand memory demand = db.getDemand(_demandId);
+        require(demand.status == MarketDB.DemandStatus.ACTIVE, "demand should be in ACTIVE state");
+
+        address originLogicRegistry = originContractLookup.originLogicRegistry();
+
+        TradableEntityContract.TradableEntity memory te = TradableEntityDB(originLogicRegistry).getTradableEntity(_entityId);
+        CertificateLogic(originLogicRegistry).transferFrom(
+            te.owner, demand.demandOwner, _entityId
+        );
+
+        emit DemandPartiallyFilled(_demandId, _entityId, te.energy);
+    }
+
 	/// @notice Function to create a supply
 	/// @dev will return an event with the event-Id
 	/// @param _propertiesDocumentHash document-hash with all the properties of the demand

--- a/packages/market/src/blockchain-facade/Demand.ts
+++ b/packages/market/src/blockchain-facade/Demand.ts
@@ -48,6 +48,7 @@ export interface IDemand extends IDemandOnChainProperties {
     id: string;
     offChainProperties: IDemandOffChainProperties;
     fill: (entityId: string) => Promise<TransactionReceipt>;
+    fillAgreement: (entityId: string) => Promise<TransactionReceipt>;
     missingEnergyInPeriod: (timeStamp: number) => Promise<TimeSeriesElement>;
     missingEnergyInCurrentPeriod: () => Promise<TimeSeriesElement>;
 }
@@ -135,6 +136,13 @@ export class Entity extends BlockchainDataModelEntity.Entity implements IDemand 
 
     async fill(entityId: string): Promise<TransactionReceipt> {
         return this.marketLogicInstance.fillDemand(this.id, entityId, {
+            from: this.configuration.blockchainProperties.activeUser.address,
+            privateKey: this.configuration.blockchainProperties.activeUser.privateKey
+        });
+    }
+
+    async fillAgreement(entityId: string): Promise<TransactionReceipt> {
+        return this.marketLogicInstance.fillAgreement(this.id, entityId, {
             from: this.configuration.blockchainProperties.activeUser.address,
             privateKey: this.configuration.blockchainProperties.activeUser.privateKey
         });

--- a/packages/market/src/wrappedContracts/MarketLogic.ts
+++ b/packages/market/src/wrappedContracts/MarketLogic.ts
@@ -99,6 +99,12 @@ export class MarketLogic extends GeneralFunctions {
         return this.send(method, txParams);
     }
 
+    async fillAgreement(_demandId: string, _entityId: string, txParams?: ISpecialTx) {
+        const method = this.web3Contract.methods.fillAgreement(_demandId, _entityId);
+
+        return this.send(method, txParams);
+    }
+
     async update(_newLogic: string, txParams?: ISpecialTx) {
         const method = this.web3Contract.methods.update(_newLogic);
 

--- a/packages/origin/contracts/Origin/CertificateLogic.sol
+++ b/packages/origin/contracts/Origin/CertificateLogic.sol
@@ -143,7 +143,7 @@ contract CertificateLogic is CertificateInterface, CertificateSpecificContract, 
     function buyCertificate(uint _certificateId)
         external
         onlyRole(RoleManagement.Role.Trader)
-     {
+    {
         buyCertificateInternal(_certificateId, msg.sender);
     }
 
@@ -154,9 +154,9 @@ contract CertificateLogic is CertificateInterface, CertificateSpecificContract, 
         public
         onlyRole(RoleManagement.Role.Matcher)
         userHasRole(RoleManagement.Role.Trader, _newOwner)
-        {
-            buyCertificateInternal(_certificateId, _newOwner);
-        }
+    {
+        buyCertificateInternal(_certificateId, _newOwner);
+    }
 
     /// @notice buys a set of certificates
     /// @param _idArray the ids of the certificates to be bought

--- a/packages/origin/contracts/Origin/CertificateLogic.sol
+++ b/packages/origin/contracts/Origin/CertificateLogic.sol
@@ -147,6 +147,17 @@ contract CertificateLogic is CertificateInterface, CertificateSpecificContract, 
         buyCertificateInternal(_certificateId, msg.sender);
     }
 
+    /// @notice buys a certificate for owner
+    /// @param _certificateId the id of the certificate
+    /// @param _newOwner the address of the new owner
+    function buyCertificateFor(uint _certificateId, address _newOwner)
+        public
+        onlyRole(RoleManagement.Role.Matcher)
+        userHasRole(RoleManagement.Role.Trader, _newOwner)
+        {
+            buyCertificateInternal(_certificateId, _newOwner);
+        }
+
     /// @notice buys a set of certificates
     /// @param _idArray the ids of the certificates to be bought
     function buyCertificateBulk(uint[] calldata _idArray) external {

--- a/packages/origin/contracts/Origin/TradableEntityLogic.sol
+++ b/packages/origin/contracts/Origin/TradableEntityLogic.sol
@@ -52,7 +52,8 @@ contract TradableEntityLogic is Updatable, RoleManagement, ERC721, ERC165, Trada
     event LogUnpublishForSale(uint indexed _entityId);
 
     modifier onlyEntityOwner(uint _entityId) {
-        require(db.getTradableEntityOwner(_entityId) == msg.sender, "not the entity-owner");
+        address owner = db.getTradableEntityOwner(_entityId);
+        require(owner == msg.sender || isRole(RoleManagement.Role.Matcher, msg.sender), "not the entity-owner or market matcher");
         _;
     }
 


### PR DESCRIPTION
This PR adds:

- when using matcher for demands - certificate buy is used
- when using matcher for demands  defined by agreement - certificate transfer is used (as before)
- matcher refactored to `CertificateMatcher` and `DemandMatcher` 