### PR TITLE
chore: add ability to run exchange test

### DIFF
--- a/packages/exchange/bin/exchange
+++ b/packages/exchange/bin/exchange
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../dist/js/src/main-dev.js');

--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -91,5 +91,8 @@
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org"
+    },
+    "bin": {
+        "exchange": "./bin/exchange"
     }
 }

--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -15,7 +15,7 @@ import { ProductService } from '../src/pods/product/product.service';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
 
-const web3 = 'http://localhost:8580';
+const web3 = process.env.EXCHANGE_TEST_PROVIDER || 'http://localhost:8580';
 
 // ganache account 2
 const registryDeployer = '0xc4b87d68ea2b91f9d3de3fcb77c299ad962f006ffb8711900cb93d94afec3dc3';


### PR DESCRIPTION
This is a prerequisite for starting test instance of an exchange via external package which depends upon `@energyweb/exchange`.