### PR TITLE
fix(exchange): do not mask orders for balance check

### DIFF
--- a/packages/exchange/src/pods/account-balance/account-balance.service.ts
+++ b/packages/exchange/src/pods/account-balance/account-balance.service.ts
@@ -77,7 +77,7 @@ export class AccountBalanceService {
     }
 
     private async getTrades(userId: string) {
-        const trades = await this.tradeService.getAll(userId);
+        const trades = await this.tradeService.getAll(userId, false);
 
         return this.sumByAsset(
             trades,

--- a/packages/exchange/src/pods/trade/trade.service.ts
+++ b/packages/exchange/src/pods/trade/trade.service.ts
@@ -44,7 +44,7 @@ export class TradeService {
         });
     }
 
-    public async getAll(userId: string) {
+    public async getAll(userId: string, maskOrders = true) {
         const trades = await this.repository
             .createQueryBuilder('trade')
             .leftJoinAndSelect('trade.bid', 'bid')
@@ -53,6 +53,6 @@ export class TradeService {
             .where('ask.userId = :userId OR bid.userId = :userId', { userId })
             .getMany();
 
-        return trades.map(trade => trade.withMaskedOrder(userId));
+        return maskOrders ? trades.map(trade => trade.withMaskedOrder(userId)) : trades;
     }
 }


### PR DESCRIPTION
This PR fixes the 500 error when checking for balance status where you have trades as a buyer.