### PR TITLE
feat(origin-ui): [IN-BROWSER PK] Keystore wallet import

### DIFF
--- a/packages/origin-ui/package.json
+++ b/packages/origin-ui/package.json
@@ -57,7 +57,6 @@
     "redux": "4.0.4",
     "redux-devtools-extension": "2.13.8",
     "redux-saga": "1.1.1",
-    "simple-crypto-js": "2.2.0",
     "toastr": "2.1.4",
     "ts-loader": "6.2.1",
     "url-loader": "2.2.0",

--- a/packages/origin-ui/src/__tests__/AppContainer.test.tsx
+++ b/packages/origin-ui/src/__tests__/AppContainer.test.tsx
@@ -126,7 +126,7 @@ describe('Application[E2E]', () => {
 
             expect(store.getState().router.location.pathname).toBe('/demands/list');
 
-            await wait(2000);
+            await wait(3000);
             await refresh();
 
             expect(

--- a/packages/origin-ui/src/__tests__/AppContainer.test.tsx
+++ b/packages/origin-ui/src/__tests__/AppContainer.test.tsx
@@ -50,9 +50,14 @@ describe('Application[E2E]', () => {
             click('account-link-import');
 
             fillInputField('account-import-privateKey', ACCOUNTS.TRADER.privateKey);
-            fillInputField('account-import-password', 'a');
 
             submitForm('account-import-form');
+
+            await refresh();
+
+            fillInputField('request-password-modal-password', 'a');
+
+            submitForm('request-password-modal-form');
 
             await wait(2000);
             await refresh();

--- a/packages/origin-ui/src/components/Header.tsx
+++ b/packages/origin-ui/src/components/Header.tsx
@@ -101,13 +101,15 @@ export function Header() {
 
         if (selectedAccount.isLocked) {
             dispatch(
-                showRequestPasswordModal((password: string) => {
-                    dispatch(
-                        unlockAccount({
-                            address,
-                            password
-                        })
-                    );
+                showRequestPasswordModal({
+                    callback: (password: string) => {
+                        dispatch(
+                            unlockAccount({
+                                address,
+                                password
+                            })
+                        );
+                    }
                 })
             );
         } else {

--- a/packages/origin-ui/src/elements/Modal/RequestPasswordModal.tsx
+++ b/packages/origin-ui/src/elements/Modal/RequestPasswordModal.tsx
@@ -15,6 +15,7 @@ import {
     getRequestPasswordModalCallback,
     getRequestPasswordModalTitle
 } from '../../features/general/selectors';
+import { dataTest } from '../../utils/Helper';
 
 export function RequestPasswordModal() {
     const show = useSelector(getRequestPasswordModalVisible);
@@ -38,6 +39,7 @@ export function RequestPasswordModal() {
                     e.preventDefault();
                     submit();
                 }}
+                {...dataTest('request-password-modal-form')}
             >
                 <DialogTitle>{title || 'Password requested'}</DialogTitle>
                 <DialogContent>
@@ -50,6 +52,7 @@ export function RequestPasswordModal() {
                         className="my-3"
                         autoFocus
                         type="password"
+                        {...dataTest('request-password-modal-password')}
                     />
                 </DialogContent>
                 <DialogActions>

--- a/packages/origin-ui/src/elements/Modal/RequestPasswordModal.tsx
+++ b/packages/origin-ui/src/elements/Modal/RequestPasswordModal.tsx
@@ -12,12 +12,14 @@ import { useSelector, useDispatch } from 'react-redux';
 import { hideRequestPasswordModal } from '../../features/general/actions';
 import {
     getRequestPasswordModalVisible,
-    getRequestPasswordModalCallback
+    getRequestPasswordModalCallback,
+    getRequestPasswordModalTitle
 } from '../../features/general/selectors';
 
 export function RequestPasswordModal() {
     const show = useSelector(getRequestPasswordModalVisible);
     const callback = useSelector(getRequestPasswordModalCallback);
+    const title = useSelector(getRequestPasswordModalTitle);
     const dispatch = useDispatch();
 
     const handleClose = () => dispatch(hideRequestPasswordModal());
@@ -37,7 +39,7 @@ export function RequestPasswordModal() {
                     submit();
                 }}
             >
-                <DialogTitle>Password requested</DialogTitle>
+                <DialogTitle>{title || 'Password requested'}</DialogTitle>
                 <DialogContent>
                     <DialogContentText>Please provide a password</DialogContentText>
                     <TextField

--- a/packages/origin-ui/src/features/authentication/actions.ts
+++ b/packages/origin-ui/src/features/authentication/actions.ts
@@ -1,3 +1,5 @@
+import { PrivateKey } from 'web3/eth/accounts'; // eslint-disable-line import/no-unresolved
+
 export enum AuthenticationActions {
     addAccount = 'ADD_ACCOUNT',
     setActiveAccount = 'SET_ACTIVE_ACCOUNT',
@@ -14,7 +16,7 @@ export interface IAccount {
 
 export interface IEncryptedAccount {
     address: string;
-    encryptedPrivateKey: string;
+    encryptedPrivateKey: PrivateKey;
 }
 
 export interface IAddAccountAction {

--- a/packages/origin-ui/src/features/contracts/sagas.ts
+++ b/packages/origin-ui/src/features/contracts/sagas.ts
@@ -41,13 +41,15 @@ async function initConf(
     let web3: Web3 = null;
     const params: any = queryString.parse(routerSearch);
 
+    const ethereumProvider = (window as any).ethereum;
+
     if (params.rpc) {
         web3 = new Web3(params.rpc);
-    } else if ((window as any).ethereum) {
-        web3 = new Web3((window as any).ethereum);
+    } else if (ethereumProvider) {
+        web3 = new Web3(ethereumProvider);
         try {
             // Request account access if needed
-            await (window as any).ethereum.enable();
+            await ethereumProvider.enable();
         } catch (error) {
             // User denied account access...
         }

--- a/packages/origin-ui/src/features/general/actions.ts
+++ b/packages/origin-ui/src/features/general/actions.ts
@@ -64,7 +64,10 @@ export type TSetError = typeof setError;
 
 export interface IRequestPasswordModalAction {
     type: GeneralActions.showRequestPasswordModal;
-    payload: (password: string) => void;
+    payload: {
+        title?: string;
+        callback: (password: string) => void;
+    };
 }
 
 export const showRequestPasswordModal = (payload: IRequestPasswordModalAction['payload']) => ({

--- a/packages/origin-ui/src/features/general/reducer.ts
+++ b/packages/origin-ui/src/features/general/reducer.ts
@@ -6,6 +6,7 @@ export interface IGeneralState {
     loading: boolean;
     error: string;
     requestPasswordModalVisible: boolean;
+    requestPasswordModalTitle: string;
     requestPasswordModalCallback: (password: string) => void;
 }
 
@@ -15,7 +16,8 @@ const defaultState: IGeneralState = {
     loading: true,
     error: null,
     requestPasswordModalVisible: false,
-    requestPasswordModalCallback: null
+    requestPasswordModalCallback: null,
+    requestPasswordModalTitle: null
 };
 
 export default function reducer(state = defaultState, action: IGeneralAction): IGeneralState {
@@ -49,14 +51,16 @@ export default function reducer(state = defaultState, action: IGeneralAction): I
             return {
                 ...state,
                 requestPasswordModalVisible: true,
-                requestPasswordModalCallback: action.payload
+                requestPasswordModalCallback: action.payload.callback,
+                requestPasswordModalTitle: action.payload.title
             };
 
         case GeneralActions.hideRequestPasswordModal:
             return {
                 ...state,
                 requestPasswordModalVisible: false,
-                requestPasswordModalCallback: null
+                requestPasswordModalCallback: null,
+                requestPasswordModalTitle: null
             };
 
         default:

--- a/packages/origin-ui/src/features/general/selectors.ts
+++ b/packages/origin-ui/src/features/general/selectors.ts
@@ -12,5 +12,9 @@ export const getError = (state: IStoreState) => state.general.error;
 
 export const getRequestPasswordModalVisible = (state: IStoreState) =>
     state.general.requestPasswordModalVisible;
+
 export const getRequestPasswordModalCallback = (state: IStoreState) =>
     state.general.requestPasswordModalCallback;
+
+export const getRequestPasswordModalTitle = (state: IStoreState) =>
+    state.general.requestPasswordModalTitle;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4004,11 +4004,6 @@ crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto-js@^3.1.9-1:
-  version "3.1.9-1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
-  integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
-
 css-loader@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.2.0.tgz#bb570d89c194f763627fcf1f80059c6832d009b2"
@@ -12031,13 +12026,6 @@ simple-concat@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
   integrity sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=
-
-simple-crypto-js@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/simple-crypto-js/-/simple-crypto-js-2.2.0.tgz#ef6413b08a889509cef4ec74bd7ecb413aa9d0a6"
-  integrity sha512-noEQl72TKmQCc46mKO1dg5jB0/M5caFckDreku68Wv6MXb/aue0I/P7RfNLWYqN/aHQjTolZB1w5AM84dIlkMw==
-  dependencies:
-    crypto-js "^3.1.9-1"
 
 simple-get@^2.7.0:
   version "2.8.1"


### PR DESCRIPTION
- Support keystore wallet imports
- Change internal account encryption method to keystore (included by default in web3)
- Ask for password in second stage of import

![localhost_3000_account_import (5)](https://user-images.githubusercontent.com/4950658/67778061-f6734800-fa62-11e9-92c0-6f771604ad27.png)
