### PR TITLE
fix(origin-ui): fix displaying accounts in header

### DIFF
--- a/packages/origin-ui/.eslintrc.js
+++ b/packages/origin-ui/.eslintrc.js
@@ -43,8 +43,7 @@ module.exports = {
         "import/order": "off",
         "prefer-destructuring": "off",
         "prefer-template": "off",
-        "react/prop-types": "off",
-        "no-undef": "off"
+        "react/prop-types": "off"
     },
     "settings": {
         "import/resolver": {

--- a/packages/origin-ui/jest.config.e2e.js
+++ b/packages/origin-ui/jest.config.e2e.js
@@ -1,7 +1,7 @@
 module.exports = {
     preset: 'ts-jest',
     moduleFileExtensions: ['ts', 'tsx', 'js', 'node', 'json'],
-    testMatch: ['**/__tests__/**/*.test.(ts|tsx|js)'],
+    testMatch: ['**/__tests__/e2e/*.test.(ts|tsx|js)'],
     roots: ['<rootDir>/src'],
     moduleNameMapper: {
         '\\.(css|less|sass|scss)$': '<rootDir>/src/__tests__/config/mocks/styleMock.js',

--- a/packages/origin-ui/jest.config.unit.js
+++ b/packages/origin-ui/jest.config.unit.js
@@ -1,7 +1,7 @@
 module.exports = {
     preset: 'ts-jest',
     moduleFileExtensions: ['ts', 'tsx', 'js', 'node', 'json'],
-    testMatch: ['**/__tests__/**/*.test.(ts|tsx|js)'],
+    testMatch: ['**/__tests__/unit/*.test.(ts|tsx|js)'],
     roots: ['<rootDir>/src'],
     moduleNameMapper: {
         '\\.(css|less|sass|scss)$': '<rootDir>/src/__tests__/config/mocks/styleMock.js',

--- a/packages/origin-ui/package.json
+++ b/packages/origin-ui/package.json
@@ -17,7 +17,11 @@
     "start": "yarn config-env && cross-env NODE_OPTIONS=\"--max_old_space_size=8192\" webpack-dev-server --config webpack/dev.config.js --watch",
     "start-all": "yarn start",
     "test": "yarn config-env && jest",
+    "test:unit": "yarn config-env && jest -c jest.config.unit.js",
+    "test:e2e": "yarn config-env && jest -c jest.config.e2e.js",
     "test:watch": "yarn config-env && jest -u --watchAll",
+    "test:unit:watch": "yarn config-env && jest -u --watchAll -c jest.config.unit.js",
+    "test:e2e:watch": "yarn config-env && jest -u --watchAll -c jest.e2e.unit.js",
     "precommit": "lint-staged",
     "prettier": "prettier --write --config-precedence file-override './src/**/*'",
     "clean": "shx rm -rf dist"

--- a/packages/origin-ui/src/__tests__/e2e/AppContainer.test.tsx
+++ b/packages/origin-ui/src/__tests__/e2e/AppContainer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { AppContainer } from '../components/AppContainer';
+import { AppContainer } from '../../components/AppContainer';
 import { Route } from 'react-router-dom';
 import {
     WrapperComponent,
@@ -8,9 +8,9 @@ import {
     wait,
     createRenderedHelpers,
     waitForConditionAndAssert
-} from './utils/helpers';
-import { startGanache, deployDemo, ACCOUNTS } from './utils/demo';
-import { dataTestSelector } from '../utils/helper';
+} from '../utils/helpers';
+import { startGanache, deployDemo, ACCOUNTS } from '../utils/demo';
+import { dataTestSelector } from '../../utils/helper';
 import { TimeFrame } from '@energyweb/utils-general';
 
 import moment from 'moment';

--- a/packages/origin-ui/src/__tests__/unit/AssetTypeSelector.test.tsx
+++ b/packages/origin-ui/src/__tests__/unit/AssetTypeSelector.test.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
 import { mount } from 'enzyme';
 import { EncodedAssetType, IRECAssetService } from '@energyweb/utils-general';
-import { setupStore, WrapperComponent } from './utils/helpers';
-import { dataTestSelector } from '../utils/helper';
+import { setupStore, WrapperComponent } from '../utils/helpers';
+import { dataTestSelector } from '../../utils/helper';
 import {
     MultiSelectAutocomplete,
     IAutocompleteMultiSelectOptionType
-} from '../components/MultiSelectAutocomplete';
+} from '../../components/MultiSelectAutocomplete';
 import { act } from '@testing-library/react';
-import { HierarchicalMultiSelect } from '../components/HierarchicalMultiSelect';
+import { HierarchicalMultiSelect } from '../../components/HierarchicalMultiSelect';
 
 describe('AssetTypeSelector', () => {
     it('correctly renders', async () => {

--- a/packages/origin-ui/src/__tests__/unit/CertificateTable.test.tsx
+++ b/packages/origin-ui/src/__tests__/unit/CertificateTable.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { CertificateTable, SelectedState } from '../components/CertificateTable';
+import { CertificateTable, SelectedState } from '../../components/CertificateTable';
 import { Certificate } from '@energyweb/origin';
 import { Unit } from '@energyweb/utils-general';
-import { setupStore, createRenderedHelpers, WrapperComponent } from './utils/helpers';
+import { setupStore, createRenderedHelpers, WrapperComponent } from '../utils/helpers';
 
 describe('CertificateTable', () => {
     it('correctly renders', async () => {

--- a/packages/origin-ui/src/__tests__/unit/Header.test.tsx
+++ b/packages/origin-ui/src/__tests__/unit/Header.test.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { setupStore, WrapperComponent } from '../utils/helpers';
+import { Header } from '../../components/Header';
+import { User } from '@energyweb/user-registry';
+import { addUser } from '../../features/users/actions';
+import { addAccount, addEncryptedAccount } from '../../features/authentication/actions';
+
+describe('Header', () => {
+    it('displays only one MetaMask account', async () => {
+        const { store, history, cleanupStore } = setupStore(undefined, {
+            mockUserFetcher: true,
+            logActions: false
+        });
+
+        const SETUP = {
+            accounts: [{ address: '0x7672fa3f8C04aBBcbaD14d896AaD8bedECe72d2b' }],
+            encryptedAccounts: [],
+            isUsingPK: false,
+            users: [
+                {
+                    active: true,
+                    id: '0x7672fa3f8c04abbcbad14d896aad8bedece72d2b',
+                    initialized: true,
+                    offChainProperties: {
+                        firstName: 'John',
+                        surname: 'Doe Six',
+                        email: 'trader@mailinator.com'
+                    },
+                    organization: 'Trader Organization',
+
+                    roles: 8
+                } as Partial<User.Entity>
+            ]
+        };
+
+        SETUP.encryptedAccounts.map(encryptedAccount =>
+            store.dispatch(addEncryptedAccount(encryptedAccount))
+        );
+        SETUP.users.map(user => store.dispatch(addUser(user as User.Entity)));
+        store.dispatch(addAccount(SETUP.accounts[0]));
+
+        function TestWrapper() {
+            return <Header />;
+        }
+
+        const rendered = await mount(
+            <WrapperComponent store={store} history={history}>
+                <TestWrapper />
+            </WrapperComponent>
+        );
+
+        expect(rendered.find('.MuiSelect-root').text()).toBe('Trader Organization');
+
+        rendered.find(`.MuiSelect-root`).simulate('click');
+
+        expect(
+            Array.from(document.querySelectorAll(`#menu- ul li`)).map(i => i.textContent)
+        ).toStrictEqual(['Trader Organization (MetaMask)']);
+
+        cleanupStore();
+    });
+
+    it('displays correctly displays MetaMask accounts next to encrypted accounts', async () => {
+        const { store, history, cleanupStore } = setupStore(undefined, {
+            mockUserFetcher: false,
+            logActions: false
+        });
+
+        const SETUP = {
+            accounts: [{ address: '0x7672fa3f8C04aBBcbaD14d896AaD8bedECe72d2b' }],
+            encryptedAccounts: [
+                {
+                    address: '0x5B1B89A48C1fB9b6ef7Fb77C453F2aAF4b156d45',
+                    encryptedPrivateKey: {
+                        version: 3,
+                        id: 'da750a17-3aa0-45bc-8c99-545ec27be0c0',
+                        address: '5b1b89a48c1fb9b6ef7fb77c453f2aaf4b156d45',
+                        crypto: {
+                            ciphertext:
+                                'b054f1bdd5b45519b356830d770b1870e941a6e0c8a9285d74d51d04e6b973b4',
+                            cipherparams: { iv: '9cd5e4b0a067783a339474ca02cda136' },
+                            cipher: 'aes-128-ctr',
+                            kdf: 'scrypt',
+                            kdfparams: {
+                                dklen: 32,
+                                salt:
+                                    '529754ac4d7364f597cc900b5d8bc540880afac4d55fd1fde03255059e87d109',
+                                n: 8192,
+                                r: 8,
+                                p: 1
+                            },
+                            mac: 'dbd33899b2ade5ed36889d7e96b9a3424c0c24fc62a7089ab8e06e09d19e80cf'
+                        }
+                    }
+                },
+                {
+                    address: '0x7672fa3f8C04aBBcbaD14d896AaD8bedECe72d2b',
+                    encryptedPrivateKey: {
+                        version: 3,
+                        id: 'd1d724f0-885c-4e29-8793-42e74796c9f1',
+                        address: '7672fa3f8c04abbcbad14d896aad8bedece72d2b',
+                        crypto: {
+                            ciphertext:
+                                '279fc512834f30baeaad358c7ddd13639bfcfb533c924bba479ede42665cc3c1',
+                            cipherparams: { iv: 'a3ade44783ab731e3dfbbc33abfa271c' },
+                            cipher: 'aes-128-ctr',
+                            kdf: 'scrypt',
+                            kdfparams: {
+                                dklen: 32,
+                                salt:
+                                    'dd0adc71172df6d395385989a878f5bb8fe5758c4fb8805f90c3bb4a14426799',
+                                n: 8192,
+                                r: 8,
+                                p: 1
+                            },
+                            mac: 'c92788334ac87b13023e406e18bd78803ab879e1f4f2133362c0cce457b17970'
+                        }
+                    }
+                }
+            ],
+            isUsingPK: false,
+            users: [
+                {
+                    active: true,
+                    id: '0x5b1b89a48c1fb9b6ef7fb77c453f2aaf4b156d45',
+                    initialized: true,
+                    offChainProperties: {
+                        firstName: 'John',
+                        surname: 'Doe Four',
+                        email: 'assetmanager@mailinator.com'
+                    },
+                    organization: 'AssetManager Organization',
+                    roles: 12
+                },
+                {
+                    active: true,
+                    id: '0x7672fa3f8c04abbcbad14d896aad8bedece72d2b',
+                    initialized: true,
+                    offChainProperties: {
+                        firstName: 'John',
+                        surname: 'Doe Six',
+                        email: 'trader@mailinator.com'
+                    },
+                    organization: 'Trader Organization',
+
+                    roles: 8
+                } as Partial<User.Entity>
+            ]
+        };
+
+        SETUP.encryptedAccounts.map(encryptedAccount =>
+            store.dispatch(addEncryptedAccount(encryptedAccount))
+        );
+        SETUP.users.map(user => store.dispatch(addUser(user as User.Entity)));
+        store.dispatch(addAccount(SETUP.accounts[0]));
+
+        function TestWrapper() {
+            return <Header />;
+        }
+
+        const rendered = await mount(
+            <WrapperComponent store={store} history={history}>
+                <TestWrapper />
+            </WrapperComponent>
+        );
+
+        expect(rendered.find('.MuiSelect-root').text()).toBe('Trader Organization');
+
+        rendered.find(`.MuiSelect-root`).simulate('click');
+
+        expect(
+            Array.from(document.querySelectorAll(`#menu- ul li`)).map(i => i.textContent)
+        ).toStrictEqual([
+            'Trader Organization (MetaMask)',
+            'AssetManager Organization',
+            'Trader Organization'
+        ]);
+
+        cleanupStore();
+    });
+});

--- a/packages/origin-ui/src/__tests__/unit/Header.test.tsx
+++ b/packages/origin-ui/src/__tests__/unit/Header.test.tsx
@@ -32,6 +32,19 @@ const ENCRYPTED_TRADER_KEYSTORE = {
     }
 };
 
+const USER_TRADER = {
+    active: true,
+    id: '0x7672fa3f8c04abbcbad14d896aad8bedece72d2b',
+    initialized: true,
+    offChainProperties: {
+        firstName: 'John',
+        surname: 'Doe Six',
+        email: 'trader@mailinator.com'
+    },
+    organization: 'Trader Organization',
+    roles: 8
+};
+
 describe('Header', () => {
     let store: Store<IStoreState>;
     let history: MemoryHistory;
@@ -83,22 +96,7 @@ describe('Header', () => {
         const SETUP = {
             accounts: [{ address: '0x7672fa3f8C04aBBcbaD14d896AaD8bedECe72d2b' }],
             encryptedAccounts: [],
-            isUsingPK: false,
-            users: [
-                {
-                    active: true,
-                    id: '0x7672fa3f8c04abbcbad14d896aad8bedece72d2b',
-                    initialized: true,
-                    offChainProperties: {
-                        firstName: 'John',
-                        surname: 'Doe Six',
-                        email: 'trader@mailinator.com'
-                    },
-                    organization: 'Trader Organization',
-
-                    roles: 8
-                } as Partial<User.Entity>
-            ]
+            users: [USER_TRADER]
         };
 
         SETUP.encryptedAccounts.map(encryptedAccount =>
@@ -155,7 +153,6 @@ describe('Header', () => {
                 },
                 ENCRYPTED_TRADER_KEYSTORE
             ],
-            isUsingPK: false,
             users: [
                 {
                     active: true,
@@ -169,19 +166,7 @@ describe('Header', () => {
                     organization: 'AssetManager Organization',
                     roles: 12
                 },
-                {
-                    active: true,
-                    id: '0x7672fa3f8c04abbcbad14d896aad8bedece72d2b',
-                    initialized: true,
-                    offChainProperties: {
-                        firstName: 'John',
-                        surname: 'Doe Six',
-                        email: 'trader@mailinator.com'
-                    },
-                    organization: 'Trader Organization',
-
-                    roles: 8
-                } as Partial<User.Entity>
+                USER_TRADER
             ]
         };
 
@@ -218,22 +203,7 @@ describe('Header', () => {
     it('correctly allows to pick encrypted account when no account (no MetaMask)', async () => {
         const SETUP = {
             encryptedAccounts: [ENCRYPTED_TRADER_KEYSTORE],
-            isUsingPK: false,
-            users: [
-                {
-                    active: true,
-                    id: '0x7672fa3f8c04abbcbad14d896aad8bedece72d2b',
-                    initialized: true,
-                    offChainProperties: {
-                        firstName: 'John',
-                        surname: 'Doe Six',
-                        email: 'trader@mailinator.com'
-                    },
-                    organization: 'Trader Organization',
-
-                    roles: 8
-                } as Partial<User.Entity>
-            ]
+            users: [USER_TRADER]
         };
 
         SETUP.encryptedAccounts.map(encryptedAccount =>
@@ -265,22 +235,7 @@ describe('Header', () => {
         const SETUP = {
             accounts: [{ address: '0x7110D0F07Be70Fc2A6C84fe66BF128593b2102Fb' }],
             encryptedAccounts: [ENCRYPTED_TRADER_KEYSTORE],
-            isUsingPK: false,
-            users: [
-                {
-                    active: true,
-                    id: '0x7672fa3f8c04abbcbad14d896aad8bedece72d2b',
-                    initialized: true,
-                    offChainProperties: {
-                        firstName: 'John',
-                        surname: 'Doe Six',
-                        email: 'trader@mailinator.com'
-                    },
-                    organization: 'Trader Organization',
-
-                    roles: 8
-                } as Partial<User.Entity>
-            ]
+            users: [USER_TRADER]
         };
 
         SETUP.encryptedAccounts.map(encryptedAccount =>

--- a/packages/origin-ui/src/__tests__/unit/PaginatedLoaderFiltered.test.tsx
+++ b/packages/origin-ui/src/__tests__/unit/PaginatedLoaderFiltered.test.tsx
@@ -4,9 +4,9 @@ import {
     IPaginatedLoaderFilteredProps,
     getInitialPaginatedLoaderFilteredState,
     RECORD_INDICATOR
-} from '../components/Table/PaginatedLoaderFiltered';
-import { IPaginatedLoaderFetchDataReturnValues } from '../components/Table/PaginatedLoader';
-import { CustomFilterInputType, ICustomFilter } from '../components/Table/FiltersHeader';
+} from '../../components/Table/PaginatedLoaderFiltered';
+import { IPaginatedLoaderFetchDataReturnValues } from '../../components/Table/PaginatedLoader';
+import { CustomFilterInputType, ICustomFilter } from '../../components/Table/FiltersHeader';
 
 describe('PaginatedLoaderFiltered', () => {
     describe('checkRecordPassesFilters()', () => {

--- a/packages/origin-ui/src/__tests__/unit/PaginatedLoaderFilteredSorted.test.ts
+++ b/packages/origin-ui/src/__tests__/unit/PaginatedLoaderFilteredSorted.test.ts
@@ -3,8 +3,8 @@ import {
     IPaginatedLoaderFilteredSortedState,
     IPaginatedLoaderFilteredSortedProps,
     getInitialPaginatedLoaderFilteredSortedState
-} from '../components/Table/PaginatedLoaderFilteredSorted';
-import { IPaginatedLoaderFetchDataReturnValues } from '../components/Table/PaginatedLoader';
+} from '../../components/Table/PaginatedLoaderFilteredSorted';
+import { IPaginatedLoaderFetchDataReturnValues } from '../../components/Table/PaginatedLoader';
 
 describe('PaginatedLoaderFilteredSorted', () => {
     it('sortData correctly sorts records by multiple properties', async () => {

--- a/packages/origin-ui/src/__tests__/unit/ProducingAssetTable.test.tsx
+++ b/packages/origin-ui/src/__tests__/unit/ProducingAssetTable.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { ProducingAssetTable } from '../components/ProducingAssetTable';
-import { dataTestSelector } from '../utils/helper';
-import { setupStore, WrapperComponent, createRenderedHelpers } from './utils/helpers';
+import { ProducingAssetTable } from '../../components/ProducingAssetTable';
+import { dataTestSelector } from '../../utils/helper';
+import { setupStore, WrapperComponent, createRenderedHelpers } from '../utils/helpers';
 
 describe('ProducingAssetTable', () => {
     it('correctly renders and search works', async () => {

--- a/packages/origin-ui/src/__tests__/unit/SmartMeterReadingsChart.test.tsx
+++ b/packages/origin-ui/src/__tests__/unit/SmartMeterReadingsChart.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { SmartMeterReadingsChart } from '../components/SmartMeterReadingsChart';
+import { SmartMeterReadingsChart } from '../../components/SmartMeterReadingsChart';
 import { ProducingAsset, Asset } from '@energyweb/asset-registry';
 import { Bar } from 'react-chartjs-2';
 import moment from 'moment-timezone';

--- a/packages/origin-ui/src/__tests__/utils/helpers.tsx
+++ b/packages/origin-ui/src/__tests__/utils/helpers.tsx
@@ -53,7 +53,8 @@ const setupStoreInternal = (
     initialHistoryEntries: string[],
     logActions = false,
     configurationClient: IConfigurationClient,
-    offChainDataClient: IOffChainDataClient
+    offChainDataClient: IOffChainDataClient,
+    runSagas = true
 ) => {
     const history = createMemoryHistory({
         initialEntries: initialHistoryEntries
@@ -86,10 +87,9 @@ const setupStoreInternal = (
         store.dispatch(setOffChainDataClient(offChainDataClient));
     }
 
-    const sagasTasks: Task[] = Object.keys(sagas).reduce(
-        (a, saga) => [...a, sagaMiddleware.run(sagas[saga])],
-        []
-    );
+    const sagasTasks: Task[] = runSagas
+        ? Object.keys(sagas).reduce((a, saga) => [...a, sagaMiddleware.run(sagas[saga])], [])
+        : [];
 
     return {
         store,
@@ -197,11 +197,13 @@ interface ISetupStoreOptions {
     logActions: boolean;
     configurationClient?: IConfigurationClient;
     offChainDataClient?: IOffChainDataClient;
+    runSagas?: boolean;
 }
 
 const DEFAULT_SETUP_STORE_OPTIONS: ISetupStoreOptions = {
     mockUserFetcher: true,
-    logActions: false
+    logActions: false,
+    runSagas: true
 };
 
 export const setupStore = (
@@ -212,7 +214,8 @@ export const setupStore = (
         initialHistoryEntries,
         options.logActions,
         options.configurationClient,
-        options.offChainDataClient
+        options.offChainDataClient,
+        options.runSagas
     );
 
     if (options.mockUserFetcher) {

--- a/packages/origin-ui/src/__tests__/utils/helpers.tsx
+++ b/packages/origin-ui/src/__tests__/utils/helpers.tsx
@@ -5,7 +5,12 @@ import { routerMiddleware, ConnectedRouter } from 'connected-react-router';
 import { createRootReducer } from '../../reducers';
 import sagas from '../../features/sagas';
 import { MarketUser, PurchasableCertificate } from '@energyweb/market';
-import { addUser, updateCurrentUserId, updateFetcher } from '../../features/users/actions';
+import {
+    addUser,
+    updateCurrentUserId,
+    updateFetcher,
+    IUserFetcher
+} from '../../features/users/actions';
 import { ReactWrapper, CommonWrapper } from 'enzyme';
 import { Configuration, Compliance } from '@energyweb/utils-general';
 import { Certificate } from '@energyweb/origin';
@@ -198,6 +203,7 @@ interface ISetupStoreOptions {
     configurationClient?: IConfigurationClient;
     offChainDataClient?: IOffChainDataClient;
     runSagas?: boolean;
+    userFetcher?: IUserFetcher;
 }
 
 const DEFAULT_SETUP_STORE_OPTIONS: ISetupStoreOptions = {
@@ -219,7 +225,7 @@ export const setupStore = (
     );
 
     if (options.mockUserFetcher) {
-        const mockUserFetcher = {
+        const mockUserFetcher = options.userFetcher || {
             async fetch(id: string) {
                 return ({
                     id,

--- a/packages/origin-ui/src/components/Header.tsx
+++ b/packages/origin-ui/src/components/Header.tsx
@@ -65,7 +65,7 @@ export function Header() {
         return {
             id: `${a.address}${a.privateKey ? 'PK' : ''}`,
             value: a.address,
-            label: (user && user.organization) || 'Guest',
+            label: user?.organization || 'Guest',
             isPrivateKey: Boolean(a.privateKey),
             isLocked: false
         };

--- a/packages/origin-ui/src/components/Header.tsx
+++ b/packages/origin-ui/src/components/Header.tsx
@@ -90,7 +90,7 @@ export function Header() {
         selectorAccounts.push({
             id: `${a.address}PK`,
             value: a.address,
-            label: (user && user.organization) || 'Guest',
+            label: user?.organization || 'Guest',
             isPrivateKey: true,
             isLocked: true
         });
@@ -134,10 +134,10 @@ export function Header() {
         value: '0x0'
     };
 
-    if (accounts.length === 0 || encryptedAccounts.length === 0) {
+    if (accounts.length === 0 || selectorAccounts.length === 0) {
         selectorAccounts.push(GUEST_ACCOUNT);
 
-        if (selectorAccounts.length === 1) {
+        if (!activeAccount) {
             activeAccount = {
                 address: '0x0'
             };
@@ -167,11 +167,21 @@ export function Header() {
                 <div className="ViewProfile">
                     <Select
                         input={
-                            <FilledInput value={activeAccount ? activeAccount.address : '0x0'} />
+                            <FilledInput
+                                value={
+                                    activeAccount
+                                        ? `${activeAccount.address}${
+                                              activeAccount.privateKey ? 'PK' : ''
+                                          }`
+                                        : ''
+                                }
+                            />
                         }
                         renderValue={(selected: string) => {
+                            const accountToFind = selected || '0x0';
+
                             const selectedAccount = selectorAccounts.find(
-                                a => a.value === selected
+                                a => a.id === accountToFind
                             );
 
                             return (

--- a/packages/origin-ui/src/components/Header.tsx
+++ b/packages/origin-ui/src/components/Header.tsx
@@ -45,6 +45,7 @@ export function Header() {
     const accounts = useSelector(getAccounts);
     const users = useSelector(getUsers);
     const encryptedAccounts = useSelector(getEncryptedAccounts);
+    let activeAccount = useSelector(getActiveAccount);
 
     const dispatch = useDispatch();
 
@@ -124,8 +125,6 @@ export function Header() {
             }
         }
     };
-
-    let activeAccount = useSelector(getActiveAccount);
 
     const GUEST_ACCOUNT = {
         id: '0x0',

--- a/packages/origin-ui/src/features/authentication/sagas.ts
+++ b/packages/origin-ui/src/features/authentication/sagas.ts
@@ -123,7 +123,9 @@ function* applyActiveUser(): SagaIterator {
 
         const configuration: IStoreState['configuration'] = yield select(getConfiguration);
 
-        configuration.blockchainProperties.activeUser = action.payload;
+        if (configuration) {
+            configuration.blockchainProperties.activeUser = action.payload;
+        }
 
         try {
             yield put(updateCurrentUserId(action.payload.address));

--- a/packages/origin-ui/tsconfig.build.json
+++ b/packages/origin-ui/tsconfig.build.json
@@ -5,8 +5,7 @@
         "module": "es2015",
         "moduleResolution": "node",
         "declaration": false,
-        "noImplicitAny": false,
-        "noUnusedLocals": true
+        "noImplicitAny": false
     },
     "include": ["./src/**/*"],
     "references": [

--- a/packages/origin-ui/tsconfig.json
+++ b/packages/origin-ui/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "types": ["jest"],
-        "noImplicitAny": false,
-        "noUnusedLocals": true
+        "noImplicitAny": false
     }
 }


### PR DESCRIPTION
- Revert checking not used locals back to eslint from tsc (due to eslint-typescript fixed for 3.7 and working again)
