### PR TITLE
feat(market): add generation time range to the certificate

### DIFF
--- a/packages/asset-registry/contracts/AssetLogic.sol
+++ b/packages/asset-registry/contracts/AssetLogic.sol
@@ -143,7 +143,21 @@ contract AssetLogic is Initializable, RoleManagement, IAssetLogic {
         emit LogAssetCreated(msg.sender, assetId);
     }
 
-    function getSmartMeterReadsForAsset(uint _assetId) external view
+    function getSmartMeterReadsForAssetByIndex(uint _assetId, uint[] calldata _indexes) external view
+        returns (AssetDefinitions.SmartMeterRead[] memory)
+    {   
+        uint length = _indexes.length;
+        AssetDefinitions.SmartMeterRead[] memory reads = new AssetDefinitions.SmartMeterRead[](length);
+        AssetDefinitions.SmartMeterRead[] memory allReads = getSmartMeterReadsForAsset(_assetId);
+
+        for (uint i=0; i < length; i++) {
+            reads[i] = allReads[_indexes[i]];
+        }
+
+        return reads;
+    }
+
+    function getSmartMeterReadsForAsset(uint _assetId) public view
         returns (AssetDefinitions.SmartMeterRead[] memory reads)
     {
         return _assetSmartMeterReadsMapping[_smAddressForAssetId(_assetId)];

--- a/packages/asset-registry/src/blockchain-facade/Asset.ts
+++ b/packages/asset-registry/src/blockchain-facade/Asset.ts
@@ -89,4 +89,14 @@ export abstract class Entity extends BlockchainDataModelEntity.Entity
             timestamp: Number(read.timestamp)
         }));
     }
+
+    async getSmartMeterReadsByIndex(indexes: number[]): Promise<ISmartMeterRead[]> {
+        const logic: AssetLogic = this.configuration.blockchainProperties
+            .assetLogicInstance;
+
+        return (await logic.getSmartMeterReadsForAssetByIndex(Number(this.id), indexes)).map((read: ISmartMeterRead) => ({
+            energy: Number(read.energy),
+            timestamp: Number(read.timestamp)
+        }));
+    }
 }

--- a/packages/asset-registry/src/wrappedContracts/AssetLogic.ts
+++ b/packages/asset-registry/src/wrappedContracts/AssetLogic.ts
@@ -48,6 +48,10 @@ export class AssetLogic extends GeneralFunctions {
         return this.web3Contract.getPastEvents('LogAssetSetInactive', eventFilter);
     }
 
+    async getSmartMeterReadsForAssetByIndex(_assetId: number, _indexes: number[], txParams?: ISpecialTx) {
+        return this.web3Contract.methods.getSmartMeterReadsForAssetByIndex(_assetId, _indexes).call(txParams);
+    }
+
     async getSmartMeterReadsForAsset(_assetId: number, txParams?: ISpecialTx) {
         return this.web3Contract.methods.getSmartMeterReadsForAsset(_assetId).call(txParams);
     }

--- a/packages/origin/contracts/CertificateDefinitions.sol
+++ b/packages/origin/contracts/CertificateDefinitions.sol
@@ -30,5 +30,7 @@ contract CertificateDefinitions {
         bool forSale;
         address acceptedToken;
         uint onChainDirectPurchasePrice;
+        uint readsStartIndex;
+        uint readsEndIndex;
     }
 }

--- a/packages/origin/src/test/CertificateLogic.test.ts
+++ b/packages/origin/src/test/CertificateLogic.test.ts
@@ -256,6 +256,8 @@ describe('CertificateLogic-Facade', () => {
 
     it('should return certificate', async () => {
         const certificate = await new Certificate.Entity('0', conf).sync();
+        const reads = await assetLogic.getSmartMeterReadsForAsset(0);
+
         assert.equal(certificate.owner, accountAssetOwner);
 
         blockCreationTime = (await web3.eth.getBlock('latest')).timestamp;
@@ -276,7 +278,9 @@ describe('CertificateLogic-Facade', () => {
             offChainSettlementOptions: {
                 price: 0,
                 currency: Currency.NONE
-            }
+            },
+            generationStartTime: Number(reads[0].timestamp),
+            generationEndTime: Number(reads[0].timestamp),
         } as Partial<Certificate.Entity>);
     });
 
@@ -584,6 +588,8 @@ describe('CertificateLogic-Facade', () => {
         };
 
         let certificate = await new Certificate.Entity('2', conf).sync();
+        
+        const reads = await assetLogic.getSmartMeterReadsForAsset(0);
 
         await certificate.splitCertificate(60);
 
@@ -627,7 +633,9 @@ describe('CertificateLogic-Facade', () => {
             offChainSettlementOptions: {
                 price: 0,
                 currency: Currency.NONE
-            }
+            },
+            generationStartTime: Number(reads[2].timestamp),
+            generationEndTime: Number(reads[2].timestamp)
         } as Partial<Certificate.Entity>);
 
         assert.deepOwnInclude(c2, {
@@ -646,7 +654,9 @@ describe('CertificateLogic-Facade', () => {
             offChainSettlementOptions: {
                 price: 0,
                 currency: Currency.NONE
-            }
+            },
+            generationStartTime: Number(reads[2].timestamp),
+            generationEndTime: Number(reads[2].timestamp)
         } as Partial<Certificate.Entity>);
 
         const activeCerts = await Certificate.getActiveCertificates(conf);


### PR DESCRIPTION
`Certificate` smart contract now hold the start and read id based on which it was created. Reads are used to determine the generation start and end date.

When splitting the certificate:
- Child1
    - `startGenerationTime` equals **parent** `startGenerationTime`
    - `endGenerationTime` equals to `timestamp` of the last read _k_ where `SUM{readsStart; k} >= required energy`
- Child2
   - `startGenerationTime` equals `Child1.endGenerationTime` when `SUM{readsStart; k} > required energy` and `reads[k+1].timestamp when SUM{readsStart; k} = required energy`
   - `endGenerationTime` equals **parent** `endGenerationTime`