### PR TITLE
Orderbook product filters

### DIFF
--- a/packages/exchange-core/src/Bid.ts
+++ b/packages/exchange-core/src/Bid.ts
@@ -4,6 +4,7 @@ import BN from 'bn.js';
 import { Ask } from './Ask';
 import { Order, OrderSide, OrderStatus } from './Order';
 import { Product } from './Product';
+import { ProductFilter, Filter } from './ProductFilter';
 
 export class Bid extends Order {
     constructor(
@@ -19,13 +20,13 @@ export class Bid extends Order {
     }
 
     public filterBy(
-        product: Product,
+        productFilter: ProductFilter,
         deviceService: IDeviceTypeService,
         locationService: ILocationService
     ): boolean {
-        const isIncludedInDeviceType = this.isIncludedInDeviceType(product, deviceService);
-        const hasMatchingVintage = this.hasMatchingVintage(product);
-        const isIncludedInLocation = this.isIncludedInLocation(product, locationService);
+        const isIncludedInDeviceType = this.isIncludedInDeviceType(productFilter, deviceService);
+        const hasMatchingVintage = this.hasMatchingVintage(productFilter);
+        const isIncludedInLocation = this.isIncludedInLocation(productFilter, locationService);
 
         return isIncludedInDeviceType && hasMatchingVintage && isIncludedInLocation;
     }
@@ -70,25 +71,37 @@ export class Bid extends Order {
         return locationService.matches(this.product.location, product.location[0]);
     }
 
-    private isIncludedInLocation(product: Product, locationService: ILocationService) {
-        if (!this.product.location?.length || !product.location?.length) {
+    private isIncludedInLocation(productFilter: ProductFilter, locationService: ILocationService) {
+        if (productFilter.locationFilter === Filter.All) {
             return true;
+        }
+        if (productFilter.locationFilter === Filter.Unspecified) {
+            return !this.product.location?.length;
         }
 
         return (
-            locationService.matchesSome(product.location, this.product.location) ||
-            locationService.matchesSome(this.product.location, product.location)
+            locationService.matchesSome(productFilter.location, this.product.location) ||
+            locationService.matchesSome(this.product.location, productFilter.location)
         );
     }
 
-    private isIncludedInDeviceType(product: Product, deviceService: IDeviceTypeService) {
-        if (!this.product.deviceType?.length || !product.deviceType?.length) {
+    private isIncludedInDeviceType(
+        productFilter: ProductFilter,
+        deviceService: IDeviceTypeService
+    ) {
+        if (productFilter.deviceTypeFilter === Filter.All) {
             return true;
+        }
+        if (productFilter.deviceTypeFilter === Filter.Unspecified) {
+            return !this.product.deviceType?.length;
         }
 
         return (
-            deviceService.includesSomeDeviceType(product.deviceType, this.product.deviceType) ||
-            deviceService.includesSomeDeviceType(this.product.deviceType, product.deviceType)
+            deviceService.includesSomeDeviceType(
+                productFilter.deviceType,
+                this.product.deviceType
+            ) ||
+            deviceService.includesSomeDeviceType(this.product.deviceType, productFilter.deviceType)
         );
     }
 

--- a/packages/exchange-core/src/Bid.ts
+++ b/packages/exchange-core/src/Bid.ts
@@ -25,7 +25,7 @@ export class Bid extends Order {
         locationService: ILocationService
     ): boolean {
         const isIncludedInDeviceType = this.isIncludedInDeviceType(productFilter, deviceService);
-        const hasMatchingVintage = this.hasMatchingVintage(productFilter);
+        const hasMatchingVintage = this.filterByDeviceVintage(productFilter);
         const isIncludedInLocation = this.isIncludedInLocation(productFilter, locationService);
 
         return isIncludedInDeviceType && hasMatchingVintage && isIncludedInLocation;
@@ -103,6 +103,17 @@ export class Bid extends Order {
             ) ||
             deviceService.includesSomeDeviceType(this.product.deviceType, productFilter.deviceType)
         );
+    }
+
+    private filterByDeviceVintage(productFilter: ProductFilter) {
+        if (productFilter.deviceVintageFilter === Filter.All) {
+            return true;
+        }
+        if (productFilter.deviceVintageFilter === Filter.Unspecified) {
+            return !this.product.deviceVintage;
+        }
+
+        return productFilter.deviceVintage.matches(this.product.deviceVintage);
     }
 
     private hasMatchingVintage(product: Product) {

--- a/packages/exchange-core/src/MatchingEngine.ts
+++ b/packages/exchange-core/src/MatchingEngine.ts
@@ -6,10 +6,10 @@ import { concatMap } from 'rxjs/operators';
 
 import { Ask } from './Ask';
 import { Bid } from './Bid';
-import { Order, OrderSide, OrderStatus } from './Order';
-import { Product } from './Product';
-import { Trade } from './Trade';
 import { DirectBuy } from './DirectBuy';
+import { Order, OrderSide, OrderStatus } from './Order';
+import { ProductFilter } from './ProductFilter';
+import { Trade } from './Trade';
 
 export type TradeExecutedEvent = { trade: Trade; ask: Ask; bid: Bid | DirectBuy };
 
@@ -68,12 +68,12 @@ export class MatchingEngine {
         return { asks: this.asks, bids: this.bids };
     }
 
-    public orderBookByProduct(product: Product) {
+    public orderBookByProduct(productFilter: ProductFilter) {
         const asks = this.asks.filter(ask =>
-            ask.filterBy(product, this.deviceService, this.locationService)
+            ask.filterBy(productFilter, this.deviceService, this.locationService)
         );
         const bids = this.bids.filter(bid =>
-            bid.filterBy(product, this.deviceService, this.locationService)
+            bid.filterBy(productFilter, this.deviceService, this.locationService)
         );
 
         return { asks, bids };

--- a/packages/exchange-core/src/ProductFilter.ts
+++ b/packages/exchange-core/src/ProductFilter.ts
@@ -1,0 +1,13 @@
+import { Product } from './Product';
+
+export enum Filter {
+    All,
+    Specific,
+    Unspecified
+}
+
+export class ProductFilter extends Product {
+    deviceTypeFilter: Filter = Filter.All;
+
+    locationFilter: Filter = Filter.All;
+}

--- a/packages/exchange-core/src/ProductFilter.ts
+++ b/packages/exchange-core/src/ProductFilter.ts
@@ -10,4 +10,6 @@ export class ProductFilter extends Product {
     deviceTypeFilter: Filter = Filter.All;
 
     locationFilter: Filter = Filter.All;
+
+    deviceVintageFilter: Filter = Filter.All;
 }

--- a/packages/exchange-core/src/index.ts
+++ b/packages/exchange-core/src/index.ts
@@ -3,6 +3,7 @@ export { Order, OrderSide, OrderStatus, IOrder } from './Order';
 export { Bid } from './Bid';
 export { Ask } from './Ask';
 export { Product } from './Product';
+export { ProductFilter, Filter } from './ProductFilter';
 export { DeviceVintage } from './DeviceVintage';
 export { Operator } from './Operator';
 export { DirectBuy } from './DirectBuy';

--- a/packages/exchange-core/src/test/Matching.test.ts
+++ b/packages/exchange-core/src/test/Matching.test.ts
@@ -535,7 +535,11 @@ describe('Matching tests', () => {
             executeOrderBookQuery(
                 asks,
                 bids,
-                { locationFilter: Filter.All, deviceTypeFilter: Filter.All },
+                {
+                    locationFilter: Filter.All,
+                    deviceTypeFilter: Filter.All,
+                    deviceVintageFilter: Filter.All
+                },
                 asks,
                 bids
             );
@@ -559,7 +563,8 @@ describe('Matching tests', () => {
                 {
                     deviceType: solarTypeLevel2,
                     deviceTypeFilter: Filter.Specific,
-                    locationFilter: Filter.All
+                    locationFilter: Filter.All,
+                    deviceVintageFilter: Filter.All
                 },
                 expectedAsks,
                 bids
@@ -579,7 +584,11 @@ describe('Matching tests', () => {
             executeOrderBookQuery(
                 asks,
                 bids,
-                { deviceTypeFilter: Filter.All, locationFilter: Filter.All },
+                {
+                    deviceTypeFilter: Filter.All,
+                    locationFilter: Filter.All,
+                    deviceVintageFilter: Filter.All
+                },
                 asks,
                 bids
             );
@@ -600,7 +609,11 @@ describe('Matching tests', () => {
             executeOrderBookQuery(
                 asks,
                 bids,
-                { deviceTypeFilter: Filter.Unspecified, locationFilter: Filter.All },
+                {
+                    deviceTypeFilter: Filter.Unspecified,
+                    locationFilter: Filter.All,
+                    deviceVintageFilter: Filter.All
+                },
                 asks,
                 bidsAfter
             );
@@ -626,7 +639,8 @@ describe('Matching tests', () => {
                 {
                     deviceType: windTypeLevel2,
                     deviceTypeFilter: Filter.Specific,
-                    locationFilter: Filter.All
+                    locationFilter: Filter.All,
+                    deviceVintageFilter: Filter.All
                 },
                 expectedAsks,
                 bids
@@ -657,7 +671,8 @@ describe('Matching tests', () => {
                 {
                     deviceType: solarTypeLevel1,
                     deviceTypeFilter: Filter.Specific,
-                    locationFilter: Filter.All
+                    locationFilter: Filter.All,
+                    deviceVintageFilter: Filter.All
                 },
                 expectedAsks,
                 expectedBids
@@ -695,7 +710,8 @@ describe('Matching tests', () => {
                 {
                     deviceType: solarTypeLevel1.concat(windTypeLevel1),
                     deviceTypeFilter: Filter.Specific,
-                    locationFilter: Filter.All
+                    locationFilter: Filter.All,
+                    deviceVintageFilter: Filter.All
                 },
                 expectedAsks,
                 expectedBids
@@ -732,7 +748,8 @@ describe('Matching tests', () => {
                 {
                     location: locationEast,
                     locationFilter: Filter.Specific,
-                    deviceTypeFilter: Filter.All
+                    deviceTypeFilter: Filter.All,
+                    deviceVintageFilter: Filter.All
                 },
                 expectedAsks,
                 expectedBids
@@ -770,7 +787,8 @@ describe('Matching tests', () => {
                 {
                     location: locationEast.concat(locationCentral),
                     locationFilter: Filter.Specific,
-                    deviceTypeFilter: Filter.All
+                    deviceTypeFilter: Filter.All,
+                    deviceVintageFilter: Filter.All
                 },
                 expectedAsks,
                 expectedBids

--- a/packages/exchange-core/src/test/Matching.test.ts
+++ b/packages/exchange-core/src/test/Matching.test.ts
@@ -12,6 +12,7 @@ import { Order, OrderStatus } from '../Order';
 import { Product } from '../Product';
 import { Trade } from '../Trade';
 import { DirectBuy } from '../DirectBuy';
+import { ProductFilter, Filter } from '../ProductFilter';
 
 interface IOrderCreationArgs {
     product?: Product;
@@ -166,6 +167,7 @@ describe('Matching tests', () => {
         });
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const executeTestCase = (testCase: ITestCase, done: any) => {
         const matchingEngine = new MatchingEngine(deviceService, locationService);
         let doneTimer: NodeJS.Timeout;
@@ -223,7 +225,7 @@ describe('Matching tests', () => {
     const executeOrderBookQuery = (
         asks: Ask[],
         bids: Bid[],
-        product: Product,
+        productFilter: ProductFilter,
         expectedAsks: Ask[],
         expectedBids: Bid[]
     ) => {
@@ -234,7 +236,7 @@ describe('Matching tests', () => {
 
         matchingEngine.tick();
 
-        const orderBook = matchingEngine.orderBookByProduct(product);
+        const orderBook = matchingEngine.orderBookByProduct(productFilter);
 
         assertOrders(List<Ask>(expectedAsks), orderBook.asks, 'asks');
         assertOrders(List<Bid>(expectedBids), orderBook.bids, 'bids');
@@ -496,11 +498,47 @@ describe('Matching tests', () => {
         });
     });
 
+    describe('unspecified product matching', () => {
+        it('should buy 2 asks', done => {
+            const asksBefore = [
+                createAsk({ product: { deviceType: windTypeLevel2 }, price: 3 }),
+                createAsk({ product: { deviceType: windTypeLevel22 }, price: 2 }),
+                createAsk({ product: { deviceType: solarTypeLevel3 }, price: 1 })
+            ];
+
+            const bidsBefore = [
+                createBid({
+                    volume: threeKWh,
+                    product: {}
+                })
+            ];
+
+            const asksAfter = [asksBefore[0]];
+            const bidsAfter = [bidsBefore[0].clone().updateWithTradedVolume(twoKWh)];
+
+            const expectedTrades = [
+                new Trade(bidsBefore[0], asksBefore[2], onekWh, asksBefore[2].price),
+                new Trade(bidsBefore[0], asksBefore[1], onekWh, asksBefore[1].price)
+            ];
+
+            executeTestCase(
+                { orders: [...asksBefore, ...bidsBefore], expectedTrades, asksAfter, bidsAfter },
+                done
+            );
+        });
+    });
+
     describe('order book filtering by product', () => {
         it('should return whole order book when no product was set', () => {
             const { asks, bids } = createOrderBookWithSpread([{}, {}, {}], [{}, {}, {}]);
 
-            executeOrderBookQuery(asks, bids, {}, asks, bids);
+            executeOrderBookQuery(
+                asks,
+                bids,
+                { locationFilter: Filter.All, deviceTypeFilter: Filter.All },
+                asks,
+                bids
+            );
         });
 
         it('should return order book based on device type where bids are "buy anything" product', () => {
@@ -515,7 +553,17 @@ describe('Matching tests', () => {
 
             const expectedAsks = asks.slice(0, -1);
 
-            executeOrderBookQuery(asks, bids, { deviceType: solarTypeLevel2 }, expectedAsks, bids);
+            executeOrderBookQuery(
+                asks,
+                bids,
+                {
+                    deviceType: solarTypeLevel2,
+                    deviceTypeFilter: Filter.Specific,
+                    locationFilter: Filter.All
+                },
+                expectedAsks,
+                bids
+            );
         });
 
         it('should return order book based on device type where bids are "buy anything" product and no filter defined', () => {
@@ -525,23 +573,37 @@ describe('Matching tests', () => {
                     { product: { deviceType: solarTypeLevel32 } },
                     { product: { deviceType: windTypeLevel2 } }
                 ],
-                [{}, {}, {}]
+                [{ product: {} }, { product: {} }, { product: {} }]
             );
 
-            executeOrderBookQuery(asks, bids, {}, asks, bids);
+            executeOrderBookQuery(
+                asks,
+                bids,
+                { deviceTypeFilter: Filter.All, locationFilter: Filter.All },
+                asks,
+                bids
+            );
         });
 
-        it('should return order book based on device type where bids are "buy anything" product and filter with deviceType is []', () => {
+        it('should return order book based on device type where bids are "buy anything"', () => {
             const { asks, bids } = createOrderBookWithSpread(
                 [
                     { product: { deviceType: solarTypeLevel3 } },
                     { product: { deviceType: solarTypeLevel32 } },
                     { product: { deviceType: windTypeLevel2 } }
                 ],
-                [{}, {}, {}]
+                [{ product: { deviceType: solarTypeLevel3 } }, { product: {} }, { product: {} }]
             );
 
-            executeOrderBookQuery(asks, bids, { deviceType: [] }, asks, bids);
+            const bidsAfter = [bids[1], bids[2]];
+
+            executeOrderBookQuery(
+                asks,
+                bids,
+                { deviceTypeFilter: Filter.Unspecified, locationFilter: Filter.All },
+                asks,
+                bidsAfter
+            );
         });
 
         it('should return order book based on device type where bids are windType on level 1 and level 2', () => {
@@ -558,7 +620,17 @@ describe('Matching tests', () => {
 
             const expectedAsks = asks.slice(-1);
 
-            executeOrderBookQuery(asks, bids, { deviceType: windTypeLevel2 }, expectedAsks, bids);
+            executeOrderBookQuery(
+                asks,
+                bids,
+                {
+                    deviceType: windTypeLevel2,
+                    deviceTypeFilter: Filter.Specific,
+                    locationFilter: Filter.All
+                },
+                expectedAsks,
+                bids
+            );
         });
 
         it('should return order book based on device type where bids are of different types', () => {
@@ -582,7 +654,11 @@ describe('Matching tests', () => {
             executeOrderBookQuery(
                 asks,
                 bids,
-                { deviceType: solarTypeLevel1 },
+                {
+                    deviceType: solarTypeLevel1,
+                    deviceTypeFilter: Filter.Specific,
+                    locationFilter: Filter.All
+                },
                 expectedAsks,
                 expectedBids
             );
@@ -616,7 +692,11 @@ describe('Matching tests', () => {
             executeOrderBookQuery(
                 asks,
                 bids,
-                { deviceType: solarTypeLevel1.concat(windTypeLevel1) },
+                {
+                    deviceType: solarTypeLevel1.concat(windTypeLevel1),
+                    deviceTypeFilter: Filter.Specific,
+                    locationFilter: Filter.All
+                },
                 expectedAsks,
                 expectedBids
             );
@@ -649,7 +729,11 @@ describe('Matching tests', () => {
             executeOrderBookQuery(
                 asks,
                 bids,
-                { location: locationEast },
+                {
+                    location: locationEast,
+                    locationFilter: Filter.Specific,
+                    deviceTypeFilter: Filter.All
+                },
                 expectedAsks,
                 expectedBids
             );
@@ -683,7 +767,11 @@ describe('Matching tests', () => {
             executeOrderBookQuery(
                 asks,
                 bids,
-                { location: locationEast.concat(locationCentral) },
+                {
+                    location: locationEast.concat(locationCentral),
+                    locationFilter: Filter.Specific,
+                    deviceTypeFilter: Filter.All
+                },
                 expectedAsks,
                 expectedBids
             );

--- a/packages/exchange/src/pods/matching-engine/matching-engine.service.ts
+++ b/packages/exchange/src/pods/matching-engine/matching-engine.service.ts
@@ -3,7 +3,7 @@ import {
     Bid,
     MatchingEngine,
     OrderSide,
-    Product,
+    ProductFilter,
     TradeExecutedEvent,
     DirectBuy
 } from '@energyweb/exchange-core';
@@ -58,9 +58,8 @@ export class MatchingEngineService {
         }
     }
 
-    public query(product: Product) {
-        // TODO: consider reading this info from DB and filtering
-        return this.matchingEngine.orderBookByProduct(product);
+    public query(productFilter: ProductFilter) {
+        return this.matchingEngine.orderBookByProduct(productFilter);
     }
 
     @Interval(1000)

--- a/packages/exchange/src/pods/order-book/order-book.controller.ts
+++ b/packages/exchange/src/pods/order-book/order-book.controller.ts
@@ -3,9 +3,9 @@ import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 import { UserDecorator } from '../decorators/user.decorator';
-import { ProductDTO } from '../order/product.dto';
 import { OrderBookOrderDTO } from './order-book-order.dto';
 import { OrderBookService } from './order-book.service';
+import { ProductFilterDTO } from './product-filter.dto';
 
 @Controller('orderbook')
 export class OrderBookController {
@@ -13,8 +13,10 @@ export class OrderBookController {
 
     @Post('/search')
     @UseGuards(AuthGuard())
-    public getByProduct(@UserDecorator() user: IUser, @Body() product: ProductDTO) {
-        const { asks, bids } = this.orderBookService.getByProduct(ProductDTO.toProduct(product));
+    public getByProduct(@UserDecorator() user: IUser, @Body() productFilter: ProductFilterDTO) {
+        const { asks, bids } = this.orderBookService.getByProduct(
+            ProductFilterDTO.toProductFilter(productFilter)
+        );
         const userId = user?.id.toString();
 
         return {

--- a/packages/exchange/src/pods/order-book/order-book.service.ts
+++ b/packages/exchange/src/pods/order-book/order-book.service.ts
@@ -1,4 +1,4 @@
-import { Product } from '@energyweb/exchange-core';
+import { ProductFilter } from '@energyweb/exchange-core';
 import { Injectable } from '@nestjs/common';
 
 import { MatchingEngineService } from '../matching-engine/matching-engine.service';
@@ -7,7 +7,7 @@ import { MatchingEngineService } from '../matching-engine/matching-engine.servic
 export class OrderBookService {
     constructor(private readonly matchingEngineService: MatchingEngineService) {}
 
-    public getByProduct(product: Product) {
-        return this.matchingEngineService.query(product);
+    public getByProduct(productFilter: ProductFilter) {
+        return this.matchingEngineService.query(productFilter);
     }
 }

--- a/packages/exchange/src/pods/order-book/product-filter.dto.ts
+++ b/packages/exchange/src/pods/order-book/product-filter.dto.ts
@@ -1,0 +1,21 @@
+// eslint-disable-next-line max-classes-per-file
+import { Filter, ProductFilter } from '@energyweb/exchange-core';
+import { IsEnum } from 'class-validator';
+
+import { ProductDTO } from '../order/product.dto';
+
+export class ProductFilterDTO extends ProductDTO {
+    @IsEnum(Filter)
+    public deviceTypeFilter: Filter;
+
+    @IsEnum(Filter)
+    public locationFilter: Filter;
+
+    public static toProductFilter(productFilter: ProductFilterDTO): ProductFilter {
+        return {
+            ...ProductDTO.toProduct(productFilter),
+            deviceTypeFilter: productFilter.deviceTypeFilter,
+            locationFilter: productFilter.locationFilter
+        };
+    }
+}

--- a/packages/exchange/src/pods/order-book/product-filter.dto.ts
+++ b/packages/exchange/src/pods/order-book/product-filter.dto.ts
@@ -11,11 +11,15 @@ export class ProductFilterDTO extends ProductDTO {
     @IsEnum(Filter)
     public locationFilter: Filter;
 
+    @IsEnum(Filter)
+    public deviceVintageFilter: Filter;
+
     public static toProductFilter(productFilter: ProductFilterDTO): ProductFilter {
         return {
             ...ProductDTO.toProduct(productFilter),
             deviceTypeFilter: productFilter.deviceTypeFilter,
-            locationFilter: productFilter.locationFilter
+            locationFilter: productFilter.locationFilter,
+            deviceVintageFilter: productFilter.deviceVintageFilter
         };
     }
 }


### PR DESCRIPTION
This PR provides the new way for filtering orderbook.

POST /orderbook/search now accepts the ProductFilterDTO object as input:

```
{
    public deviceTypeFilter: Filter;
    public locationFilter: Filter;
    public deviceVintageFilter: Filter;
    
    public deviceType?: string[];
    public location?: string[];
    public deviceVintage?: DeviceVintageDTO;
}
```

Filter enum has 3 options:

1) All - which returns all bid/order
2) Unspecified - which returns all asks and bids that are set to buy any deviceType or location
3) Specific - which requires the deviceType or location to be filled with the value to be used as filters