### PR TITLE
fix(origin-ui-core): solidify custom row display in exchange ask details

### DIFF
--- a/packages/origin-ui-core/src/components/CertificateTable.tsx
+++ b/packages/origin-ui-core/src/components/CertificateTable.tsx
@@ -291,10 +291,10 @@ export function CertificateTable(props: IProps) {
         setShowClaimBulkModal(false);
     }
 
-    function customSelectCounterGenerator(selectedIndexes: number[]) {
+    function customSelectCounterGenerator(selectedIndexes: string[]) {
         if (selectedIndexes.length > 0) {
             const includedCertificates = paginatedData
-                .filter((item, index) => selectedIndexes.includes(index))
+                .filter((item, index) => selectedIndexes.includes(index?.toString()))
                 .map((i) => i.certificate);
 
             const energy = includedCertificates.reduce((a, b) => a + b.energy, 0);
@@ -424,7 +424,9 @@ export function CertificateTable(props: IProps) {
                 batchableActions={batchableActions}
                 customSelectCounterGenerator={customSelectCounterGenerator}
                 filters={filters}
-                handleRowClick={(row: number) => showCertificateDetails(row)}
+                handleRowClick={(rowIndex: string) =>
+                    showCertificateDetails(parseInt(rowIndex, 10))
+                }
                 actions={actions}
                 currentSort={currentSort}
                 sortAscending={sortAscending}

--- a/packages/origin-ui-core/src/components/CertificationRequestsTable.tsx
+++ b/packages/origin-ui-core/src/components/CertificationRequestsTable.tsx
@@ -127,7 +127,7 @@ export function CertificationRequestsTable(props: IProps) {
                   {
                       icon: <Check />,
                       name: 'Approve',
-                      onClick: (row: number) => approve(row)
+                      onClick: (row: string) => approve(parseInt(row, 10))
                   }
               ]
             : [];

--- a/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
@@ -150,12 +150,12 @@ export function OrganizationInvitationTable(props: IProps) {
                   {
                       icon: <Check />,
                       name: 'Accept',
-                      onClick: (row: number) => accept(row)
+                      onClick: (row: string) => accept(parseInt(row, 10))
                   },
                   {
                       icon: <Clear />,
                       name: 'Reject',
-                      onClick: (row: number) => reject(row)
+                      onClick: (row: string) => reject(parseInt(row, 10))
                   }
               ]
             : [];

--- a/packages/origin-ui-core/src/components/Organization/OrganizationTable.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationTable.tsx
@@ -119,7 +119,7 @@ export function OrganizationTable() {
               {
                   icon: <Check />,
                   name: 'Approve',
-                  onClick: (row: number) => approve(row)
+                  onClick: (index: string) => approve(parseInt(index, 10))
               }
           ]
         : [];
@@ -149,7 +149,7 @@ export function OrganizationTable() {
             total={total}
             pageSize={pageSize}
             actions={actions}
-            handleRowClick={viewEntity}
+            handleRowClick={(index: string) => viewEntity(parseInt(index, 10))}
         />
     );
 }

--- a/packages/origin-ui-core/src/components/Organization/OrganizationUsersTable.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationUsersTable.tsx
@@ -88,7 +88,7 @@ export function OrganizationUsersTable() {
         {
             icon: <DeleteOutline />,
             name: 'Remove',
-            onClick: (row: number) => remove(row)
+            onClick: (index: string) => remove(parseInt(index, 10))
         }
     ];
 

--- a/packages/origin-ui-core/src/components/ProducingDeviceTable.tsx
+++ b/packages/origin-ui-core/src/components/ProducingDeviceTable.tsx
@@ -232,7 +232,7 @@ export function ProducingDeviceTable(props: IOwnProps) {
                 total={total}
                 pageSize={pageSize}
                 filters={filters}
-                handleRowClick={(row) => viewDevice(row)}
+                handleRowClick={(index) => viewDevice(parseInt(index, 10))}
                 actions={actions}
             />
             {props.showAddDeviceButton && (

--- a/packages/origin-ui-core/src/components/Table/Actions.tsx
+++ b/packages/origin-ui-core/src/components/Table/Actions.tsx
@@ -8,12 +8,12 @@ import { useOriginConfiguration } from '../../utils/configuration';
 export interface ITableAction {
     name: string;
     icon: React.ReactNode;
-    onClick: (rowIndex: number) => void;
+    onClick: (rowId: string) => void;
 }
 
 interface IProps {
     actions: ITableAction[];
-    id: number;
+    id: string;
 }
 
 export function Actions(props: IProps) {

--- a/packages/origin-ui-core/src/components/Table/ColumnBatchActions.tsx
+++ b/packages/origin-ui-core/src/components/Table/ColumnBatchActions.tsx
@@ -3,36 +3,36 @@ import { Button } from '@material-ui/core';
 
 export interface IBatchableAction {
     label: string;
-    handler: (selectedIndexes: number[]) => void;
+    handler: (selectedIds: string[]) => void;
 }
 
-export type CustomCounterGeneratorFunction = (selectedIndexes: number[]) => string;
+export type CustomCounterGeneratorFunction = (selectedIds: string[]) => string;
 
 interface IProps {
-    selectedIndexes: number[];
+    selectedIds: string[];
     batchableActions: IBatchableAction[];
     customCounterGenerator?: CustomCounterGeneratorFunction;
 }
 
 export class ColumnBatchActions extends Component<IProps> {
     handleAction(action: IBatchableAction) {
-        action.handler(this.props.selectedIndexes);
+        action.handler(this.props.selectedIds);
     }
 
     get counter(): string {
-        const { customCounterGenerator, selectedIndexes } = this.props;
+        const { customCounterGenerator, selectedIds } = this.props;
 
         if (customCounterGenerator) {
-            return customCounterGenerator(selectedIndexes);
+            return customCounterGenerator(selectedIds);
         }
 
-        return `${selectedIndexes.length} selected`;
+        return `${selectedIds.length} selected`;
     }
 
     render() {
-        const { batchableActions, selectedIndexes } = this.props;
+        const { batchableActions, selectedIds } = this.props;
 
-        return selectedIndexes.length ? (
+        return selectedIds.length ? (
             <div className="ColumnBatchActions">
                 <span className="ColumnBatchActions_counter">{this.counter}</span>
                 <div className="ColumnBatchActions_list">

--- a/packages/origin-ui-core/src/components/exchange/Asks.tsx
+++ b/packages/origin-ui-core/src/components/exchange/Asks.tsx
@@ -30,7 +30,6 @@ export function Asks(props: Props) {
     const { t } = useTranslation();
     const { Yup } = useValidation();
 
-    const [selectedIndex, setSelectedIndex] = useState<number>(null);
     const [selectedOrder, setSelectedOrder] = useState<IOrderBookOrderDTO>(null);
     const [asset, setAsset] = useState<IAsset>();
     const [device, setDevice] = useState<IDeviceWithRelationsIds>();
@@ -76,19 +75,17 @@ export function Asks(props: Props) {
 
     return (
         <Orders
-            handleRowClick={(index, newOrder) => {
-                if (selectedIndex === index) {
-                    setSelectedIndex(null);
+            handleRowClick={(newOrder) => {
+                if (selectedOrder?.id === newOrder?.id) {
                     setSelectedOrder(null);
                 } else {
-                    setSelectedIndex(index);
                     setSelectedOrder(newOrder);
                 }
             }}
             customRow={
-                displayAssetDetails && device
+                selectedOrder && displayAssetDetails && device
                     ? {
-                          renderAfterIndex: selectedIndex,
+                          shouldDisplay: (row: { id: string }) => row?.id === selectedOrder?.id,
                           display: (
                               <TableCell colSpan={2}>
                                   {t('device.properties.facilityName')}: {device?.facilityName}

--- a/packages/origin-ui-core/src/components/exchange/Orders.tsx
+++ b/packages/origin-ui-core/src/components/exchange/Orders.tsx
@@ -13,8 +13,8 @@ export interface IOrdersProps {
     currency: string;
     title: string;
     highlightOrdersUserId: string;
-    handleRowClick?: (index: number, order: IOrderBookOrderDTO) => void;
-    customRow?: ICustomRow;
+    handleRowClick?: (order: IOrderBookOrderDTO) => void;
+    customRow?: ICustomRow<any>;
 }
 
 export function Orders(props: IOrdersProps) {
@@ -65,12 +65,13 @@ export function Orders(props: IOrdersProps) {
     ] as const;
 
     const highlightedRowsIndexes = [];
-    const rows = paginatedData.map(({ price, volume, userId }, index) => {
+    const rows = paginatedData.map(({ id, price, volume, userId }, index) => {
         if (typeof userId !== 'undefined' && userId !== null && userId === highlightOrdersUserId) {
             highlightedRowsIndexes.push(index);
         }
 
         return {
+            id,
             volume: EnergyFormatter.format(volume),
             price: (price / 100).toFixed(2)
         };
@@ -87,11 +88,11 @@ export function Orders(props: IOrdersProps) {
                 loadPage={loadPage}
                 total={total}
                 pageSize={pageSize}
-                highlightedRowsIndexes={highlightedRowsIndexes}
+                highlightedRowsIds={highlightedRowsIndexes}
                 handleRowClick={
                     handleRowClick
-                        ? (index: number) => {
-                              handleRowClick(index, paginatedData[index]);
+                        ? (id: string) => {
+                              handleRowClick(paginatedData?.find((r) => r.id === id));
                           }
                         : null
                 }


### PR DESCRIPTION
- Use less naive implementation and display ask details for order id, not order index in table
- Add support in TableMaterial to use rows string ids as TableRow keys (this allows React to more effectively manage rows when sorting etc.)
- Fix bug where ask details were staying open even when order was removed from the table for example due to filtering
- Use cleaner and more flexible implementation for displaying custom row in TableMaterial