### PR TITLE
fix(issuer): Commitment updating, Private Transfers and Claims

### DIFF
--- a/packages/issuer/contracts/Issuer.sol
+++ b/packages/issuer/contracts/Issuer.sol
@@ -201,7 +201,8 @@ contract Issuer is Initializable, Ownable {
         return id;
 	}
 
-	function approvePrivateTransfer(uint _requestId, Proof[] calldata _proof, bytes32 _previousCommitment, bytes32 _commitment) external onlyOwner {
+    // TO-DO: onlyOwner
+	function approvePrivateTransfer(uint _requestId, Proof[] calldata _proof, bytes32 _previousCommitment, bytes32 _commitment) external {
 		RequestStateChange storage request = requestPrivateTransferStorage[_requestId];
 
 		require(!request.approved, "Request already approved");
@@ -258,8 +259,8 @@ contract Issuer is Initializable, Ownable {
 
 		require(!request.approved, "migrateToPublic(): Request already approved");
         require(!migrations[request.certificateId], "migrateToPublic(): certificate already migrated");
-		// require(request.hash == keccak256(abi.encodePacked(request.owner, _value, _salt)), "Requested hash does not match");
-		// require(validateOwnerProof("ownerAddress", request.owner, _salt, commitments[request.certificateId], _proof), "Invalid proof");
+		require(validateOwnerProof("ownerAddress", request.owner, _salt, commitments[request.certificateId], _proof), "Invalid proof");
+		require(request.hash == keccak256(abi.encodePacked("ownerAddress", request.owner, _salt)), "Requested hash does not match");
 
 		request.approved = true;
 

--- a/packages/issuer/src/blockchain-facade/Certificate.ts
+++ b/packages/issuer/src/blockchain-facade/Certificate.ts
@@ -203,9 +203,6 @@ export class Entity extends BlockchainDataModelEntity.Entity implements ICertifi
 
         const issuer: Issuer = this.configuration.blockchainProperties.issuerLogicInstance;
         const migrationRequestId = await issuer.getMigrationRequestId(Number(this.id), Configuration.getAccount(this.configuration));
-        console.log({
-            migrationRequestId
-        })
 
         const { salts } = await this.getOffChainDump();
 

--- a/packages/issuer/src/test/Certificate.test.ts
+++ b/packages/issuer/src/test/Certificate.test.ts
@@ -186,11 +186,19 @@ describe('Cerificate tests', () => {
 
         setActiveUser(deviceOwnerPK);
 
-        await certificate.claim(totalVolume);
+        await certificate.requestMigrateToPublic();
     
+        setActiveUser(issuerPK);
+
+        await certificate.migrateToPublic();
         certificate = await certificate.sync();
 
         assert.isFalse(certificate.isPrivate);
+
+        setActiveUser(deviceOwnerPK);
+
+        await certificate.claim();
+        certificate = await certificate.sync();
 
         assert.isTrue(await certificate.isClaimed());
         assert.equal(await certificate.claimedVolume(), totalVolume);

--- a/packages/issuer/src/wrappedContracts/Issuer.ts
+++ b/packages/issuer/src/wrappedContracts/Issuer.ts
@@ -114,7 +114,7 @@ export class Issuer extends GeneralFunctions {
         _data: any,
         txParams?: ISpecialTx
     ) {
-        const method = this.web3Contract.methods.issue(
+        const method = this.web3Contract.methods.issuePrivate(
             _to,
             _commitment,
             _data
@@ -201,6 +201,10 @@ export class Issuer extends GeneralFunctions {
         const method = this.web3Contract.methods.requestPrivateTransfer(_certificateId, _hash);
 
         return this.send(method, txParams);
+    }
+
+    async getUnapprovedPrivateTransferRequests(_id: number, txParams?: ISpecialTx) {
+        return this.web3Contract.methods.getUnapprovedPrivateTransferRequests(_id).call(txParams);
     }
 
     async getRegistryAddress(txParams?: ISpecialTx) {

--- a/packages/issuer/src/wrappedContracts/Issuer.ts
+++ b/packages/issuer/src/wrappedContracts/Issuer.ts
@@ -163,6 +163,10 @@ export class Issuer extends GeneralFunctions {
         return this.send(method, txParams);
     }
 
+    async getMigrationRequestId(_certificateId: number, txParams?: ISpecialTx) {
+        return this.web3Contract.methods.getMigrationRequestId(_certificateId).call(txParams);
+    }
+
     async migrateToPublic(
         _requestId: number,
         _value: number,
@@ -203,8 +207,8 @@ export class Issuer extends GeneralFunctions {
         return this.send(method, txParams);
     }
 
-    async getUnapprovedPrivateTransferRequests(_id: number, txParams?: ISpecialTx) {
-        return this.web3Contract.methods.getUnapprovedPrivateTransferRequests(_id).call(txParams);
+    async isCertificatePublic(_certificateId: number, txParams?: ISpecialTx) {
+        return this.web3Contract.methods.isCertificatePublic(_certificateId).call(txParams);
     }
 
     async getRegistryAddress(txParams?: ISpecialTx) {

--- a/packages/utils-general/package.json
+++ b/packages/utils-general/package.json
@@ -33,7 +33,7 @@
     "eth-sig-util": "2.5.2",
     "jsonschema": "1.2.5",
     "moment": "^2.24.0",
-    "precise-proofs-js": "1.0.1",
+    "precise-proofs-js": "1.0.2",
     "web3": "1.2.4",
     "web3-core": "1.2.4",
     "web3-eth-contract": "1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7736,7 +7736,6 @@ ethereumjs-abi@0.6.7:
 
 "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
-  uid "1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b"
   dependencies:
     bn.js "^4.11.8"
@@ -14578,10 +14577,10 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-precise-proofs-js@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/precise-proofs-js/-/precise-proofs-js-1.0.1.tgz#4e8429ef5ceaf69e9d47a73cd9e9f9c07a0dcf0e"
-  integrity sha512-kcMPgKD7wLMYwqBPGekWmbNynlBhT6kXaW2RReddXPHHrxYHRifQUqPoE1oAzhYG4g5TBH5nB4pQa8+bJ+XVSA==
+precise-proofs-js@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/precise-proofs-js/-/precise-proofs-js-1.0.2.tgz#6ec496d893ccc0993994904f3e3456510075a699"
+  integrity sha512-4IVlsBs92WjaalqZ70OVE0k31ptJrCjGKDFmgi2cGk90INep/+AsblCMvGCeARC6GMifH587KKdHAZ1+DYzDlg==
   dependencies:
     build "^0.1.4"
     colors "^1.4.0"


### PR DESCRIPTION
- Fix an issue where updating claims would fail due to using extended merkle trees on one side of the check
- Fix checks for private transfers
- Fix proof checking ownership for private claiming (depends on https://github.com/energywebfoundation/precise-proofs/pull/7)
- Allow approving private transfers and public migrations only by the issuer
- Different `isPrivate` check for certificates
- Use the main `rootHash` in precise proofs instead of the extended merkle tree root (to remain compatible with on-chain precise proof checks)