### PR TITLE
fix: revert solidity compiler to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "mocha": "6.2.2",
         "prettier": "1.19.1",
         "shx": "0.3.2",
-        "solc": "0.6.0",
+        "solc": "0.5.15",
         "truffle": "5.1.5",
         "ts-node": "8.5.4",
         "typescript": "3.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13570,10 +13570,10 @@ solc-wrapper@^0.5.8:
     semver "^5.5.0"
     tmp "0.0.33"
 
-solc@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.6.0.tgz#061a36075087b5ca16e1c4fc4fad565aa2851fe4"
-  integrity sha512-fYVRKbJLbg0oETBuAJN/ts0X/hj2YgOAl3ly3nrm/qhleVr22ecl3OSXW3hRmOWvH81hJ2KHRYRQWgqioK6d0A==
+solc@0.5.15:
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.15.tgz#f674ce93d4d04a86b65a4393657edf03b2f26028"
+  integrity sha512-uI+7XtBu/0CXRc8IMjzxbh0haLwaBF32VxAkkks06zEk+mVcsQbHdjvojXX6zQYtZVuXdVYPVccoIjEhvvqKnQ==
   dependencies:
     command-exists "^1.2.8"
     commander "3.0.2"


### PR DESCRIPTION
Reverts `solc` back to v5 since OpenZeppelin doesn't support v6 yet.

Related issue:
- [ ] https://github.com/OpenZeppelin/openzeppelin-contracts/issues/2028