### PR TITLE
fix: fix event-listener and simulator configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,6 @@ ENERGY_API_BASE_URL="http://localhost:3031"
 # Secret keys
 DEPLOY_KEY="d9066ff9f753a1898709b568119055660a77d9aae4d7a4ad677b8fb3d2a571e5"
 MATCHER_PRIV_KEY="0xe9a63e116f72c2e368376eb88c22fecf2a5e94a93464ff8802cf97caac657548"
-# Addresses of already-deployed contracts, needed for matcher (contracts addresses displayed are just examples)
-MARKET_CONTRACT_ADDRESS="0x665B25e0eDc2D9B5DEe75c5f652f92F5B58BE12B"
 
 # ------- OPTIONAL ------- #
 MANDRILL_API_KEY="<API_KEY>"

--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,7 @@ ENERGY_API_BASE_URL="http://localhost:3031"
 # Secret keys
 DEPLOY_KEY="d9066ff9f753a1898709b568119055660a77d9aae4d7a4ad677b8fb3d2a571e5"
 MATCHER_PRIV_KEY="0xe9a63e116f72c2e368376eb88c22fecf2a5e94a93464ff8802cf97caac657548"
-# Addresses of already-deployed contracts, needed for solar simulator and matcher (contracts addresses displayed are just examples)
-ASSET_CONTRACT_LOOKUP_ADDRESS="0x24B207fFf1a1097d3c3D69fcE461544f83c6E774"
+# Addresses of already-deployed contracts, needed for matcher (contracts addresses displayed are just examples)
 MARKET_CONTRACT_ADDRESS="0x665B25e0eDc2D9B5DEe75c5f652f92F5B58BE12B"
 
 # ------- OPTIONAL ------- #

--- a/packages/event-listener/src/index.ts
+++ b/packages/event-listener/src/index.ts
@@ -13,7 +13,7 @@ const startEventListener = async () => {
     const web3 = new Web3(process.env.WEB3 || 'http://localhost:8550');
     const backendUrl: string = process.env.BACKEND_URL || 'http://localhost:3035';
 
-    const result: AxiosResponse = await axios.get(`${backendUrl}/MarketContractLookup`);
+    const result: AxiosResponse = await axios.get(`${backendUrl}/api/MarketContractLookup`);
 
     const latestMarketContract: string = process.env.MARKET_CONTRACT_ADDRESS || result.data.pop();
 

--- a/packages/market-matcher/package.json
+++ b/packages/market-matcher/package.json
@@ -37,6 +37,7 @@
         "@energyweb/origin": "1.3.0",
         "@energyweb/user-registry": "1.3.0",
         "@energyweb/utils-general": "1.3.0",
+        "axios": "^0.19.0",
         "moment": "^2.24.0",
         "polly-js": "^1.6.5",
         "reflect-metadata": "^0.1.13",

--- a/packages/market-matcher/src/main.ts
+++ b/packages/market-matcher/src/main.ts
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv';
 import Web3 from 'web3';
+import axios, { AxiosResponse } from 'axios';
 
 import { startMatcher } from '.';
 
@@ -7,17 +8,26 @@ dotenv.config({
     path: '../../.env'
 });
 
-const privateKey = process.env.MATCHER_PRIV_KEY;
-const web3 = new Web3(process.env.WEB3);
+(async () => {
+    const privateKey = process.env.MATCHER_PRIV_KEY;
+    const web3 = new Web3(process.env.WEB3);
 
-const config = {
-    web3Url: process.env.WEB3,
-    marketContractLookupAddress: process.env.MARKET_CONTRACT_ADDRESS,
-    matcherAccount: {
-        address: web3.eth.accounts.privateKeyToAccount(privateKey).address,
-        privateKey
-    },
-    offChainDataSourceUrl: `${process.env.BACKEND_URL}/api`
-};
+    const backendUrl: string = process.env.BACKEND_URL || 'http://localhost:3035';
 
-startMatcher(config);
+    const result: AxiosResponse = await axios.get(`${backendUrl}/api/MarketContractLookup`);
+
+    const marketContractLookupAddress: string =
+        process.env.MARKET_CONTRACT_ADDRESS || result.data.pop();
+
+    const config = {
+        web3Url: process.env.WEB3,
+        marketContractLookupAddress,
+        matcherAccount: {
+            address: web3.eth.accounts.privateKeyToAccount(privateKey).address,
+            privateKey
+        },
+        offChainDataSourceUrl: `${process.env.BACKEND_URL}/api`
+    };
+
+    startMatcher(config);
+})();

--- a/packages/solar-simulator/README.md
+++ b/packages/solar-simulator/README.md
@@ -44,7 +44,6 @@ To run simulator and consumer services you need to deploy Origin first.
 ### General
 
 Edit `.env` in the root of the monorepo and configure:
-- `ASSET_CONTRACT_LOOKUP_ADDRESS` - this is `AddressContractLookup` smart-contract address, you can get it via output of Origin deployment script ("info: Asset Contract Deployed: X", where X is the address you need)
 - `WEB3` - by default configured to local Ganache instance (`http://localhost:8545`), if you've deployed Origin to Volta, use: `https://volta-rpc.energyweb.org`
 - `ENERGY_API_BASE_URL` - the address on which simulation server is running, by default locally it's `http://localhost:3031`, in Docker it's `http://simulation:3031`
 

--- a/packages/solar-simulator/package.json
+++ b/packages/solar-simulator/package.json
@@ -19,6 +19,7 @@
   "license": "GPL-3.0-only",
   "dependencies": {
     "@energyweb/asset-registry": "1.3.0",
+    "@energyweb/market": "1.3.0",
     "@energyweb/utils-general": "1.3.0",
     "@types/moment-timezone": "0.5.12",
     "axios": "0.19.0",

--- a/packages/solar-simulator/tsconfig.build.json
+++ b/packages/solar-simulator/tsconfig.build.json
@@ -14,6 +14,9 @@
         },
         {
             "path": "../asset-registry/tsconfig.build.json"
+        },
+        {
+            "path": "../market/tsconfig.build.json"
         }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2631,7 +2631,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@0.19.0:
+axios@0.19.0, axios@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
   integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==


### PR DESCRIPTION
- solar-simulator: Get contract address from API
- event-listener: Fix getting latest contract from API (missing `/api`)
- market-matcher: Get contract address from API

New approach:
1. if specified, take Market address from .env
2. if not, get it from API