### PR TITLE
fix(issuer): double requesting for the same generation period

### DIFF
--- a/packages/issuer/src/blockchain-facade/Certificate.ts
+++ b/packages/issuer/src/blockchain-facade/Certificate.ts
@@ -13,7 +13,6 @@ export interface ICertificate {
     generationStartTime: number;
     generationEndTime: number;
 
-    energy: number;
     creationTime: number;
 
     sync(): Promise<ICertificate>;
@@ -24,6 +23,11 @@ export interface ICertificate {
     transfer(to: string, amount: number): Promise<TransactionReceipt>;
 
     getAllCertificateEvents(): Promise<EventLog[]>;
+
+    isOwned(): Promise<boolean>;
+    ownedVolume(): Promise<number>;
+    isClaimed(): Promise<boolean>;
+    claimedVolume(): Promise<number>;
 }
 
 const getAccountFromConfiguration = (configuration: Configuration.Entity) => ({

--- a/packages/issuer/src/test/Certificate.test.ts
+++ b/packages/issuer/src/test/Certificate.test.ts
@@ -36,6 +36,8 @@ describe('Cerificate tests', () => {
     const traderPK = '0xca77c9b06fde68bcbcc09f603c958620613f4be79f3abb4b2032131d0229462e';
     const accountTrader = web3.eth.accounts.privateKeyToAccount(traderPK).address;
 
+    let timestamp = moment().unix();
+
     const setActiveUser = (privateKey: string) => {
         conf.blockchainProperties.activeUser = {
             address: web3.eth.accounts.privateKeyToAccount(privateKey).address,
@@ -46,9 +48,8 @@ describe('Cerificate tests', () => {
     const issueCertificate = async (volume: number, isPrivate: boolean = false) => {
         setActiveUser(issuerPK);
 
-        const now = moment();
-        const generationStartTime = now.subtract(30, 'day').unix();
-        const generationEndTime = now.unix();
+        const generationStartTime = timestamp;
+        const generationEndTime = timestamp++;
         const deviceId = '1';
 
         return Certificate.createCertificate(
@@ -230,5 +231,41 @@ describe('Cerificate tests', () => {
         assert.isTrue(await certificate2.isClaimed());
         assert.equal(await certificate.claimedVolume(), totalVolume);
         assert.equal(await certificate2.claimedVolume(), totalVolume);
+    });
+
+    it('doesnt allow issuing the same certificate twice', async () => {
+        const totalVolume = 1e9;
+
+        setActiveUser(issuerPK);
+
+        const generationStartTime = timestamp;
+        const generationEndTime = timestamp++;
+        const deviceId = '1';
+
+        await Certificate.createCertificate(
+            accountDeviceOwner,
+            totalVolume,
+            generationStartTime,
+            generationEndTime,
+            deviceId,
+            conf
+        );
+
+        let failed = false;
+
+        try {
+            await Certificate.createCertificate(
+                accountDeviceOwner,
+                totalVolume,
+                generationStartTime,
+                generationEndTime,
+                deviceId,
+                conf
+            );
+        } catch (e) {
+            failed = true;
+        }
+
+        assert.isTrue(failed);
     });
 });


### PR DESCRIPTION
Fixes an issue where a user was able to request issuance of a certificate for which it has already been issued.