### PR TITLE
Direct asks matching by providing askId

### DIFF
--- a/packages/exchange-core/src/DirectBuy.ts
+++ b/packages/exchange-core/src/DirectBuy.ts
@@ -1,0 +1,15 @@
+import BN from 'bn.js';
+import { Bid } from './Bid';
+import { OrderStatus } from './Order';
+
+export class DirectBuy extends Bid {
+    constructor(
+        id: string,
+        userId: string,
+        price: number,
+        volume: BN,
+        public readonly askId: string
+    ) {
+        super(id, price, volume, null, new Date(), OrderStatus.Active, userId);
+    }
+}

--- a/packages/exchange-core/src/MatchingEngine.ts
+++ b/packages/exchange-core/src/MatchingEngine.ts
@@ -100,10 +100,14 @@ export class MatchingEngine {
         actions.forEach(action => {
             switch (action.kind) {
                 case ActionKind.AddOrder: {
-                    const order = action.value as Order;
+                    try {
+                        const order = action.value as Order;
 
-                    this.insertOrder(order);
-                    trades = trades.concat(this.match());
+                        this.insertOrder(order);
+                        trades = trades.concat(this.match());
+                    } catch (error) {
+                        console.log(error);
+                    }
                     break;
                 }
                 case ActionKind.CancelOrder: {
@@ -195,15 +199,9 @@ export class MatchingEngine {
 
         this.bids.forEach(bid => {
             const executed = this.generateTrades(bid);
-            if (executed.isEmpty()) {
-                return true;
-            }
-
             this.updateOrderBook(executed);
 
             executedTrades = executedTrades.concat(executed);
-
-            return true;
         });
 
         return executedTrades;

--- a/packages/exchange-core/src/Order.ts
+++ b/packages/exchange-core/src/Order.ts
@@ -11,7 +11,8 @@ export enum OrderStatus {
     Active,
     Cancelled,
     Filled,
-    PartiallyFilled
+    PartiallyFilled,
+    PendingCancellation
 }
 
 export interface IOrder {

--- a/packages/exchange-core/src/Order.ts
+++ b/packages/exchange-core/src/Order.ts
@@ -12,7 +12,8 @@ export enum OrderStatus {
     Cancelled,
     Filled,
     PartiallyFilled,
-    PendingCancellation
+    PendingCancellation,
+    NotExecuted
 }
 
 export interface IOrder {
@@ -48,6 +49,13 @@ export abstract class Order implements IOrder {
         volume: BN,
         public readonly userId: string
     ) {
+        if (volume.isZero() || volume.isNeg()) {
+            throw new Error('Incorrect negative volume');
+        }
+        if (price <= 0) {
+            throw new Error('Incorrect negative price');
+        }
+
         this._status = status;
         this._volume = volume;
     }

--- a/packages/exchange-core/src/index.ts
+++ b/packages/exchange-core/src/index.ts
@@ -5,3 +5,4 @@ export { Ask } from './Ask';
 export { Product } from './Product';
 export { DeviceVintage } from './DeviceVintage';
 export { Operator } from './Operator';
+export { DirectBuy } from './DirectBuy';

--- a/packages/exchange/src/pods/demand/demand.dto.ts
+++ b/packages/exchange/src/pods/demand/demand.dto.ts
@@ -41,7 +41,9 @@ export class DemandDTO {
                     product: bid.product,
                     side: bid.side,
                     validFrom: bid.validFrom.toISOString(),
-                    demandId: demand.id
+                    demandId: demand.id,
+                    type: bid.type,
+                    directBuyId: bid.directBuyId
                 })
             )
         };

--- a/packages/exchange/src/pods/order/create-ask.dto.ts
+++ b/packages/exchange/src/pods/order/create-ask.dto.ts
@@ -1,8 +1,9 @@
-import { IsInt, IsUUID, IsPositive, Validate, IsDateString } from 'class-validator';
-import { BNStringValidator } from '../../utils/bnStringValidator';
+import { IsDateString, IsInt, IsPositive, IsUUID, Validate } from 'class-validator';
+
+import { PositiveBNStringValidator } from '../../utils/positiveBNStringValidator';
 
 export class CreateAskDTO {
-    @Validate(BNStringValidator)
+    @Validate(PositiveBNStringValidator)
     readonly volume: string;
 
     @IsInt()

--- a/packages/exchange/src/pods/order/create-bid.dto.ts
+++ b/packages/exchange/src/pods/order/create-bid.dto.ts
@@ -1,10 +1,10 @@
-import { IsInt, IsPositive, Validate, ValidateNested, IsDateString } from 'class-validator';
+import { IsDateString, IsInt, IsPositive, Validate, ValidateNested } from 'class-validator';
 
-import { BNStringValidator } from '../../utils/bnStringValidator';
+import { PositiveBNStringValidator } from '../../utils/positiveBNStringValidator';
 import { ProductDTO } from './product.dto';
 
 export class CreateBidDTO {
-    @Validate(BNStringValidator)
+    @Validate(PositiveBNStringValidator)
     readonly volume: string;
 
     @IsInt()

--- a/packages/exchange/src/pods/order/direct-buy.dto.ts
+++ b/packages/exchange/src/pods/order/direct-buy.dto.ts
@@ -1,11 +1,12 @@
-import { Validate, IsUUID, IsInt, IsPositive } from 'class-validator';
-import { BNStringValidator } from '../../utils/bnStringValidator';
+import { IsInt, IsPositive, IsUUID, Validate } from 'class-validator';
+
+import { PositiveBNStringValidator } from '../../utils/positiveBNStringValidator';
 
 export class DirectBuyDTO {
     @IsUUID()
     readonly askId: string;
 
-    @Validate(BNStringValidator)
+    @Validate(PositiveBNStringValidator)
     readonly volume: string;
 
     @IsInt()

--- a/packages/exchange/src/pods/order/direct-buy.dto.ts
+++ b/packages/exchange/src/pods/order/direct-buy.dto.ts
@@ -1,0 +1,14 @@
+import { Validate, IsUUID, IsInt, IsPositive } from 'class-validator';
+import { BNStringValidator } from '../../utils/bnStringValidator';
+
+export class DirectBuyDTO {
+    @IsUUID()
+    readonly askId: string;
+
+    @Validate(BNStringValidator)
+    readonly volume: string;
+
+    @IsInt()
+    @IsPositive()
+    readonly price: number;
+}

--- a/packages/exchange/src/pods/order/order-type.enum.ts
+++ b/packages/exchange/src/pods/order/order-type.enum.ts
@@ -1,0 +1,4 @@
+export enum OrderType {
+    Limit,
+    Direct
+}

--- a/packages/exchange/src/pods/order/order.dto.ts
+++ b/packages/exchange/src/pods/order/order.dto.ts
@@ -2,6 +2,7 @@ import { OrderStatus, OrderSide } from '@energyweb/exchange-core';
 import { ProductDTO } from './product.dto';
 import { Asset } from '../asset/asset.entity';
 import { Order } from './order.entity';
+import { OrderType } from './order-type.enum';
 
 export class OrderDTO {
     id: string;
@@ -25,6 +26,10 @@ export class OrderDTO {
     asset: Asset;
 
     demandId: string;
+
+    type: OrderType;
+
+    directBuyId: string;
 
     public static fromOrder(order: Order): OrderDTO {
         return {

--- a/packages/exchange/src/pods/order/order.entity.ts
+++ b/packages/exchange/src/pods/order/order.entity.ts
@@ -17,6 +17,7 @@ import { Asset } from '../asset/asset.entity';
 import { Demand } from '../demand/demand.entity';
 import { ProductDTO } from './product.dto';
 import { Trade } from '../trade/trade.entity';
+import { OrderType } from './order-type.enum';
 
 @Entity()
 export class Order extends BaseEntity {
@@ -40,6 +41,12 @@ export class Order extends BaseEntity {
 
     @Column()
     price: number;
+
+    @Column({ default: OrderType.Limit })
+    type: OrderType;
+
+    @Column({ nullable: true, type: 'uuid' })
+    directBuyId: string;
 
     @Column()
     @UpdateDateColumn({ type: 'timestamptz' })

--- a/packages/exchange/src/utils/positiveBNStringValidator.ts
+++ b/packages/exchange/src/utils/positiveBNStringValidator.ts
@@ -1,0 +1,14 @@
+import { ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
+import BN from 'bn.js';
+
+@ValidatorConstraint()
+export class PositiveBNStringValidator implements ValidatorConstraintInterface {
+    validate(text: string) {
+        try {
+            const bn = new BN(text);
+            return bn.gt(new BN(0));
+        } catch (e) {
+            return false;
+        }
+    }
+}

--- a/packages/exchange/test/app.e2e-spec.ts
+++ b/packages/exchange/test/app.e2e-spec.ts
@@ -431,16 +431,33 @@ describe('AppController (e2e)', () => {
                 volume: ask2.startVolume.toString(10)
             };
 
+            let createdDirectBuyOrder: OrderDTO;
+
             await request(app.getHttpServer())
                 .post('/orders/ask/buy')
                 .send(directBuyOrder)
                 .expect(201)
                 .expect(res => {
-                    const order = res.body as OrderDTO;
+                    createdDirectBuyOrder = res.body as OrderDTO;
 
-                    expect(order.type).toBe(OrderType.Direct);
-                    expect(order.price).toBe(directBuyOrder.price);
-                    expect(order.startVolume).toBe(directBuyOrder.volume);
+                    expect(createdDirectBuyOrder.type).toBe(OrderType.Direct);
+                    expect(createdDirectBuyOrder.price).toBe(directBuyOrder.price);
+                    expect(createdDirectBuyOrder.startVolume).toBe(directBuyOrder.volume);
+                });
+
+            await sleep(3000);
+
+            await request(app.getHttpServer())
+                .get(`/trade`)
+                .expect(200)
+                .expect(res => {
+                    const trades = res.body as TradeDTO[];
+                    const [trade] = trades;
+
+                    expect(trades).toBeDefined();
+                    expect(trades).toHaveLength(1);
+                    expect(trade.bidId).toBe(createdDirectBuyOrder.id);
+                    expect(trade.volume).toBe(createdDirectBuyOrder.startVolume);
                 });
         });
     });

--- a/packages/exchange/test/app.e2e-spec.ts
+++ b/packages/exchange/test/app.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { INestApplication } from '@nestjs/common';
-import { Contract, ethers } from 'ethers';
+import { Contract, ethers, ContractTransaction } from 'ethers';
 import request from 'supertest';
 
 import { Account } from '../src/pods/account/account';
@@ -7,6 +7,9 @@ import { AccountDTO } from '../src/pods/account/account.dto';
 import { AccountService } from '../src/pods/account/account.service';
 import { DemandService } from '../src/pods/demand/demand.service';
 import { CreateAskDTO } from '../src/pods/order/create-ask.dto';
+import { DirectBuyDTO } from '../src/pods/order/direct-buy.dto';
+import { OrderType } from '../src/pods/order/order-type.enum';
+import { OrderDTO } from '../src/pods/order/order.dto';
 import { Order } from '../src/pods/order/order.entity';
 import { OrderService } from '../src/pods/order/order.service';
 import { ProductService } from '../src/pods/product/product.service';
@@ -16,7 +19,6 @@ import { TransferDirection } from '../src/pods/transfer/transfer-direction';
 import { Transfer } from '../src/pods/transfer/transfer.entity';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
-import { OrderDTO } from '../src/pods/order/order.dto';
 import { bootstrapTestInstance } from './exchange';
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
@@ -66,6 +68,7 @@ describe('AppController (e2e)', () => {
         } = await bootstrapTestInstance());
 
         await app.init();
+        await databaseService.cleanUp();
     });
 
     describe('account deposit confirmation', () => {
@@ -208,6 +211,8 @@ describe('AppController (e2e)', () => {
         });
 
         it('should be able to withdraw after confirming deposit', async () => {
+            jest.setTimeout(10000);
+
             await confirmDeposit();
 
             const withdrawal: RequestWithdrawalDTO = {
@@ -233,6 +238,9 @@ describe('AppController (e2e)', () => {
                     expect(account.balances.available[0].amount).toEqual('0');
                     expect(account.balances.available[0].asset).toMatchObject(dummyAsset);
                 });
+
+            // wait to withdrawal to be finished to not mess with tx nonces
+            await sleep(5000);
         });
     });
 
@@ -245,23 +253,19 @@ describe('AppController (e2e)', () => {
         const tokenReceiver = new ethers.Wallet(tokenReceiverPrivateKey, provider);
 
         const issueToken = async (to: string, amount: string) => {
-            const receipt = await registry.functions.issue(to, '0x0', 100, amount, '0x0');
-
-            return receipt.wait();
+            await registry.functions.issue(to, '0x0', 100, amount, '0x0');
         };
 
         const depositToken = async (to: string, amount: string) => {
             const registryWithUserAsSigner = registry.connect(tokenReceiver);
 
-            const transferReceipt = await registryWithUserAsSigner.functions.safeTransferFrom(
+            await registryWithUserAsSigner.functions.safeTransferFrom(
                 tokenReceiver.address,
                 to,
                 1,
                 amount,
                 '0x0'
             );
-
-            return transferReceipt.wait();
         };
 
         beforeEach(async () => {
@@ -355,13 +359,12 @@ describe('AppController (e2e)', () => {
             const deposit = await createDeposit(sellerAddress);
             await confirmDeposit();
 
-            const askOrder = await orderService.createAsk(sellerId, {
+            await orderService.createAsk(sellerId, {
                 assetId: deposit.asset.id,
                 volume: '500',
                 price: 1000,
                 validFrom: validFrom.toISOString()
             });
-            await orderService.submit(askOrder);
 
             const product = productService.getProduct('deviceId');
 
@@ -400,16 +403,49 @@ describe('AppController (e2e)', () => {
         });
     });
 
+    describe('DirectBuy orders tests', () => {
+        it('should allow to buy a selected ask', async () => {
+            const validFrom = new Date();
+            const sellerId = '2';
+            const { address } = await accountService.getOrCreateAccount(sellerId);
+            const deposit = await createDeposit(address);
+            await confirmDeposit();
+
+            await orderService.createAsk(sellerId, {
+                assetId: deposit.asset.id,
+                volume: '500',
+                price: 1000,
+                validFrom: validFrom.toISOString()
+            });
+
+            const ask2 = await orderService.createAsk(sellerId, {
+                assetId: deposit.asset.id,
+                volume: '500',
+                price: 2000,
+                validFrom: validFrom.toISOString()
+            });
+
+            const directBuyOrder: DirectBuyDTO = {
+                askId: ask2.id,
+                price: ask2.price,
+                volume: ask2.startVolume.toString(10)
+            };
+
+            await request(app.getHttpServer())
+                .post('/orders/ask/buy')
+                .send(directBuyOrder)
+                .expect(201)
+                .expect(res => {
+                    const order = res.body as OrderDTO;
+
+                    expect(order.type).toBe(OrderType.Direct);
+                    expect(order.price).toBe(directBuyOrder.price);
+                    expect(order.startVolume).toBe(directBuyOrder.volume);
+                });
+        });
+    });
+
     afterEach(async () => {
-        try {
-            await databaseService.cleanUp();
-        } catch (error) {
-            console.error(error);
-        }
-        try {
-            await app.close();
-        } catch (error) {
-            console.error(error);
-        }
+        await app.close();
     });
 });


### PR DESCRIPTION
This PR provides:
- in-order order book actions execution
- fix for in-order cancellation
- API for directly buying selected Ask via `POST /orders/ask/buy`