### PR TITLE
Asset endpoint and assetid

### DIFF
--- a/packages/exchange-core/src/Ask.ts
+++ b/packages/exchange-core/src/Ask.ts
@@ -13,7 +13,8 @@ export class Ask extends Order {
         volume: BN,
         product: Product,
         validFrom: Date,
-        userId: string
+        userId: string,
+        public readonly assetId: string
     ) {
         super(id, OrderSide.Ask, validFrom, product, price, volume, userId);
 
@@ -81,7 +82,15 @@ export class Ask extends Order {
     }
 
     public clone() {
-        return new Ask(this.id, this.price, this.volume, this.product, this.validFrom, this.userId);
+        return new Ask(
+            this.id,
+            this.price,
+            this.volume,
+            this.product,
+            this.validFrom,
+            this.userId,
+            this.assetId
+        );
     }
 
     private filter(filter: Filter, pred: () => boolean) {

--- a/packages/exchange-core/src/test/Matching.test.ts
+++ b/packages/exchange-core/src/test/Matching.test.ts
@@ -105,7 +105,8 @@ describe('Matching tests', () => {
                 ...args?.product
             },
             args?.validFrom || new Date(),
-            args?.userId || defaultSeller
+            args?.userId || defaultSeller,
+            'assetId'
         );
     };
 

--- a/packages/exchange/src/pods/asset/asset.controller.ts
+++ b/packages/exchange/src/pods/asset/asset.controller.ts
@@ -4,10 +4,8 @@ import {
     Get,
     Param,
     ParseUUIDPipe,
-    UseGuards,
     UseInterceptors
 } from '@nestjs/common';
-import { AuthGuard } from '@nestjs/passport';
 
 import { AssetService } from './asset.service';
 
@@ -17,7 +15,6 @@ export class AssetController {
     constructor(private readonly assetService: AssetService) {}
 
     @Get('/:id')
-    @UseGuards(AuthGuard())
     public get(@Param('id', new ParseUUIDPipe({ version: '4' })) assetId: string) {
         return this.assetService.get(assetId);
     }

--- a/packages/exchange/src/pods/asset/asset.controller.ts
+++ b/packages/exchange/src/pods/asset/asset.controller.ts
@@ -1,0 +1,24 @@
+import {
+    ClassSerializerInterceptor,
+    Controller,
+    Get,
+    Param,
+    ParseUUIDPipe,
+    UseGuards,
+    UseInterceptors
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+import { AssetService } from './asset.service';
+
+@Controller('asset')
+@UseInterceptors(ClassSerializerInterceptor)
+export class AssetController {
+    constructor(private readonly assetService: AssetService) {}
+
+    @Get('/:id')
+    @UseGuards(AuthGuard())
+    public get(@Param('id', new ParseUUIDPipe({ version: '4' })) assetId: string) {
+        return this.assetService.get(assetId);
+    }
+}

--- a/packages/exchange/src/pods/asset/asset.module.ts
+++ b/packages/exchange/src/pods/asset/asset.module.ts
@@ -3,10 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { Asset } from './asset.entity';
 import { AssetService } from './asset.service';
+import { AssetController } from './asset.controller';
 
 @Module({
     imports: [TypeOrmModule.forFeature([Asset], 'ExchangeConnection')],
     providers: [AssetService],
-    exports: [AssetService]
+    exports: [AssetService],
+    controllers: [AssetController]
 })
 export class AssetModule {}

--- a/packages/exchange/src/pods/matching-engine/matching-engine.service.ts
+++ b/packages/exchange/src/pods/matching-engine/matching-engine.service.ts
@@ -110,7 +110,8 @@ export class MatchingEngineService implements OnModuleInit {
                   order.currentVolume,
                   ProductDTO.toProduct(order.product),
                   order.validFrom,
-                  order.userId
+                  order.userId,
+                  order.assetId
               )
             : new Bid(
                   order.id,

--- a/packages/exchange/src/pods/order-book/order-book-order.dto.ts
+++ b/packages/exchange/src/pods/order-book/order-book-order.dto.ts
@@ -9,6 +9,8 @@ export class OrderBookOrderDTO {
 
     userId: string;
 
+    assetId?: string;
+
     public static fromOrder(order: Bid | Ask, userId?: string): OrderBookOrderDTO {
         return {
             ...order,


### PR DESCRIPTION
This PR provides:

- Ask object now requires assetId
- GET /asset/:id endpoint for reading asset information
- POST /orderbook/search results returns assetId for asks 