### PR TITLE
[feat] Add health check endpoint

### DIFF
--- a/packages/origin-backend/src/app.module.ts
+++ b/packages/origin-backend/src/app.module.ts
@@ -27,6 +27,7 @@ import { OrganizationInvitation } from './pods/organization/organizationInvitati
 import { User } from './pods/user/user.entity';
 import { UserModule } from './pods/user/user.module';
 import { ISmartMeterReadingsAdapter } from '@energyweb/origin-backend-core';
+import { StatusModule } from './pods/status/status.module';
 
 const ENV_FILE_PATH = path.resolve(__dirname, '../../../../../.env');
 
@@ -60,6 +61,7 @@ export class AppModule {
                 FileModule,
                 UserModule,
                 ConfigurationModule,
+                StatusModule,
                 JsonEntityModule,
                 OrganizationModule,
                 DeviceModule.register(smartMeterReadingsAdapter),

--- a/packages/origin-backend/src/pods/status/status.controller.ts
+++ b/packages/origin-backend/src/pods/status/status.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('status')
+export class StatusController {
+    @Get()
+    async get() {
+        return { status: 'OK'};
+    }
+}

--- a/packages/origin-backend/src/pods/status/status.module.ts
+++ b/packages/origin-backend/src/pods/status/status.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+import { StatusController } from './status.controller';
+
+@Module({
+    controllers: [StatusController]
+})
+export class StatusModule {}


### PR DESCRIPTION
This PR introduces a new endpoint for health checking if service is up and running, `/api/status`.