### PR TITLE
fix(solar-simulator): correctly reflect breaking change renaming asset to device

### DIFF
--- a/packages/solar-simulator/README.md
+++ b/packages/solar-simulator/README.md
@@ -51,7 +51,7 @@ Edit `.env` in the root of the monorepo and configure:
 
 Edit device configuration in `config/config.json`. Properties:
 - `maxCapacity` - maximum device capacity in Wh
-- `smartMeterPrivateKey` - private key of smart meter device to save reads on-chain
+- `smartMeterPrivateKey` - private key of a smart meter device to save reads on-chain
 
 Place example energy generation data in `config/data.csv` in the following format:
 


### PR DESCRIPTION
BREAKING CHANGE: reflect assets renamed to devices in config

Commit for conventional commits alignment.