### PR TITLE
Orders API, DB re-design

### DIFF
--- a/packages/exchange/src/app.service.ts
+++ b/packages/exchange/src/app.service.ts
@@ -15,12 +15,12 @@ export class AppService {
         private readonly withdrawalProcessorService: WithdrawalProcessorService
     ) {}
 
-    public async init() {
+    public async init(deviceTypes: string[][]) {
         this.logger.log('Initializing matching engine');
 
         const orders = await this.ordersService.getAllActiveOrders();
 
-        this.matchingEngineService.init(orders);
+        this.matchingEngineService.init(orders, deviceTypes);
 
         await this.depositWatcherService.init();
 

--- a/packages/exchange/src/pods/demand/demand.dto.ts
+++ b/packages/exchange/src/pods/demand/demand.dto.ts
@@ -1,0 +1,48 @@
+import { ProductDTO } from '../order/product.dto';
+import { OrderDTO } from '../order/order.dto';
+import { Demand } from './demand.entity';
+import { Order } from '../order/order.entity';
+
+export class DemandDTO {
+    id: string;
+
+    price: number;
+
+    start: string;
+
+    volumePerPeriod: string;
+
+    periods: number;
+
+    timeFrame: number;
+
+    product: ProductDTO;
+
+    bids: OrderDTO[];
+
+    public static fromDemand(demand: Demand): DemandDTO {
+        return {
+            id: demand.id,
+            price: demand.price,
+            start: demand.start.toISOString(),
+            volumePerPeriod: demand.volumePerPeriod.toString(10),
+            periods: demand.periods,
+            timeFrame: demand.timeFrame,
+            product: demand.product,
+            bids: demand.bids.map(
+                (bid: Order): OrderDTO => ({
+                    id: bid.id,
+                    userId: bid.userId,
+                    status: bid.status,
+                    startVolume: bid.startVolume.toString(10),
+                    currentVolume: bid.currentVolume.toString(10),
+                    asset: bid.asset,
+                    price: bid.price,
+                    product: bid.product,
+                    side: bid.side,
+                    validFrom: bid.validFrom.toISOString()
+                })
+            )
+        };
+    }
+}

--- a/packages/exchange/src/pods/demand/demand.dto.ts
+++ b/packages/exchange/src/pods/demand/demand.dto.ts
@@ -40,7 +40,8 @@ export class DemandDTO {
                     price: bid.price,
                     product: bid.product,
                     side: bid.side,
-                    validFrom: bid.validFrom.toISOString()
+                    validFrom: bid.validFrom.toISOString(),
+                    demandId: demand.id
                 })
             )
         };

--- a/packages/exchange/src/pods/demand/demand.entity.ts
+++ b/packages/exchange/src/pods/demand/demand.entity.ts
@@ -3,8 +3,7 @@ import {
     BaseEntity,
     Column,
     Entity,
-    JoinTable,
-    ManyToMany,
+    OneToMany,
     PrimaryGeneratedColumn,
     UpdateDateColumn
 } from 'typeorm';
