### PR TITLE
Solidity-compatible Precise Proofs

### DIFF
--- a/packages/event-listener/src/listeners/origin.listener.ts
+++ b/packages/event-listener/src/listeners/origin.listener.ts
@@ -100,7 +100,7 @@ export class OriginEventListener implements IOriginEventListener {
                     `Automatically publishing Certificate #${newCertificate.id} for sale...`
                 );
                 await newCertificate.publishForSale(
-                    autoPublishSettings.price,
+                    autoPublishSettings.priceInCents,
                     autoPublishSettings.currency
                 );
                 this.conf.logger.info(

--- a/packages/event-listener/src/test/deployDemo.ts
+++ b/packages/event-listener/src/test/deployDemo.ts
@@ -204,7 +204,7 @@ export class Demo {
             notifications: true,
             autoPublish: {
                 enabled: true,
-                price: 1000,
+                priceInCents: 1000,
                 currency: 'USD'
             }
         };
@@ -452,7 +452,7 @@ export class Demo {
 
         const demandOffChainProps: Demand.IDemandOffChainProperties = {
             timeFrame: TimeFrame.hourly,
-            maxPricePerMwh: 150000,
+            maxPriceInCentsPerMwh: 150000,
             currency: 'USD',
             location: ['Thailand;Central;Nakhon Pathom'],
             deviceType: ['Wind'],

--- a/packages/market-matcher-core/src/MatchableDemand.ts
+++ b/packages/market-matcher-core/src/MatchableDemand.ts
@@ -30,7 +30,7 @@ export class MatchableDemand {
                 MatchingErrorReason.PERIOD_ALREADY_FILLED
             )
             .validate(
-                certificate.price <= offChainProperties.maxPricePerMwh,
+                certificate.price <= offChainProperties.maxPriceInCentsPerMwh,
                 MatchingErrorReason.TOO_EXPENSIVE
             )
             .validate(
@@ -59,7 +59,7 @@ export class MatchableDemand {
 
     public matchesSupply(supply: Supply.ISupply) {
         const supplyPricePerMwh =
-            (supply.offChainProperties.price / supply.offChainProperties.availableWh) * 1e6;
+            (supply.offChainProperties.priceInCents / supply.offChainProperties.availableWh) * 1e6;
 
         const { offChainProperties } = this.demand;
 
@@ -70,7 +70,7 @@ export class MatchableDemand {
                 MatchingErrorReason.NOT_ENOUGH_ENERGY
             )
             .validate(
-                supplyPricePerMwh <= offChainProperties.maxPricePerMwh,
+                supplyPricePerMwh <= offChainProperties.maxPriceInCentsPerMwh,
                 MatchingErrorReason.TOO_EXPENSIVE
             )
             .result();

--- a/packages/market-matcher-core/src/test/unit/MatchableDemand.test.ts
+++ b/packages/market-matcher-core/src/test/unit/MatchableDemand.test.ts
@@ -30,7 +30,7 @@ describe('MatchableDemand tests', () => {
     describe('Certificates', () => {
         const missingDemand = 1000;
         const certificateEnergy = 1000;
-        const energyPrice = 2;
+        const energyPrice = 200;
         const currency = 'USD';
         const deviceType = 'Solar';
         const location = [`${country};Central;Nakhon Pathom`];
@@ -42,7 +42,7 @@ describe('MatchableDemand tests', () => {
         const createMatchingMocks = (options: IMockOptions) => {
             const demandOffChainProperties = Substitute.for<Demand.IDemandOffChainProperties>();
             demandOffChainProperties.energyPerTimeFrame.returns(certificateEnergy);
-            demandOffChainProperties.maxPricePerMwh.returns(energyPrice);
+            demandOffChainProperties.maxPriceInCentsPerMwh.returns(energyPrice);
             demandOffChainProperties.currency.returns(currency);
             demandOffChainProperties.deviceType.returns([deviceType]);
             demandOffChainProperties.location.returns(options.location || location);
@@ -240,14 +240,14 @@ describe('MatchableDemand tests', () => {
     });
     describe('Supply', () => {
         const supplyEnergy = 1000;
-        const energyPrice = 100;
+        const energyPrice = 10000;
         const currency = 'USD';
         const deviceType = 'Solar';
 
         const createMatchingMocks = (options: IMockOptions) => {
             const demandOffChainProperties = Substitute.for<Demand.IDemandOffChainProperties>();
             demandOffChainProperties.energyPerTimeFrame.returns(supplyEnergy);
-            demandOffChainProperties.maxPricePerMwh.returns(energyPrice * 1e6);
+            demandOffChainProperties.maxPriceInCentsPerMwh.returns(energyPrice * 1e6);
             demandOffChainProperties.currency.returns(currency);
             demandOffChainProperties.deviceType.returns([deviceType]);
 
@@ -257,7 +257,7 @@ describe('MatchableDemand tests', () => {
 
             const supplyOffChainProperties = Substitute.for<Supply.ISupplyOffChainProperties>();
             supplyOffChainProperties.availableWh.returns(options.energy || supplyEnergy);
-            supplyOffChainProperties.price.returns(
+            supplyOffChainProperties.priceInCents.returns(
                 options.price || (energyPrice * (options.energy || supplyEnergy)) / 1e6
             );
 

--- a/packages/market-matcher/src/strategy/LowestPriceStrategy.ts
+++ b/packages/market-matcher/src/strategy/LowestPriceStrategy.ts
@@ -5,7 +5,7 @@ import { IStrategy } from '@energyweb/market-matcher-core';
 export class LowestPriceStrategy implements IStrategy {
     private agreementPriorities = [
         (a: Agreement.IAgreement, b: Agreement.IAgreement) =>
-            a.offChainProperties.price - b.offChainProperties.price
+            a.offChainProperties.priceInCents - b.offChainProperties.priceInCents
     ];
 
     private certificatePriorities = [

--- a/packages/market-matcher/src/test/Matcher.test.ts
+++ b/packages/market-matcher/src/test/Matcher.test.ts
@@ -75,7 +75,7 @@ describe('Market-matcher e2e tests', async () => {
             certificate = await deployCertificate(config, device.id, requiredEnergy);
 
             await certificate.publishForSale(
-                demand.offChainProperties.maxPricePerMwh / 100,
+                demand.offChainProperties.maxPriceInCentsPerMwh / 100,
                 demand.offChainProperties.currency
             );
 
@@ -106,7 +106,7 @@ describe('Market-matcher e2e tests', async () => {
             certificate = await deployCertificate(config, device.id, certificateEnergy);
 
             await certificate.publishForSale(
-                demand.offChainProperties.maxPricePerMwh / 100,
+                demand.offChainProperties.maxPriceInCentsPerMwh / 100,
                 demand.offChainProperties.currency
             );
 
@@ -123,7 +123,7 @@ describe('Market-matcher e2e tests', async () => {
 
     describe('Demand -> Certificate matching tests', () => {
         const requiredEnergy = 1 * Unit.MWh;
-        const price = 150;
+        const priceInCents = 150;
         const currency = 'USD';
 
         let config: Configuration.Entity<MarketLogic, DeviceLogic, CertificateLogic, UserLogic>;
@@ -138,11 +138,11 @@ describe('Market-matcher e2e tests', async () => {
             config = configuration.config;
             device = await deployDevice(config);
             certificate = await deployCertificate(config, device.id, requiredEnergy);
-            await certificate.publishForSale(price / 100, currency);
+            await certificate.publishForSale(priceInCents, currency);
 
             await startMatcher(matcherConfig);
 
-            demand = await deployDemand(config, requiredEnergy, price, currency);
+            demand = await deployDemand(config, requiredEnergy, priceInCents, currency);
         });
 
         it('demand should be matched with existing certificate', done => {
@@ -152,7 +152,7 @@ describe('Market-matcher e2e tests', async () => {
 
     describe('Agreement -> Certificate matching tests', () => {
         const requiredEnergy = 1 * Unit.MWh;
-        const price = 150;
+        const priceInCents = 150;
         const currency = 'USD';
 
         let config: Configuration.Entity<MarketLogic, DeviceLogic, CertificateLogic, UserLogic>;
@@ -169,12 +169,12 @@ describe('Market-matcher e2e tests', async () => {
             device = await deployDevice(config);
             certificate = await deployCertificate(config, device.id, requiredEnergy);
 
-            supply = await deploySupply(config, device.id, requiredEnergy, price, currency);
-            demand = await deployDemand(config, requiredEnergy, price, currency);
+            supply = await deploySupply(config, device.id, requiredEnergy, priceInCents, currency);
+            demand = await deployDemand(config, requiredEnergy, priceInCents, currency);
 
-            await deployAgreement(config, demand.id, supply.id, price, currency);
+            await deployAgreement(config, demand.id, supply.id, priceInCents, currency);
 
-            await certificate.publishForSale(price / 100, currency);
+            await certificate.publishForSale(priceInCents, currency);
 
             await startMatcher(matcherConfig);
         });

--- a/packages/market-matcher/src/test/TestEnvironment.ts
+++ b/packages/market-matcher/src/test/TestEnvironment.ts
@@ -226,7 +226,7 @@ const deployDemand = async (
 
     const demandOffChainProps: Demand.IDemandOffChainProperties = {
         timeFrame: TimeFrame.hourly,
-        maxPricePerMwh: price,
+        maxPriceInCentsPerMwh: price,
         currency,
         location: ['Thailand;Central;Nakhon Pathom'],
         deviceType: ['Solar'],
@@ -303,7 +303,7 @@ const deploySupply = (
             deviceId
         },
         {
-            price,
+            priceInCents: price,
             currency,
             availableWh: requiredEnergy,
             timeFrame: TimeFrame.hourly
@@ -365,7 +365,7 @@ const deployAgreement = async (
     const agreementOffChainProps: Agreement.IAgreementOffChainProperties = {
         start: startTime,
         end: endTime,
-        price,
+        priceInCents: price,
         currency,
         period: 10,
         timeFrame: TimeFrame.hourly

--- a/packages/market/src/blockchain-facade/Agreement.ts
+++ b/packages/market/src/blockchain-facade/Agreement.ts
@@ -13,7 +13,7 @@ import AgreementOffChainPropertiesSchema from '../../schemas/AgreementOffChainPr
 export interface IAgreementOffChainProperties {
     start: Timestamp;
     end: Timestamp;
-    price: number;
+    priceInCents: number;
     currency: Currency;
     period: number;
     timeFrame: TimeFrame;

--- a/packages/market/src/blockchain-facade/Demand.ts
+++ b/packages/market/src/blockchain-facade/Demand.ts
@@ -20,7 +20,7 @@ import { Currency } from '../types';
 
 export interface IDemandOffChainProperties {
     timeFrame: TimeFrame;
-    maxPricePerMwh: number;
+    maxPriceInCentsPerMwh: number;
     currency: Currency;
     location?: string[];
     deviceType?: string[];

--- a/packages/market/src/blockchain-facade/MarketUser.ts
+++ b/packages/market/src/blockchain-facade/MarketUser.ts
@@ -6,7 +6,7 @@ import MarketUserOffChainPropertiesSchema from '../../schemas/MarketUserOffChain
 export interface IAutoPublishConfig {
     enabled: boolean;
     currency: Currency;
-    price: number;
+    priceInCents: number;
 }
 
 export interface IMarketUserOffChainProperties extends User.IUserOffChainProperties {

--- a/packages/market/src/blockchain-facade/PurchasableCertificate.ts
+++ b/packages/market/src/blockchain-facade/PurchasableCertificate.ts
@@ -10,7 +10,7 @@ import { Currency } from '../types';
 import { NoneCurrency } from '../const';
 
 const DEFAULT_OFF_CHAIN_PROPERTIES = {
-    price: 0,
+    priceInCents: 0,
     currency: NoneCurrency
 };
 
@@ -32,7 +32,7 @@ export interface IPurchasableCertificate {
 }
 
 export interface IPurchasableCertificateOffChainProperties {
-    price: number;
+    priceInCents: number;
     currency: Currency;
 }
 
@@ -204,7 +204,7 @@ export class Entity extends BlockchainDataModelEntity.Entity implements IPurchas
             tokenAddress: isErc20Sale
                 ? tokenAddressOrCurrency
                 : '0x0000000000000000000000000000000000000000',
-            offChainPrice: isFiatSale ? Math.floor(price * 100) : 0,
+            offChainPrice: isFiatSale ? Math.floor(price) : 0,
             offChainCurrency: isFiatSale ? tokenAddressOrCurrency : NoneCurrency
         };
 
@@ -215,7 +215,7 @@ export class Entity extends BlockchainDataModelEntity.Entity implements IPurchas
         }
 
         const newOffChainProperties = {
-            price: saleParams.offChainPrice,
+            priceInCents: saleParams.offChainPrice,
             currency: saleParams.offChainCurrency
         };
         const updatedOffChainStorageProperties = this.prepareEntityCreation(
@@ -296,7 +296,7 @@ export class Entity extends BlockchainDataModelEntity.Entity implements IPurchas
         }
 
         return this.isOffChainSettlement
-            ? this.offChainProperties.price
+            ? this.offChainProperties.priceInCents
             : this.onChainDirectPurchasePrice;
     }
 

--- a/packages/market/src/blockchain-facade/Supply.ts
+++ b/packages/market/src/blockchain-facade/Supply.ts
@@ -6,7 +6,7 @@ import supplyOffChainPropertiesSchema from '../../schemas/SupplyOffChainProperti
 import { Currency } from '../types';
 
 export interface ISupplyOffChainProperties {
-    price: number;
+    priceInCents: number;
     currency: Currency;
     availableWh: number;
     timeFrame: TimeFrame;

--- a/packages/market/src/test/MarketFacade.test.ts
+++ b/packages/market/src/test/MarketFacade.test.ts
@@ -390,7 +390,7 @@ describe('Market-Facade', () => {
 
             const demandOffChainProps: Demand.IDemandOffChainProperties = {
                 timeFrame: TimeFrame.hourly,
-                maxPricePerMwh: 1.5,
+                maxPriceInCentsPerMwh: 150,
                 currency: 'USD',
                 location: ['Thailand;Central;Nakhon Pathom'],
                 deviceType: ['Solar'],
@@ -443,7 +443,7 @@ describe('Market-Facade', () => {
                 location: ['Thailand;Central;Nakhon Pathom'],
                 minCO2Offset: 10,
                 otherGreenAttributes: 'string',
-                maxPricePerMwh: 1.5,
+                maxPriceInCentsPerMwh: 150,
                 registryCompliance: 'I-REC',
                 energyPerTimeFrame: 10,
                 timeFrame: TimeFrame.hourly,
@@ -623,7 +623,7 @@ describe('Market-Facade', () => {
             };
 
             const supplyOffChainProperties: Supply.ISupplyOffChainProperties = {
-                price: 10,
+                priceInCents: 1000,
                 currency: 'USD',
                 availableWh: 10,
                 timeFrame: TimeFrame.hourly
@@ -649,7 +649,7 @@ describe('Market-Facade', () => {
                 offChainProperties: {
                     availableWh: 10,
                     currency: 'USD',
-                    price: 10,
+                    priceInCents: 1000,
                     timeFrame: TimeFrame.hourly
                 }
             } as Partial<Supply.Entity>);
@@ -666,7 +666,7 @@ describe('Market-Facade', () => {
                 offChainProperties: {
                     availableWh: 10,
                     currency: 'USD',
-                    price: 10,
+                    priceInCents: 1000,
                     timeFrame: TimeFrame.hourly
                 }
             } as Partial<Supply.Entity>);
@@ -692,7 +692,7 @@ describe('Market-Facade', () => {
             const agreementOffchainProps: IAgreementOffChainProperties = {
                 start: startTime,
                 end: startTime + 1000,
-                price: 10,
+                priceInCents: 1000,
                 currency: 'USD',
                 period: 10,
                 timeFrame: TimeFrame.hourly
@@ -728,7 +728,7 @@ describe('Market-Facade', () => {
                     currency: 'USD',
                     end: startTime + 1000,
                     period: 10,
-                    price: 10,
+                    priceInCents: 1000,
                     start: startTime,
                     timeFrame: TimeFrame.hourly
                 }
@@ -753,7 +753,7 @@ describe('Market-Facade', () => {
                     currency: 'USD',
                     end: startTime + 1000,
                     period: 10,
-                    price: 10,
+                    priceInCents: 1000,
                     start: startTime,
                     timeFrame: TimeFrame.hourly
                 }
@@ -784,7 +784,7 @@ describe('Market-Facade', () => {
                     currency: 'USD',
                     end: startTime + 1000,
                     period: 10,
-                    price: 10,
+                    priceInCents: 1000,
                     start: startTime,
                     timeFrame: TimeFrame.hourly
                 }
@@ -802,7 +802,7 @@ describe('Market-Facade', () => {
             const agreementOffchainProps: IAgreementOffChainProperties = {
                 start: startTime,
                 end: startTime + 1000,
-                price: 10,
+                priceInCents: 1000,
                 currency: 'USD',
                 period: 10,
                 timeFrame: TimeFrame.hourly
@@ -835,7 +835,7 @@ describe('Market-Facade', () => {
                     currency: 'USD',
                     end: startTime + 1000,
                     period: 10,
-                    price: 10,
+                    priceInCents: 1000,
                     start: startTime,
                     timeFrame: TimeFrame.hourly
                 }
@@ -866,7 +866,7 @@ describe('Market-Facade', () => {
                     currency: 'USD',
                     end: startTime + 1000,
                     period: 10,
-                    price: 10,
+                    priceInCents: 1000,
                     start: startTime,
                     timeFrame: TimeFrame.hourly
                 }

--- a/packages/market/src/test/PurchasableCertificate.test.ts
+++ b/packages/market/src/test/PurchasableCertificate.test.ts
@@ -270,7 +270,7 @@ describe('PurchasableCertificate-Facade', () => {
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: 0,
             offChainProperties: {
-                price: 0,
+                priceInCents: 0,
                 currency: NoneCurrency
             }
         } as Partial<PurchasableCertificate.Entity>);
@@ -339,7 +339,7 @@ describe('PurchasableCertificate-Facade', () => {
             acceptedToken: erc20TestTokenAddress,
             onChainDirectPurchasePrice: 100,
             offChainProperties: {
-                price: 0,
+                priceInCents: 0,
                 currency: NoneCurrency
             }
         } as Partial<PurchasableCertificate.Entity>);
@@ -427,7 +427,7 @@ describe('PurchasableCertificate-Facade', () => {
             acceptedToken: '0x0000000000000000000000000000000000000000',
             onChainDirectPurchasePrice: 0,
             offChainProperties: {
-                price: 0,
+                priceInCents: 0,
                 currency: NoneCurrency
             }
         } as Partial<PurchasableCertificate.Entity>);
@@ -437,9 +437,9 @@ describe('PurchasableCertificate-Facade', () => {
         const newCertificateId = await generateCertificateAndGetId();
         let pCert = await new PurchasableCertificate.Entity(newCertificateId, conf).sync();
 
-        const price = 10.5;
+        const priceInCents = 1050;
 
-        await pCert.publishForSale(price, 'USD');
+        await pCert.publishForSale(priceInCents, 'USD');
 
         pCert = await pCert.sync();
 
@@ -449,7 +449,7 @@ describe('PurchasableCertificate-Facade', () => {
             forSale: true,
             acceptedToken: '0x0000000000000000000000000000000000000000',
             offChainProperties: {
-                price: price * 100,
+                priceInCents,
                 currency: 'USD'
             }
         } as Partial<PurchasableCertificate.Entity>);
@@ -588,7 +588,7 @@ describe('PurchasableCertificate-Facade', () => {
             await Certificate.getCertificateListLength(conf)
         );
         const CERTIFICATE_ENERGY = 100;
-        const CERTIFICATE_PRICE = 7;
+        const CERTIFICATE_PRICE = 700;
         const CERTIFICATE_CURRENCY = 'USD';
         const TRADER_STARTING_TOKEN_BALANCE = Number(await erc20TestToken.balanceOf(accountTrader));
         const DEVICE_OWNER_STARTING_TOKEN_BALANCE = Number(
@@ -609,7 +609,7 @@ describe('PurchasableCertificate-Facade', () => {
 
         assert.equal(parentCertificate.onChainDirectPurchasePrice, 0);
         assert.deepEqual(parentCertificate.offChainProperties, {
-            price: CERTIFICATE_PRICE * 100,
+            priceInCents: CERTIFICATE_PRICE,
             currency: CERTIFICATE_CURRENCY
         });
 

--- a/packages/migrations/config/examples/agreement.json
+++ b/packages/migrations/config/examples/agreement.json
@@ -416,7 +416,7 @@
                 "trader": "0x4095f1db44884764C17c7A9A31B4Bf20f5779691",
                 "traderPK": "0x9d66d342a3b6014a7cff6ff0379b192dbe193e43bb6979625c600c4996bb3b85",
                 "timeframe": "hourly",
-                "maxPricePerMwh": 10,
+                "maxPriceInCentsPerMwh": 10,
                 "currency": "USD",
                 "producingDevice": 0,
                 "consumingDevice": 0,

--- a/packages/migrations/src/certificate.ts
+++ b/packages/migrations/src/certificate.ts
@@ -186,7 +186,7 @@ export const certificateDemo = async (
             try {
                 let certificate = await new PurchasableCertificate.Entity(action.data.certId, conf).sync();
 
-                await certificate.publishForSale(action.data.price, action.data.currency);
+                await certificate.publishForSale((action.data.price * 100), action.data.currency);
                 certificate = await certificate.sync();
 
                 conf.logger.info(`Certificate ${action.data.certId} published for sale`);

--- a/packages/migrations/src/market.ts
+++ b/packages/migrations/src/market.ts
@@ -164,7 +164,7 @@ export const marketDemo = async (demoConfigPath: string, contractConfig: Deploye
 
                 const demandOffchainProps: Demand.IDemandOffChainProperties = {
                     timeFrame: TimeFrame[action.data.timeframe as keyof typeof TimeFrame],
-                    maxPricePerMwh: action.data.maxPricePerMwh,
+                    maxPriceInCentsPerMwh: action.data.maxPriceInCentsPerMwh,
                     currency: action.data.currency,
                     location: [action.data.location],
                     deviceType: action.data.devicetype,
@@ -202,7 +202,7 @@ export const marketDemo = async (demoConfigPath: string, contractConfig: Deploye
                 };
 
                 const supplyOffChainProperties: Supply.ISupplyOffChainProperties = {
-                    price: action.data.price,
+                    priceInCents: parseInt(action.data.price, 10) * 100,
                     currency: action.data.currency,
                     availableWh: action.data.availableWh,
                     timeFrame: TimeFrame[action.data.timeframe as keyof typeof TimeFrame]
@@ -253,7 +253,7 @@ export const marketDemo = async (demoConfigPath: string, contractConfig: Deploye
                 const agreementOffchainProps: Agreement.IAgreementOffChainProperties = {
                     start: action.data.startTime,
                     end: action.data.endTime,
-                    price: action.data.price,
+                    priceInCents: parseInt(action.data.price, 10) * 100,
                     currency: action.data.currency,
                     period: action.data.period,
                     timeFrame: TimeFrame[action.data.timeframe as keyof typeof TimeFrame]

--- a/packages/migrations/src/onboarding.ts
+++ b/packages/migrations/src/onboarding.ts
@@ -54,7 +54,7 @@ export const onboardDemo = async (
             notifications: action.data.notifications || false,
             autoPublish: action.data.autoPublish || {
                 enabled: false,
-                price: 1.5,
+                priceInCents: 150,
                 currency: currencies[0]
             }
         };

--- a/packages/origin-ui-core/src/components/Account/AccountSettings.tsx
+++ b/packages/origin-ui-core/src/components/Account/AccountSettings.tsx
@@ -193,13 +193,13 @@ export function AccountSettings() {
                                         <div>
                                             <TextField
                                                 label="Price"
-                                                value={autoPublishCandidate.price}
+                                                value={autoPublishCandidate.priceInCents / 100}
                                                 type="number"
                                                 placeholder="1"
                                                 onChange={e =>
                                                     setAutoPublish({
                                                         ...autoPublishCandidate,
-                                                        price: parseFloat(e.target.value)
+                                                        priceInCents: parseFloat(e.target.value) * 100
                                                     })
                                                 }
                                                 id="priceInput"

--- a/packages/origin-ui-core/src/components/CertificateTable.tsx
+++ b/packages/origin-ui-core/src/components/CertificateTable.tsx
@@ -480,7 +480,7 @@ class CertificateTableClass extends PaginatedLoaderFilteredSorted<Props, ICertif
 
             const offChainProperties: Demand.IDemandOffChainProperties = {
                 timeFrame: TimeFrame.yearly,
-                maxPricePerMwh: 0,
+                maxPriceInCentsPerMwh: 0,
                 currency: currencies[0],
                 otherGreenAttributes: device.offChainProperties.otherGreenAttributes,
                 typeOfPublicSupport: device.offChainProperties.typeOfPublicSupport,

--- a/packages/origin-ui-core/src/components/Demand/DemandForm.tsx
+++ b/packages/origin-ui-core/src/components/Demand/DemandForm.tsx
@@ -114,7 +114,7 @@ export function DemandForm(props: IProps) {
                     demand.offChainProperties.energyPerTimeFrame
                 ).toString(),
                 maxPricePerMWh: Math.round(
-                    demand.offChainProperties.maxPricePerMwh / 100
+                    demand.offChainProperties.maxPriceInCentsPerMwh
                 ).toString(),
                 procureFromSingleFacility: demand.offChainProperties.procureFromSingleFacility,
                 timeframe: demand.offChainProperties.timeFrame,
@@ -192,7 +192,7 @@ export function DemandForm(props: IProps) {
             startTime: values.startDate.unix(),
             endTime: values.endDate.unix(),
             timeFrame: values.timeframe,
-            maxPricePerMwh: Math.round(parseFloat(values.maxPricePerMWh) * 100),
+            maxPriceInCentsPerMwh: parseFloat(values.maxPricePerMWh, 10) * 100,
             energyPerTimeFrame: EnergyFormatter.getBaseValueFromValueInDisplayUnit(
                 parseFloat(values.demandNeedsInDisplayUnit)
             ),

--- a/packages/origin-ui-core/src/components/Demand/DemandForm.tsx
+++ b/packages/origin-ui-core/src/components/Demand/DemandForm.tsx
@@ -192,7 +192,7 @@ export function DemandForm(props: IProps) {
             startTime: values.startDate.unix(),
             endTime: values.endDate.unix(),
             timeFrame: values.timeframe,
-            maxPriceInCentsPerMwh: parseFloat(values.maxPricePerMWh, 10) * 100,
+            maxPriceInCentsPerMwh: parseFloat(values.maxPricePerMWh) * 100,
             energyPerTimeFrame: EnergyFormatter.getBaseValueFromValueInDisplayUnit(
                 parseFloat(values.demandNeedsInDisplayUnit)
             ),

--- a/packages/origin-ui-core/src/components/Demand/DemandTable.tsx
+++ b/packages/origin-ui-core/src/components/Demand/DemandTable.tsx
@@ -301,7 +301,7 @@ class DemandTableClass extends PaginatedLoaderFiltered<Props, IDemandTableState>
                         ? `${demand.offChainProperties.vintage[0]} - ${demand.offChainProperties.vintage[1]}`
                         : NO_VALUE_TEXT,
                 demand: EnergyFormatter.format(demand.offChainProperties.energyPerTimeFrame),
-                max: `${(demand.offChainProperties.maxPricePerMwh / 100).toFixed(2)} ${
+                max: `${(demand.offChainProperties.maxPriceInCentsPerMwh / 100).toFixed(2)} ${
                     demand.offChainProperties.currency
                 }`,
                 status: demandStatus,

--- a/packages/origin-ui-core/src/components/Modal/PublishForSaleModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/PublishForSaleModal.tsx
@@ -95,7 +95,7 @@ export function PublishForSaleModal(props: IProps) {
 
         dispatch(setLoading(true));
         await certificate.publishForSale(
-            price,
+            price * 100,
             isErc20Sale ? erc20TokenAddress : currency,
             energyInBaseUnit
         );

--- a/packages/origin-ui-core/src/features/certificates/sagas.ts
+++ b/packages/origin-ui-core/src/features/certificates/sagas.ts
@@ -33,7 +33,7 @@ function areOffChainSettlementOptionsMissing(certificate: PurchasableCertificate
         certificate.acceptedToken === '0x0000000000000000000000000000000000000000' &&
         (!certificate.offChainProperties ||
             (certificate.offChainProperties.currency === NoneCurrency &&
-                certificate.offChainProperties.price === 0))
+                certificate.offChainProperties.priceInCents === 0))
     );
 }
 

--- a/packages/utils-general/package.json
+++ b/packages/utils-general/package.json
@@ -30,7 +30,7 @@
   "types": "dist/js/src/index.d.ts",
   "dependencies": {
     "@energyweb/origin-backend-client": "2.2.3",
-    "ew-utils-general-precise-proofs": "0.3.0",
+    "precise-proofs-js": "1.0.1",
     "jsonschema": "1.2.5",
     "moment": "^2.24.0",
     "web3": "1.2.4",

--- a/packages/utils-general/src/blockchain-facade/BlockchainDataModelEntity.ts
+++ b/packages/utils-general/src/blockchain-facade/BlockchainDataModelEntity.ts
@@ -1,5 +1,5 @@
 import * as Configuration from './Configuration';
-import { PreciseProofs } from 'ew-utils-general-precise-proofs';
+import { PreciseProofs } from 'precise-proofs-js';
 import { validateJson } from '../off-chain-data/json-validator';
 import { IOffChainData } from '@energyweb/origin-backend-client';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,11 +2108,6 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.7.tgz#1c8c25cbf6e59ffa7d6b9652c78e547d9a41692d"
   integrity sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==
 
-"@types/chai@^4.1.4":
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.5.tgz#f8da153ebbe30babb0adc9a528b9ad32be3175a2"
-  integrity sha512-YvbLiIc0DbbhiANrfVObdkLEHJksQZVq0Uvfg550SRAKVYaEJy+V70j65BVe2WNp6E3HtKsUczeijHFCjba3og==
-
 "@types/cheerio@*":
   version "0.22.14"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.14.tgz#d150889891e7db892c6a0b16bd5583cc70b3fc44"
@@ -2124,13 +2119,6 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
-"@types/colors@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@types/colors/-/colors-1.2.1.tgz#57703f1a9f7f5fc40afb81eef13e96acdd1016a6"
-  integrity sha512-7jNkpfN2lVO07nJ1RWzyMnNhH/I5N9iWuMPx9pedptxJ4MODf8rRV0lbJi6RakQ4sKQk231Fw4e2W9n3D7gZ3w==
-  dependencies:
-    colors "*"
 
 "@types/connect@*":
   version "3.4.32"
@@ -2170,14 +2158,6 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
-
-"@types/ethereumjs-util@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@types/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz#f49fe8114789ec0871721392c09318c3eb56671b"
-  integrity sha512-qwQgQqXXTRv2h2AlJef+tMEszLFkCB9dWnrJYIdAwqjubERXEc/geB+S3apRw0yQyTVnsBf8r6BhlrE8vx+3WQ==
-  dependencies:
-    "@types/bn.js" "*"
-    "@types/node" "*"
 
 "@types/events@*":
   version "3.0.0"
@@ -2320,7 +2300,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/mocha@5.2.7", "@types/mocha@^5.2.5":
+"@types/mocha@5.2.7":
   version "5.2.7"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
@@ -3823,6 +3803,22 @@ buffer@^5.0.5, buffer@^5.1.0, buffer@^5.2.1:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
+build@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/build/-/build-0.1.4.tgz#707fe026ffceddcacbfdcdf356eafda64f151046"
+  integrity sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=
+  dependencies:
+    cssmin "0.3.x"
+    jsmin "1.x"
+    jxLoader "*"
+    moo-server "*"
+    promised-io "*"
+    timespan "2.x"
+    uglify-js "1.x"
+    walker "1.x"
+    winston "*"
+    wrench "1.3.x"
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -4425,7 +4421,7 @@ colornames@^1.1.1:
   resolved "https://registry.yarnpkg.com/colornames/-/colornames-1.1.1.tgz#f8889030685c7c4ff9e2a559f5077eb76a816f96"
   integrity sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=
 
-colors@*, colors@^1.1.2, colors@^1.2.1, colors@^1.3.1:
+colors@^1.1.2, colors@^1.2.1, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -5020,6 +5016,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssmin@0.3.x:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/cssmin/-/cssmin-0.3.2.tgz#ddce4c547b510ae0d594a8f1fbf8aaf8e2c5c00d"
+  integrity sha1-3c5MVHtRCuDVlKjx+/iq+OLFwA0=
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@~0.3.6:
   version "0.3.8"
@@ -6289,19 +6290,6 @@ ethereumjs-util@6.1.0:
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
-ethereumjs-util@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz#3e0c0d1741471acf1036052d048623dee54ad642"
-  integrity sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==
-  dependencies:
-    bn.js "^4.11.0"
-    create-hash "^1.1.2"
-    ethjs-util "^0.1.3"
-    keccak "^1.0.2"
-    rlp "^2.0.0"
-    safe-buffer "^5.1.1"
-    secp256k1 "^3.0.1"
-
 ethereumjs-util@^6.0.0, ethereumjs-util@^6.1.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz#23ec79b2488a7d041242f01e25f24e5ad0357960"
@@ -6370,7 +6358,7 @@ ethjs-unit@0.1.6:
     bn.js "4.11.6"
     number-to-bn "1.7.0"
 
-ethjs-util@0.1.6, ethjs-util@^0.1.3:
+ethjs-util@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
   integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==
@@ -6434,20 +6422,6 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
-
-ew-utils-general-precise-proofs@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/ew-utils-general-precise-proofs/-/ew-utils-general-precise-proofs-0.3.0.tgz#3618ec00ea5d8413a192f3c6b572e1fc17fad7d8"
-  integrity sha512-eaVlRlIaN07ItzMxMv3+hDlSjaAkMVUx7xlZOKIoxWbcO65jVXSBojkX0WEmpQfFQeYwfomqIWVDPeMGOivx4w==
-  dependencies:
-    "@types/chai" "^4.1.4"
-    "@types/colors" "^1.2.1"
-    "@types/ethereumjs-util" "^5.2.0"
-    "@types/mocha" "^5.2.5"
-    colors "^1.3.1"
-    ethereumjs-util "^5.2.0"
-    treeify "^1.1.0"
-    typescript "^3.0.1"
 
 exec-sh@^0.3.2:
   version "0.3.4"
@@ -9340,6 +9314,11 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
+js-yaml@0.3.x:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-0.3.7.tgz#d739d8ee86461e54b354d6a7d7d1f2ad9a167f62"
+  integrity sha1-1znY7oZGHlSzVNan19HyrZoWf2I=
+
 js-yaml@3.13.1, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
@@ -9421,6 +9400,11 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+jsmin@1.x:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jsmin/-/jsmin-1.0.1.tgz#e7bd0dcd6496c3bf4863235bf461a3d98aa3b98c"
+  integrity sha1-570NzWSWw79IYyNb9GGj2YqjuYw=
 
 json-buffer@3.0.0:
   version "3.0.0"
@@ -9658,6 +9642,16 @@ jws@^3.1.5, jws@^3.2.2:
   dependencies:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
+
+jxLoader@*:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jxLoader/-/jxLoader-0.1.1.tgz#0134ea5144e533b594fc1ff25ff194e235c53ecd"
+  integrity sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=
+  dependencies:
+    js-yaml "0.3.x"
+    moo-server "1.3.x"
+    promised-io "*"
+    walker "1.x"
 
 keccak@^1.0.2:
   version "1.4.0"
@@ -10933,6 +10927,11 @@ moment@2.24.0, "moment@>= 2.9.0", moment@>=2.14.0, moment@^2.10.2, moment@^2.24.
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
+moo-server@*, moo-server@1.3.x:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/moo-server/-/moo-server-1.3.0.tgz#5dc79569565a10d6efed5439491e69d2392e58f1"
+  integrity sha1-XceVaVZaENbv7VQ5SR5p0jkuWPE=
 
 moo@^0.4.3:
   version "0.4.3"
@@ -12428,6 +12427,16 @@ postcss@^7.0.23:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+precise-proofs-js@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/precise-proofs-js/-/precise-proofs-js-1.0.1.tgz#4e8429ef5ceaf69e9d47a73cd9e9f9c07a0dcf0e"
+  integrity sha512-kcMPgKD7wLMYwqBPGekWmbNynlBhT6kXaW2RReddXPHHrxYHRifQUqPoE1oAzhYG4g5TBH5nB4pQa8+bJ+XVSA==
+  dependencies:
+    build "^0.1.4"
+    colors "^1.4.0"
+    treeify "^1.1.0"
+    web3 "1.2.4"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -12522,6 +12531,11 @@ promise@^7.1.1:
   integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
   dependencies:
     asap "~2.0.3"
+
+promised-io@*:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/promised-io/-/promised-io-0.3.5.tgz#4ad217bb3658bcaae9946b17a8668ecd851e1356"
+  integrity sha1-StIXuzZYvKrplGsXqGaOzYUeE1Y=
 
 prompts@^2.0.1:
   version "2.3.0"
@@ -14945,6 +14959,11 @@ timers-ext@^0.1.5, timers-ext@^0.1.7:
     es5-ext "~0.10.46"
     next-tick "1"
 
+timespan@2.x:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/timespan/-/timespan-2.3.0.tgz#4902ce040bd13d845c8f59b27e9d59bad6f39929"
+  integrity sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk=
+
 tiny-invariant@^1.0.2:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
@@ -15364,7 +15383,7 @@ typescript@3.7.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
-typescript@^3.0.1, typescript@^3.5.3:
+typescript@^3.5.3:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
   integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
@@ -15378,6 +15397,11 @@ ua-parser-js@^0.7.18:
   version "0.7.20"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
   integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
+
+uglify-js@1.x:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-1.3.5.tgz#4b5bfff9186effbaa888e4c9e94bd9fc4c94929d"
+  integrity sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=
 
 uglify-js@3.4.x:
   version "3.4.10"
@@ -15710,7 +15734,7 @@ wait-on@3.3.0:
     request "^2.88.0"
     rx "^4.1.0"
 
-walker@^1.0.7, walker@~1.0.5:
+walker@1.x, walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
@@ -16696,7 +16720,7 @@ winston-transport@^4.3.0:
     readable-stream "^2.3.6"
     triple-beam "^1.2.0"
 
-winston@3.2.1:
+winston@*, winston@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/winston/-/winston-3.2.1.tgz#63061377976c73584028be2490a1846055f77f07"
   integrity sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==
@@ -16773,6 +16797,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+wrench@1.3.x:
+  version "1.3.9"
+  resolved "https://registry.yarnpkg.com/wrench/-/wrench-1.3.9.tgz#6f13ec35145317eb292ca5f6531391b244111411"
+  integrity sha1-bxPsNRRTF+spLKX2UxORskQRFBE=
 
 write-file-atomic@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
- Use the new `precise-proofs-js` instead of `ew-utils-general-precise-proofs`
- Denote all prices in cents instead of decimal values*

`*` Note: Denoting the prices in decimals lead to issues with creating precise proofs because `web3.utils.soliditySha3` doesn't support decimals