### PR TITLE
Market matcher overmatching

### DIFF
--- a/packages/device-registry/src/wrappedContracts/DeviceLogic.ts
+++ b/packages/device-registry/src/wrappedContracts/DeviceLogic.ts
@@ -28,23 +28,24 @@ export class DeviceLogic extends GeneralFunctions {
     }
 
     async getAllLogNewMeterReadEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('LogNewMeterRead', eventFilter);
+        
+        return this.web3Contract.getPastEvents('LogNewMeterRead', this.createFilter(eventFilter));
     }
 
     async getAllLogDeviceCreatedEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('LogDeviceCreated', eventFilter);
+        return this.web3Contract.getPastEvents('LogDeviceCreated', this.createFilter(eventFilter));
     }
 
     async getAllLogDeviceFullyInitializedEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('LogDeviceFullyInitialized', eventFilter);
+        return this.web3Contract.getPastEvents('LogDeviceFullyInitialized', this.createFilter(eventFilter));
     }
 
     async getAllLogDeviceSetActiveEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('LogDeviceSetActive', eventFilter);
+        return this.web3Contract.getPastEvents('LogDeviceSetActive', this.createFilter(eventFilter));
     }
 
     async getAllLogDeviceSetInactiveEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('LogDeviceSetInactive', eventFilter);
+        return this.web3Contract.getPastEvents('LogDeviceSetInactive', this.createFilter(eventFilter));
     }
 
     async getSmartMeterReadsForDeviceByIndex(
@@ -62,11 +63,11 @@ export class DeviceLogic extends GeneralFunctions {
     }
 
     async getAllLogChangeOwnerEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('LogChangeOwner', eventFilter);
+        return this.web3Contract.getPastEvents('LogChangeOwner', this.createFilter(eventFilter));
     }
 
     async getAllEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('allEvents', eventFilter);