@@ -12,7 +11,6 @@ import {
 import { BNTransformer } from '../../utils/valueTransformers';
 import { Order } from '../order/order.entity';
 import { ProductDTO } from '../order/product.dto';
-import { Trade } from '../trade/trade.entity';
 
 @Entity()
 export class Demand extends BaseEntity {
@@ -41,16 +39,12 @@ export class Demand extends BaseEntity {
     @Column('json')
     product: ProductDTO;
 
-    @ManyToMany(() => Order, {
-        eager: true
-    })
-    @JoinTable()
+    @OneToMany(
+        () => Order,
+        order => order.demand,
+        {
+            eager: true
+        }
+    )
     bids: Order[];
-
-    @ManyToMany(() => Trade, {
-        eager: true,
-        cascade: true
-    })
-    @JoinTable()
-    trades: Trade[];
 }

--- a/packages/exchange/src/pods/order/create-ask.dto.ts
+++ b/packages/exchange/src/pods/order/create-ask.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsUUID, IsPositive, Validate, IsNotEmpty, IsDateString } from 'class-validator';
+import { IsInt, IsUUID, IsPositive, Validate, IsDateString } from 'class-validator';
 import { BNStringValidator } from '../../utils/bnStringValidator';
 
 export class CreateAskDTO {
@@ -11,9 +11,6 @@ export class CreateAskDTO {
 
     @IsDateString()
     readonly validFrom: string;
-
-    @IsNotEmpty()
-    readonly userId: string;
 
     @IsUUID()
     readonly assetId: string;

--- a/packages/exchange/src/pods/order/create-bid.dto.ts
+++ b/packages/exchange/src/pods/order/create-bid.dto.ts
@@ -1,11 +1,4 @@
-import {
-    IsInt,
-    IsNotEmpty,
-    IsPositive,
-    Validate,
-    ValidateNested,
-    IsDateString
-} from 'class-validator';
+import { IsInt, IsPositive, Validate, ValidateNested, IsDateString } from 'class-validator';
 
 import { BNStringValidator } from '../../utils/bnStringValidator';
 import { ProductDTO } from './product.dto';
@@ -23,7 +16,4 @@ export class CreateBidDTO {
 
     @ValidateNested()
     readonly product: ProductDTO;
-
-    @IsNotEmpty()
-    readonly userId: string;
 }

--- a/packages/exchange/src/pods/order/order.dto.ts
+++ b/packages/exchange/src/pods/order/order.dto.ts
@@ -1,0 +1,38 @@
+import { OrderStatus, OrderSide } from '@energyweb/exchange-core';
+import { ProductDTO } from './product.dto';
+import { Asset } from '../asset/asset.entity';
+import { Order } from './order.entity';
+
+export class OrderDTO {
+    id: string;
+
+    userId: string;
+
+    status: OrderStatus;
+
+    startVolume: string;
+
+    currentVolume: string;
+
+    side: OrderSide;
+
+    price: number;
+
+    validFrom: string;
+
+    product: ProductDTO;
+
+    asset: Asset;
+
+    demandId: string;
+
+    public static fromOrder(order: Order): OrderDTO {
+        return {
+            ...order,
+            startVolume: order.startVolume.toString(10),
+            currentVolume: order.currentVolume.toString(10),
+            validFrom: order.validFrom.toISOString(),
+            demandId: order.demandId
+        };
+    }
+}

--- a/packages/exchange/src/pods/order/order.service.ts
+++ b/packages/exchange/src/pods/order/order.service.ts
@@ -1,18 +1,21 @@
-import { OrderStatus, OrderSide } from '@energyweb/exchange-core';
-import { Injectable, Inject, forwardRef } from '@nestjs/common';
+import { OrderSide, OrderStatus } from '@energyweb/exchange-core';
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import BN from 'bn.js';
 import { Repository } from 'typeorm';
 
+import { AccountBalanceService } from '../account-balance/account-balance.service';
+import { AssetService } from '../asset/asset.service';
 import { MatchingEngineService } from '../matching-engine/matching-engine.service';
+import { ProductService } from '../product/product.service';
+import { CreateAskDTO } from './create-ask.dto';
 import { CreateBidDTO } from './create-bid.dto';
 import { Order } from './order.entity';
-import { CreateAskDTO } from './create-ask.dto';
-import { ProductService } from '../product/product.service';
-import { AssetService } from '../asset/asset.service';
-import { AccountBalanceService } from '../account-balance/account-balance.service';
 
 @Injectable()
 export class OrderService {
+    private readonly logger = new Logger(OrderService.name);
+
     constructor(
         @InjectRepository(Order, 'ExchangeConnection')
         private readonly repository: Repository<Order>,
@@ -23,21 +26,49 @@ export class OrderService {
         private readonly assetService: AssetService
     ) {}
 
-    public async createBid(bid: CreateBidDTO) {
+    public async createBid(userId: string, bid: CreateBidDTO): Promise<Order> {
+        this.logger.debug(`Requested bid creation for user:${userId} bid:${JSON.stringify(bid)}`);
+
         return this.repository.save({
-            ...bid,
+            userId,
             validFrom: new Date(bid.validFrom),
             side: OrderSide.Bid,
             status: OrderStatus.Active,
-            startVolume: bid.volume,
-            currentVolume: bid.volume
+            startVolume: new BN(bid.volume),
+            currentVolume: new BN(bid.volume),
+            price: bid.price,
+            product: bid.product
         });
     }
 
-    public async createAsk(ask: CreateAskDTO) {
+    public async createDemandBid(
+        userId: string,
+        bid: CreateBidDTO,
+        demandId: string
+    ): Promise<Order> {
+        this.logger.debug(
+            `Requested demand bid creation for user:${userId} bid:${JSON.stringify(bid)}`
+        );
+
+        return this.repository.save({
+            userId,
+            validFrom: new Date(bid.validFrom),
+            side: OrderSide.Bid,
+            status: OrderStatus.Active,
+            startVolume: new BN(bid.volume),
+            currentVolume: new BN(bid.volume),
+            price: bid.price,
+            product: bid.product,
+            demand: { id: demandId }
+        });
+    }
+
+    public async createAsk(userId: string, ask: CreateAskDTO): Promise<Order> {
+        this.logger.debug(`Requested ask creation for user:${userId} ask:${JSON.stringify(ask)}`);
+
         if (
             !(await this.accountBalanceService.hasEnoughAssetAmount(
-                ask.userId,
+                userId,
                 ask.assetId,
                 ask.volume.toString()
             ))
@@ -46,22 +77,31 @@ export class OrderService {
         }
 
         const { deviceId } = await this.assetService.get(ask.assetId);
-        const product = await this.productService.getProduct(deviceId);
+        const product = this.productService.getProduct(deviceId);
 
         return this.repository.save({
-            ...ask,
+            userId,
             validFrom: new Date(ask.validFrom),
             product,
             side: OrderSide.Ask,
             status: OrderStatus.Active,
-            startVolume: ask.volume,
-            currentVolume: ask.volume,
-            asset: { id: ask.assetId }
+            startVolume: new BN(ask.volume),
+            currentVolume: new BN(ask.volume),
+            asset: { id: ask.assetId },
+            price: ask.price
         });
     }
 
     public async submit(order: Order) {
+        this.logger.debug(`Submitting order:${JSON.stringify(order)}`);
+
         this.matchingEngineService.submit(order);
+    }
+
+    public async getAllOrders(userId: string) {
+        return this.repository.find({
+            where: { userId }
+        });
     }
 
     public async getAllActiveOrders() {

--- a/packages/exchange/src/pods/order/product.dto.ts
+++ b/packages/exchange/src/pods/order/product.dto.ts
@@ -17,11 +17,11 @@ export class ProductDTO {
     @ValidateNested()
     public deviceVintage?: DeviceVintageDTO;
 
-    public static toProduct(product: ProductDTO): Product {
+    public static toProduct(dto: ProductDTO): Product {
         return {
-            ...product,
-            deviceVintage: product.deviceVintage
-                ? new DeviceVintage(product.deviceVintage.year, product.deviceVintage.operator)
+            ...dto,
+            deviceVintage: dto.deviceVintage
+                ? new DeviceVintage(dto.deviceVintage.year, dto.deviceVintage.operator)
                 : null
         };
     }

--- a/packages/exchange/src/pods/product/product.service.ts
+++ b/packages/exchange/src/pods/product/product.service.ts
@@ -5,10 +5,11 @@ import { ProductDTO } from '../order/product.dto';
 export class ProductService {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public getProduct(deviceId: string): ProductDTO {
-        return {
-            deviceType: ['Solar;Photovoltaic;Classic silicon'],
-            location: ['Thailand;Central;Nakhon Pathom'],
-            deviceVintage: { year: 2016 }
-        };
+        const product = new ProductDTO();
+        product.deviceType = ['Solar;Photovoltaic;Classic silicon'];
+        product.location = ['Thailand;Central;Nakhon Pathom'];
+        product.deviceVintage = { year: 2016 };
+
+        return product;
     }
 }

--- a/packages/exchange/src/utils/valueTransformers.ts
+++ b/packages/exchange/src/utils/valueTransformers.ts
@@ -2,6 +2,6 @@ import { ValueTransformer } from 'typeorm';
 import BN from 'bn.js';
 
 export const BNTransformer: ValueTransformer = {
-    to: (entityValue: BN) => entityValue.toString(10),
+    to: (entityValue: BN) => entityValue?.toString(10),
     from: (databaseValue: string): BN => new BN(databaseValue)
 };

--- a/packages/exchange/test/app.e2e-spec.ts
+++ b/packages/exchange/test/app.e2e-spec.ts
@@ -29,7 +29,7 @@ import { TransferDirection } from '../src/pods/transfer/transfer-direction';
 import { Transfer } from '../src/pods/transfer/transfer.entity';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
-import { OrderDTO } from 'src/pods/order/order.dto';
+import { OrderDTO } from '../src/pods/order/order.dto';
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 

--- a/packages/exchange/test/app.e2e-spec.ts
+++ b/packages/exchange/test/app.e2e-spec.ts
@@ -1,5 +1,11 @@
 import { Contracts } from '@energyweb/issuer';
-import { CanActivate, ExecutionContext, INestApplication, ValidationPipe } from '@nestjs/common';
+import {
+    CanActivate,
+    ExecutionContext,
+    INestApplication,
+    Logger,
+    ValidationPipe
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AuthGuard } from '@nestjs/passport';
 import { Test } from '@nestjs/testing';
@@ -12,14 +18,18 @@ import { EmptyResultInterceptor } from '../src/empty-result.interceptor';
 import { Account } from '../src/pods/account/account';
 import { AccountDTO } from '../src/pods/account/account.dto';
 import { AccountService } from '../src/pods/account/account.service';
-import { AssetDTO } from '../src/pods/asset/asset.dto';
+import { DemandService } from '../src/pods/demand/demand.service';
 import { CreateAskDTO } from '../src/pods/order/create-ask.dto';
 import { Order } from '../src/pods/order/order.entity';
+import { OrderService } from '../src/pods/order/order.service';
+import { ProductService } from '../src/pods/product/product.service';
+import { TradeDTO } from '../src/pods/trade/trade.dto';
 import { RequestWithdrawalDTO } from '../src/pods/transfer/create-withdrawal.dto';
 import { TransferDirection } from '../src/pods/transfer/transfer-direction';
 import { Transfer } from '../src/pods/transfer/transfer.entity';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
+import { OrderDTO } from 'src/pods/order/order.dto';
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -28,11 +38,13 @@ describe('AppController (e2e)', () => {
     let transferService: TransferService;
     let databaseService: DatabaseService;
     let accountService: AccountService;
+    let demandService: DemandService;
+    let orderService: OrderService;
+    let productService: ProductService;
 
     const user1Id = '1';
-    let user1Address: string;
+    const dummyAsset = { address: '0x9876', tokenId: '0', deviceId: '0' };
 
-    const asset1Address = '0x9876';
     const transactionHash = `0x${((Math.random() * 0xffffff) << 0).toString(16)}`;
     const withdrawalAddress = ethers.Wallet.createRandom().address;
 
@@ -43,9 +55,9 @@ describe('AppController (e2e)', () => {
 
     let registry: Contract;
 
-    const createDeposit = (amount: string, asset: AssetDTO) => {
+    const createDeposit = (address: string, amount = '1000', asset = dummyAsset) => {
         return transferService.createDeposit({
-            address: user1Address,
+            address,
             transactionHash,
             amount,
             asset
@@ -79,7 +91,25 @@ describe('AppController (e2e)', () => {
         }
     };
 
-    beforeAll(async () => {
+    const testLogger = new Logger('e2e');
+
+    const deviceTypes = [
+        ['Solar'],
+        ['Solar', 'Photovoltaic'],
+        ['Solar', 'Photovoltaic', 'Roof mounted'],
+        ['Solar', 'Photovoltaic', 'Ground mounted'],
+        ['Solar', 'Photovoltaic', 'Classic silicon'],
+        ['Solar', 'Concentration'],
+        ['Wind'],
+        ['Wind', 'Onshore'],
+        ['Wind', 'Offshore'],
+        ['Marine'],
+        ['Marine', 'Tidal'],
+        ['Marine', 'Tidal', 'Inshore'],
+        ['Marine', 'Tidal', 'Offshore']
+    ];
+
+    beforeEach(async () => {
         registry = await deployRegistry();
 
         const configService = new ConfigService({
@@ -109,20 +139,23 @@ describe('AppController (e2e)', () => {
         transferService = await app.resolve<TransferService>(TransferService);
         accountService = await app.resolve<AccountService>(AccountService);
         databaseService = await app.resolve<DatabaseService>(DatabaseService);
+        demandService = await app.resolve<DemandService>(DemandService);
+        orderService = await app.resolve<OrderService>(OrderService);
+        productService = await app.resolve<ProductService>(ProductService);
 
         const appService = await app.resolve<AppService>(AppService);
-        await appService.init();
+        await appService.init(deviceTypes);
 
         app.useGlobalInterceptors(new EmptyResultInterceptor());
         app.useGlobalPipes(new ValidationPipe());
+        app.useLogger(testLogger);
 
         await app.init();
     });
 
     describe('account deposit confirmation', () => {
-        const amount = '1000';
-        const tokenId = '0';
-        const asset = { address: asset1Address, tokenId, deviceId: tokenId };
+        let user1Address: string;
+        const amount = '100';
 
         beforeEach(async () => {
             const { address } = await accountService.getOrCreateAccount(user1Id);
@@ -130,7 +163,7 @@ describe('AppController (e2e)', () => {
         });
 
         it('should not list unconfirmed deposit', async () => {
-            await createDeposit(amount, asset);
+            await createDeposit(user1Address, amount);
 
             await request(app.getHttpServer())
                 .get('/account')
@@ -144,7 +177,7 @@ describe('AppController (e2e)', () => {
         });
 
         it('should list confirmed deposit', async () => {
-            await createDeposit(amount, asset);
+            await createDeposit(user1Address, amount);
             await confirmDeposit();
 
             await request(app.getHttpServer())
@@ -156,35 +189,32 @@ describe('AppController (e2e)', () => {
                     expect(account.address).toBe(user1Address);
                     expect(account.balances.available.length).toBe(1);
                     expect(account.balances.available[0].amount).toEqual(amount);
-                    expect(account.balances.available[0].asset).toMatchObject(asset);
+                    expect(account.balances.available[0].asset).toMatchObject(dummyAsset);
                 });
         });
     });
 
     describe('account ask order send', () => {
-        const amount = '1000';
-        const tokenId = '0';
-        const asset = { address: asset1Address, tokenId, deviceId: tokenId };
-
         let deposit: Transfer;
+        let user1Address: string;
+        const amount = '1000';
 
         beforeEach(async () => {
             const { address } = await accountService.getOrCreateAccount(user1Id);
             user1Address = address;
-            deposit = await createDeposit(amount, asset);
+            deposit = await createDeposit(address);
         });
 
         it('should not be able to create ask order on unconfirmed deposit', async () => {
             const createAsk: CreateAskDTO = {
                 assetId: deposit.asset.id,
-                userId: user1Id,
                 volume: '100',
                 price: 100,
                 validFrom: new Date().toISOString()
             };
 
             await request(app.getHttpServer())
-                .post('/order/ask')
+                .post('/orders/ask')
                 .send(createAsk)
                 .expect(403);
         });
@@ -194,14 +224,13 @@ describe('AppController (e2e)', () => {
 
             const createAsk: CreateAskDTO = {
                 assetId: deposit.asset.id,
-                userId: user1Id,
                 volume: '100',
                 price: 100,
                 validFrom: new Date().toISOString()
             };
 
             await request(app.getHttpServer())
-                .post('/order/ask')
+                .post('/orders/ask')
                 .send(createAsk)
                 .expect(201)
                 .expect(res => {
@@ -217,14 +246,13 @@ describe('AppController (e2e)', () => {
 
             const createAsk: CreateAskDTO = {
                 assetId: deposit.asset.id,
-                userId: user1Id,
                 volume: '1001',
                 price: 100,
                 validFrom: new Date().toISOString()
             };
 
             await request(app.getHttpServer())
-                .post('/order/ask')
+                .post('/orders/ask')
                 .send(createAsk)
                 .expect(403);
         });
@@ -234,19 +262,18 @@ describe('AppController (e2e)', () => {
 
             const createAsk: CreateAskDTO = {
                 assetId: deposit.asset.id,
-                userId: user1Id,
                 volume: '1000',
                 price: 100,
                 validFrom: new Date().toISOString()
             };
 
             await request(app.getHttpServer())
-                .post('/order/ask')
+                .post('/orders/ask')
                 .send(createAsk)
                 .expect(201);
 
             await request(app.getHttpServer())
-                .post('/order/ask')
+                .post('/orders/ask')
                 .send(createAsk)
                 .expect(403);
         });
@@ -289,7 +316,7 @@ describe('AppController (e2e)', () => {
                     expect(account.address).toBe(user1Address);
                     expect(account.balances.available.length).toBe(1);
                     expect(account.balances.available[0].amount).toEqual('0');
-                    expect(account.balances.available[0].asset).toMatchObject(asset);
+                    expect(account.balances.available[0].asset).toMatchObject(dummyAsset);
                 });
         });
     });
@@ -328,12 +355,14 @@ describe('AppController (e2e)', () => {
         });
 
         it('should discover token deposit', async () => {
+            jest.setTimeout(10000);
+
             const depositAmount = '10';
 
             await issueToken(tokenReceiver.address, '1000');
             await depositToken(depositAddress, depositAmount);
 
-            await sleep(3000);
+            await sleep(5000);
 
             await request(app.getHttpServer())
                 .get('/transfer/all')
@@ -351,11 +380,9 @@ describe('AppController (e2e)', () => {
         });
 
         it('should withdraw to requested address', async () => {
-            jest.setTimeout(10000);
+            jest.setTimeout(15000);
 
             const withdrawalAmount = '5';
-            // ganache account 10
-            const withdrawalAddress = '0x6cc53915DBec95A66deb7c709C800cAc40eE55f9';
             const startBalance = (await registry.functions.balanceOf(
                 withdrawalAddress,
                 1
@@ -363,9 +390,10 @@ describe('AppController (e2e)', () => {
 
             const depositAmount = '10';
 
+            await issueToken(tokenReceiver.address, '1000');
             await depositToken(depositAddress, depositAmount);
 
-            await sleep(3000);
+            await sleep(5000);
 
             const res = await request(app.getHttpServer()).get('/transfer/all');
             const [deposit] = res.body as Transfer[];
@@ -395,15 +423,74 @@ describe('AppController (e2e)', () => {
         });
     });
 
+    describe('Demand orders trading', () => {
+        jest.setTimeout(10000);
+
+        const demandOwner = '1';
+        const sellerId = '2';
+        let sellerAddress: string;
+
+        beforeEach(async () => {
+            const { address } = await accountService.getOrCreateAccount(sellerId);
+            sellerAddress = address;
+        });
+        it('should trade the bid from the demand', async () => {
+            const validFrom = new Date();
+
+            const deposit = await createDeposit(sellerAddress);
+            await confirmDeposit();
+
+            const askOrder = await orderService.createAsk(sellerId, {
+                assetId: deposit.asset.id,
+                volume: '500',
+                price: 1000,
+                validFrom: validFrom.toISOString()
+            });
+            await orderService.submit(askOrder);
+
+            const product = productService.getProduct('deviceId');
+
+            const demand = await demandService.createSingle(
+                demandOwner,
+                1000,
+                '250',
+                product,
+                validFrom
+            );
+
+            await sleep(5000);
+
+            await request(app.getHttpServer())
+                .get(`/trade`)
+                .expect(200)
+                .expect(res => {
+                    const trades = res.body as TradeDTO[];
+
+                    expect(trades).toBeDefined();
+                    expect(trades).toHaveLength(1);
+                    expect(trades[0].askId).toBeUndefined(); // as a buyer, I should not see the askId
+                    expect(trades[0].bidId).toBe(demand.bids[0].id);
+                });
+
+            await request(app.getHttpServer())
+                .get(`/orders`)
+                .expect(200)
+                .expect(res => {
+                    const orders = res.body as OrderDTO[];
+
+                    expect(orders).toBeDefined();
+                    expect(orders).toHaveLength(1);
+                    expect(orders[0].demandId).toBe(demand.id);
+                });
+        });
+    });
+
     afterEach(async () => {
         try {
             await databaseService.cleanUp();
         } catch (error) {
             console.error(error);
         }
-    });
-
-    afterAll(async () => {
         try {
             await app.close();
         } catch (error) {


### PR DESCRIPTION
This PR provides:
- deviceTypes initialization
- /orders/ API to fetch all users orders
- re-designed trade, demand, order relations for more performance queries
- trading related e2e tests
- DTO objects refactoring
- fix for MatchingEngine where it was possible send multiple triggers at once