### PR TITLE
Certificate Revoking

### DIFF
--- a/packages/issuer/src/blockchain-facade/Certificate.ts
+++ b/packages/issuer/src/blockchain-facade/Certificate.ts
@@ -179,6 +179,12 @@ export class Entity extends BlockchainDataModelEntity.Entity implements ICertifi
         );
     }
 
+    async revoke(): Promise<TransactionReceipt> {
+        const publicIssuer: PublicIssuer = this.configuration.blockchainProperties.issuerLogicInstance.public;
+        
+        return publicIssuer.revokeCertificate(Number(this.id), getAccountFromConfiguration(this.configuration));
+    }
+
     async getAllCertificateEvents(): Promise<EventLog[]> {
         return getAllCertificateEvents(parseInt(this.id, 10), this.configuration);
     }
@@ -244,7 +250,7 @@ export const createCertificate = async (
     const registry: Registry = configuration.blockchainProperties.certificateLogicInstance;
 
     const getIdFromLogs = (logs: any) => configuration.blockchainProperties.web3.utils
-        .hexToNumber(logs[1].topics[1])
+        .hexToNumber(logs[0].topics[2])
         .toString();
 
     if (isVolumePrivate) {
@@ -262,7 +268,7 @@ export const createCertificate = async (
         const publicIssuer: PublicIssuer = configuration.blockchainProperties.issuerLogicInstance.public
         const data = await publicIssuer.encodeIssue(fromTime, toTime, deviceId);
 
-        const { logs } = await registry.issue(to, [], PUBLIC_CERTIFICATE_TOPIC, value, data, getAccountFromConfiguration(configuration));
+        const { logs } = await publicIssuer.issue(to, value, data, getAccountFromConfiguration(configuration));
 
         certificate.id = getIdFromLogs(logs);
     }

--- a/packages/issuer/src/test/PublicIssuer.test.ts
+++ b/packages/issuer/src/test/PublicIssuer.test.ts
@@ -113,4 +113,39 @@ describe('PublicIssuer', () => {
         assert.equal(deviceOwnerBalance, volume);
     });
 
+    it('issuer revokes a certificate', async () => {
+        conf.blockchainProperties.activeUser = {
+            address: accountDeviceOwner,
+            privateKey: deviceOwnerPK
+        };
+
+        const now = moment();
+        const fromTime = now.subtract(30, 'day').unix();
+        const toTime = now.unix();
+        const deviceId = '1';
+
+        let requestIssue = await RequestIssue.createRequestIssue(fromTime, toTime, deviceId, conf);
+
+        conf.blockchainProperties.activeUser = {
+            address: issuerAccount,
+            privateKey: issuerPK
+        };
+
+        const volume = 1000;
+        const certificateId = await requestIssue.approve(accountDeviceOwner, volume);
+
+        requestIssue = await requestIssue.sync();
+
+        assert.isTrue(requestIssue.approved);
+        assert.isFalse(requestIssue.revoked);
+
+        await requestIssue.revoke();
+
+        requestIssue = await requestIssue.sync();
+        assert.isTrue(requestIssue.revoked);
+        
+        const deviceOwnerBalance = await registry.balanceOf(accountDeviceOwner, Number(certificateId));
+        assert.equal(deviceOwnerBalance, volume);
+    });
+
 });

--- a/packages/issuer/src/wrappedContracts/PrivateIssuer.ts
+++ b/packages/issuer/src/wrappedContracts/PrivateIssuer.ts
@@ -93,6 +93,15 @@ export class PrivateIssuer extends GeneralFunctions {
 
         return this.send(method, txParams);
     }
+
+    async revokeRequest(
+        _requestId: number,
+        txParams?: ISpecialTx
+    ) {
+        const method = this.web3Contract.methods.revokeRequest(_requestId);
+
+        return this.send(method, txParams);
+    }
     
     async version(txParams?: ISpecialTx) {
         return this.web3Contract.methods.version().call(txParams);

--- a/packages/issuer/src/wrappedContracts/PublicIssuer.ts
+++ b/packages/issuer/src/wrappedContracts/PublicIssuer.ts
@@ -65,7 +65,34 @@ export class PublicIssuer extends GeneralFunctions {
 
         return this.send(method, txParams);
     }
-    
+
+    async issue(
+        _to: string,
+        _value: number,
+        _data: any,
+        txParams?: ISpecialTx
+    ) {
+        const method = this.web3Contract.methods.issue(
+            _to,
+            _value,
+            _data
+        );
+
+        return this.send(method, txParams);
+    }
+
+    async revokeRequest(_requestId: number, txParams?: ISpecialTx) {
+        const method = this.web3Contract.methods.revokeRequest(_requestId);
+
+        return this.send(method, txParams);
+    }
+
+    async revokeCertificate(_certificateId: number, txParams?: ISpecialTx) {
+        const method = this.web3Contract.methods.revokeCertificate(_certificateId);
+
+        return this.send(method, txParams);
+    }
+
     async version(txParams?: ISpecialTx) {
         return this.web3Contract.methods.version().call(txParams);
     }


### PR DESCRIPTION
Changes:
- Enables revoking a certificate
- Disabled issuing a certificate without creating a `requestIssue` - made to unify the approach and store `revoked` boolean in the `requestIssue`
- Couple the certificate with the corresponding `requestIssue`
- Adds `Ownable` property to Issuers to make sure that only an issuer can approve/issue certificates
- Disable claiming revoked certificates