### PR TITLE
Fix/self trading

### DIFF
--- a/packages/exchange-core/src/Ask.ts
+++ b/packages/exchange-core/src/Ask.ts
@@ -12,9 +12,10 @@ export class Ask extends Order {
         volume: BN,
         product: Product,
         validFrom: Date,
-        status: OrderStatus
+        status: OrderStatus,
+        userId: string
     ) {
-        super(id, OrderSide.Ask, status, validFrom, product, price, volume);
+        super(id, OrderSide.Ask, status, validFrom, product, price, volume, userId);
 
         if (product.deviceType?.length !== 1) {
             throw new Error('Unable to create ask order. DeviceType has to be specified');
@@ -42,7 +43,15 @@ export class Ask extends Order {
     }
 
     public clone() {
-        return new Ask(this.id, this.price, this.volume, this.product, this.validFrom, this.status);
+        return new Ask(
+            this.id,
+            this.price,
+            this.volume,
+            this.product,
+            this.validFrom,
+            this.status,
+            this.userId
+        );
     }
 
     private hasMatchingDeviceType(product: Product, deviceService: IDeviceTypeService) {

--- a/packages/exchange-core/src/Bid.ts
+++ b/packages/exchange-core/src/Bid.ts
@@ -12,9 +12,10 @@ export class Bid extends Order {
         volume: BN,
         product: Product,
         validFrom: Date,
-        status: OrderStatus
+        status: OrderStatus,
+        userId: string
     ) {
-        super(id, OrderSide.Bid, status, validFrom, product, price, volume);
+        super(id, OrderSide.Bid, status, validFrom, product, price, volume, userId);
     }
 
     public filterBy(
@@ -42,7 +43,15 @@ export class Bid extends Order {
     }
 
     public clone() {
-        return new Bid(this.id, this.price, this.volume, this.product, this.validFrom, this.status);
+        return new Bid(
+            this.id,
+            this.price,
+            this.volume,
+            this.product,
+            this.validFrom,
+            this.status,
+            this.userId
+        );
     }
 
     private hasMatchingDeviceType(product: Product, deviceService: IDeviceTypeService) {

--- a/packages/exchange-core/src/MatchingEngine.ts
+++ b/packages/exchange-core/src/MatchingEngine.ts
@@ -128,8 +128,9 @@ export class MatchingEngine {
         this.asks.forEach(ask => {
             const isMatching = this.matches(bid, ask);
             const isFilled = bid.volume.isZero();
+            const isOwned = bid.userId === ask.userId;
 
-            if (!isMatching || isFilled) {
+            if (!isMatching || isFilled || isOwned) {
                 return false;
             }
 

--- a/packages/exchange-core/src/Order.ts
+++ b/packages/exchange-core/src/Order.ts
@@ -44,7 +44,8 @@ export abstract class Order implements IOrder {
         public readonly validFrom: Date,
         public readonly product: Product,
         public readonly price: number,
-        volume: BN
+        volume: BN,
+        public readonly userId: string
     ) {
         this._status = status;
         this._volume = volume;

--- a/packages/exchange-core/src/test/Matching.test.ts
+++ b/packages/exchange-core/src/test/Matching.test.ts
@@ -16,6 +16,7 @@ interface IOrderCreationArgs {
     product?: Product;
     price?: number;
     volume?: BN;
+    userId?: string;
 }
 
 interface ITestCase {
@@ -46,6 +47,8 @@ describe('Matching tests', () => {
     ]);
     const locationService = new LocationService();
 
+    const defaultBuyer = '1';
+    const defaultSeller = '2';
     const twoUSD = 2;
     const onekWh = new BN(1000);
     const twoKWh = new BN(2000);
@@ -81,7 +84,8 @@ describe('Matching tests', () => {
                 location: locationCentral
             },
             new Date(0),
-            OrderStatus.Active
+            OrderStatus.Active,
+            args?.userId || defaultSeller
         );
     };
 
@@ -96,7 +100,8 @@ describe('Matching tests', () => {
                 location: locationCentral
             },
             new Date(0),
-            OrderStatus.Active
+            OrderStatus.Active,
+            args?.userId || defaultBuyer
         );
     };
 
@@ -152,7 +157,7 @@ describe('Matching tests', () => {
         matchingEngine.tick();
 
         if (testCase.expectedTrades.length === 0) {
-            setTimeout(() => done(), 250);
+            setTimeout(() => done(), 100);
         }
     };
 
@@ -182,6 +187,15 @@ describe('Matching tests', () => {
             const expectedTrades = [
                 new Trade(bidsBefore[0], asksBefore[0], asksBefore[0].volume, asksBefore[0].price)
             ];
+
+            executeTestCase({ asksBefore, bidsBefore, expectedTrades }, done);
+        });
+
+        it('should not trade when owning both bid and ask', done => {
+            const asksBefore = [createAsk({ userId: defaultBuyer })];
+            const bidsBefore = [createBid({ userId: defaultBuyer })];
+
+            const expectedTrades: Trade[] = [];
 
             executeTestCase({ asksBefore, bidsBefore, expectedTrades }, done);
         });

--- a/packages/exchange/src/pods/matching-engine/matching-engine.service.ts
+++ b/packages/exchange/src/pods/matching-engine/matching-engine.service.ts
@@ -78,7 +78,8 @@ export class MatchingEngineService {
                   order.currentVolume,
                   ProductDTO.toProduct(order.product),
                   order.validFrom,
-                  order.status
+                  order.status,
+                  order.userId
               )
             : new Bid(
                   order.id,
@@ -86,7 +87,8 @@ export class MatchingEngineService {
                   order.currentVolume,
                   ProductDTO.toProduct(order.product),
                   order.validFrom,
-                  order.status
+                  order.status,
+                  order.userId
               );
     }
 }

--- a/packages/exchange/src/pods/order-book/order-book-order.dto.ts
+++ b/packages/exchange/src/pods/order-book/order-book-order.dto.ts
@@ -1,4 +1,4 @@
-import { Product } from '@energyweb/exchange-core';
+import { Product, Bid, Ask } from '@energyweb/exchange-core';
 
 export class OrderBookOrderDTO {
     price: number;
@@ -6,4 +6,14 @@ export class OrderBookOrderDTO {
     volume: string;
 
     product: Product;
+
+    userId: string;
+
+    public static fromOrder(order: Bid | Ask, userId?: string): OrderBookOrderDTO {
+        return {
+            ...order,
+            volume: order.volume.toString(10),
+            userId: order.userId === userId ? order.userId : undefined
+        };
+    }
 }

--- a/packages/exchange/src/pods/order-book/order-book.service.ts
+++ b/packages/exchange/src/pods/order-book/order-book.service.ts
@@ -1,26 +1,13 @@
-import { Product, Order } from '@energyweb/exchange-core';
+import { Product } from '@energyweb/exchange-core';
 import { Injectable } from '@nestjs/common';
 
 import { MatchingEngineService } from '../matching-engine/matching-engine.service';
-import { OrderBookOrderDTO } from './order-book-order.dto';
 
 @Injectable()
 export class OrderBookService {
     constructor(private readonly matchingEngineService: MatchingEngineService) {}
 
-    public getByProduct(
-        product: Product
-    ): { asks: OrderBookOrderDTO[]; bids: OrderBookOrderDTO[] } {
-        const { asks, bids } = this.matchingEngineService.query(product);
-        const toOrderBookOrderDTO = (order: Order) => ({
-            price: order.price,
-            volume: order.volume.toString(10),
-            product: order.product
-        });
-
-        return {
-            asks: asks.map(ask => toOrderBookOrderDTO(ask)).toArray(),
-            bids: bids.map(bid => toOrderBookOrderDTO(bid)).toArray()
-        };
+    public getByProduct(product: Product) {
+        return this.matchingEngineService.query(product);
     }
 }


### PR DESCRIPTION
This PR provides the fix for self-trading on matching engine as well as additional userId field when querying `orderbook` endpoint. 

UserId will be returned only with user's owned orders when authenticated. UserId is not returned for non-authenticated users.  