+        return this.web3Contract.getPastEvents('allEvents', this.createFilter(eventFilter));
     }
 
     async getLastMeterReadingAndHash(_deviceId: number, txParams?: ISpecialTx) {

--- a/packages/market-matcher/src/EntityStore.ts
+++ b/packages/market-matcher/src/EntityStore.ts
@@ -257,6 +257,11 @@ export class EntityStore implements IEntityStore {
     private async handleCertificate(id: string, trigger = true) {
         const certificate = await this.fetcher.getCertificate(id);
 
+        if (certificate.certificate.children.length) {
+            this.logger.verbose(`[Certificate ${certificate.id}] Is parent certificate, skipping.`);
+            return;
+        }
+
         this.certificates.set(certificate.id, certificate);
         this.logger.verbose(`[Certificate ${certificate.id}] Registered`);
 

--- a/packages/market/src/blockchain-facade/Demand.ts
+++ b/packages/market/src/blockchain-facade/Demand.ts
@@ -347,9 +347,9 @@ export const calculateTotalEnergyDemand = (
     return energyPerTimeFrame * durationInTimeFrame;
 };
 
-export const alignToResolution = (timeStamp: number, resolution: Resolution) =>
+export const alignToResolution = (timestamp: number, resolution: Resolution) =>
     moment
-        .unix(timeStamp)
+        .unix(timestamp)
         .startOf(resolution as moment.unitOfTime.StartOf)
         .unix();
 
@@ -377,13 +377,18 @@ export const calculateMissingEnergyDemand = async (
         filter: { _demandId: demand.id }
     });
 
+    config.logger.debug(
+        `[Demand #${demand.id}] filledEvents ${JSON.stringify(filledEvents.map(e => ({
+            block: e.blockNumber,
+            value: e.returnValues._amount
+        })))}`
+    );
+
     const filledDemandsTimeSeries = await Promise.all(
         filledEvents.map(async log => {
             const block = await config.blockchainProperties.web3.eth.getBlock(log.blockNumber);
-            const nearestTime = moment
-                .unix(parseInt(block.timestamp.toString(), 10))
-                .startOf(resolution as moment.unitOfTime.StartOf)
-                .unix();
+            const timestamp = parseInt(block.timestamp.toString(), 10);
+            const nearestTime = alignToResolution(timestamp, resolution);
 
             return { time: nearestTime, value: Number(log.returnValues._amount) * -1 };
         })

--- a/packages/market/src/blockchain-facade/Demand.ts
+++ b/packages/market/src/blockchain-facade/Demand.ts
@@ -378,10 +378,12 @@ export const calculateMissingEnergyDemand = async (
     });
 
     config.logger.debug(
-        `[Demand #${demand.id}] filledEvents ${JSON.stringify(filledEvents.map(e => ({
-            block: e.blockNumber,
-            value: e.returnValues._amount
-        })))}`
+        `[Demand #${demand.id}] filledEvents ${JSON.stringify(
+            filledEvents.map(e => ({
+                block: e.blockNumber,
+                value: e.returnValues._amount
+            }))
+        )}`
     );
 
     const filledDemandsTimeSeries = await Promise.all(

--- a/packages/market/src/test/unit/Demand.test.ts
+++ b/packages/market/src/test/unit/Demand.test.ts
@@ -5,6 +5,7 @@ import moment from 'moment';
 import Web3 from 'web3';
 import { Eth, BlockTransactionObject } from 'web3-eth';
 import { EventLog } from 'web3-core';
+import * as Winston from 'winston';
 
 import {
     calculateMissingEnergyDemand,
@@ -55,6 +56,8 @@ describe('Demand unit tests', () => {
             return config;
         };
 
+        let demandNonce = 0;
+
         const createDemand = (
             start: moment.Moment,
             end: moment.Moment,
@@ -69,6 +72,7 @@ describe('Demand unit tests', () => {
             offChainProperties.timeFrame.returns(timeFrame);
             offChainProperties.energyPerTimeFrame.returns(energyPerTimeFrame);
 
+            demand.id.returns((demandNonce++).toString());
             demand.offChainProperties.returns(offChainProperties);
 
             return demand;

--- a/packages/market/src/test/unit/Demand.test.ts
+++ b/packages/market/src/test/unit/Demand.test.ts
@@ -5,7 +5,6 @@ import moment from 'moment';
 import Web3 from 'web3';
 import { Eth, BlockTransactionObject } from 'web3-eth';
 import { EventLog } from 'web3-core';
-import * as Winston from 'winston';
 
 import {
     calculateMissingEnergyDemand,

--- a/packages/market/src/wrappedContracts/MarketLogic.ts
+++ b/packages/market/src/wrappedContracts/MarketLogic.ts
@@ -38,12 +38,11 @@ export class MarketLogic extends GeneralFunctions {
         if (!SUPPORTED_EVENTS.includes(event)) {
             throw new Error('This event does not exist.');
         }
-
-        return this.web3Contract.getPastEvents(event, eventFilter);
+        return this.web3Contract.getPastEvents(event, this.createFilter(eventFilter));
     }
 
     async getAllEvents(eventFilter?: PastEventOptions) {
-        return this.getEvents('allEvents', eventFilter);
+        return this.getEvents('allEvents', this.createFilter(eventFilter));
     }
 
     async initialize(certificateContractAddress: string, txParams: ISpecialTx) {

--- a/packages/origin/src/wrappedContracts/CertificateLogic.ts
+++ b/packages/origin/src/wrappedContracts/CertificateLogic.ts
@@ -26,43 +26,43 @@ export class CertificateLogic extends GeneralFunctions {
     }
 
     async getAllCertificationApprovedEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('CertificationRequestApproved', eventFilter);
+        return this.web3Contract.getPastEvents('CertificationRequestApproved', this.createFilter(eventFilter));
     }
 
     async getAllCertificationCreatedEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('CertificationRequestCreated', eventFilter);
+        return this.web3Contract.getPastEvents('CertificationRequestCreated', this.createFilter(eventFilter));
     }
 
     async getAllLogCreatedCertificateEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('LogCreatedCertificate', eventFilter);
+        return this.web3Contract.getPastEvents('LogCreatedCertificate', this.createFilter(eventFilter));
     }
 
     async getAllLogCertificateClaimedEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('LogCertificateClaimed', eventFilter);
+        return this.web3Contract.getPastEvents('LogCertificateClaimed', this.createFilter(eventFilter));
     }
 
     async getAllLogCertificateSplitEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('LogCertificateSplit', eventFilter);
+        return this.web3Contract.getPastEvents('LogCertificateSplit', this.createFilter(eventFilter));
     }
 
     async getAllTransferEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('Transfer', eventFilter);
+        return this.web3Contract.getPastEvents('Transfer', this.createFilter(eventFilter));
     }
 
     async getAllApprovalEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('Approval', eventFilter);
+        return this.web3Contract.getPastEvents('Approval', this.createFilter(eventFilter));
     }
 
     async getAllApprovalForAllEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('ApprovalForAll', eventFilter);
+        return this.web3Contract.getPastEvents('ApprovalForAll', this.createFilter(eventFilter));
     }
 
     async getAllLogChangeOwnerEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('LogChangeOwner', eventFilter);
+        return this.web3Contract.getPastEvents('LogChangeOwner', this.createFilter(eventFilter));
     }
 
     async getAllEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('allEvents', eventFilter);
+        return this.web3Contract.getPastEvents('allEvents', this.createFilter(eventFilter));
     }
 
     async getApproved(_tokenId: number, txParams?: ISpecialTx) {

--- a/packages/user-registry/src/wrappedContracts/RoleManagement.ts
+++ b/packages/user-registry/src/wrappedContracts/RoleManagement.ts
@@ -40,27 +40,11 @@ export class RoleManagement extends GeneralFunctions {
     }
 
     async getAllLogChangeOwnerEvents(eventFilter?: PastEventOptions) {
-        let filterParams: any;
-        if (eventFilter) {
-            filterParams = {
-                fromBlock: eventFilter.fromBlock ? eventFilter.fromBlock : 0,
-                toBlock: eventFilter.toBlock ? eventFilter.toBlock : 'latest'
-            };
-            if (eventFilter.topics) {
-                filterParams.topics = eventFilter.topics;
-            }
-        } else {
-            filterParams = {
-                fromBlock: 0,
-                toBlock: 'latest'
-            };
-        }
-
-        return this.web3Contract.getPastEvents('LogChangeOwner', eventFilter);
+        return this.web3Contract.getPastEvents('LogChangeOwner', this.createFilter(eventFilter));
     }
 
     async getAllEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('allEvents', eventFilter);
+        return this.web3Contract.getPastEvents('allEvents', this.createFilter(eventFilter));
     }
 
     async owner(txParams?: ISpecialTx) {

--- a/packages/user-registry/src/wrappedContracts/UserLogic.ts
+++ b/packages/user-registry/src/wrappedContracts/UserLogic.ts
@@ -20,7 +20,7 @@ export class UserLogic extends GeneralFunctions {
     }
 
     async getAllEvents(eventFilter?: PastEventOptions) {
-        return this.web3Contract.getPastEvents('allEvents', eventFilter);
+        return this.web3Contract.getPastEvents('allEvents', this.createFilter(eventFilter));
     }
 
     async initialize(txParams: ISpecialTx) {

--- a/packages/utils-general/src/GeneralFunctions.ts
+++ b/packages/utils-general/src/GeneralFunctions.ts
@@ -1,6 +1,6 @@
 import Web3 from 'web3';
 import { TransactionConfig, TransactionReceipt } from 'web3-core';
-import { Contract } from 'web3-eth-contract';
+import { Contract, PastEventOptions } from 'web3-eth-contract';
 
 export declare interface ISpecialTx extends TransactionConfig {
     privateKey?: string;
@@ -170,5 +170,9 @@ export class GeneralFunctions {
             to: this.web3Contract.options.address,
             privateKey: parameters.privateKey ? parameters.privateKey : ''
         };
+    }
+
+    createFilter(eventFilter?: PastEventOptions) {
+        return Object.assign({ fromBlock: 0, toBlock: 'latest' }, eventFilter || {});
     }
 }


### PR DESCRIPTION
This PR fixes the issue that caused market-matcher to match more energy than required by the demand.

The root cause of this issue was lack of `fromBlock` and `toBlock` values set on the filter.  