### PR TITLE
Automatic ask creation using pre-defined price per device

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "test:ci:contracts": "lerna run --scope @energyweb/issuer --scope @energyweb/utils-general test:concurrent --since master --parallel --stream",
         "test:ci:apps": "lerna run --scope @energyweb/exchange --scope @energyweb/origin-backend test:concurrent --since master --parallel --stream",
         "test:ci:ui": "yarn test:ui",
-        "test:ci:e2e": "lerna run test:e2e --stream --scope @energyweb/exchange",
+        "test:ci:e2e": "lerna run test:e2e --stream --scope @energyweb/exchange --scope @energyweb/origin-backend",
         "publish:canary": "lerna publish --yes --skip-git --exact --cd-version=prerelease --pre-dist-tag canary --preid=alpha.$TRAVIS_BUILD_NUMBER",
         "publish:release": "lerna version --create-release github --conventional-commits --exact --yes --message \"chore(release): publish /skip-deploy\" && lerna publish from-git --yes",
         "build:containers:canary": "lerna run build:container:canary --stream",

--- a/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
+++ b/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
@@ -60,6 +60,10 @@ export class Entity implements IDevice {
 
     organization: number;
 
+    automaticPostForSale: boolean;
+
+    defaultAskPrice: number;
+
     constructor(
         public id: number,
         public configuration: Configuration.Entity,

--- a/packages/device-registry/src/test/DeviceFacade.test.ts
+++ b/packages/device-registry/src/test/DeviceFacade.test.ts
@@ -65,7 +65,9 @@ describe('Device Facade', () => {
                 region: '',
                 province: '',
                 organization: 4,
-                gridOperator: ''
+                gridOperator: '',
+                automaticPostForSale: false,
+                defaultAskPrice: null
             };
 
             assert.equal(await ProducingDevice.getDeviceListLength(conf), 0);

--- a/packages/exchange/src/pods/deposit-watcher/deposit-watcher.module.ts
+++ b/packages/exchange/src/pods/deposit-watcher/deposit-watcher.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { DepositWatcherService } from './deposit-watcher.service';
 import { TransferModule } from '../transfer/transfer.module';
+import { OrderModule } from '../order/order.module';
+import { AccountModule } from '../account/account.module';
 
 @Module({
     providers: [DepositWatcherService],
-    imports: [TransferModule],
+    imports: [TransferModule, OrderModule, AccountModule],
     exports: [DepositWatcherService]
 })
 export class DepositWatcherModule {}

--- a/packages/exchange/test/deposits-auto-post-for-sale.e2e-spec.ts
+++ b/packages/exchange/test/deposits-auto-post-for-sale.e2e-spec.ts
@@ -1,0 +1,105 @@
+import { OrderSide } from '@energyweb/exchange-core';
+import { DeviceService, ExtendedBaseEntity } from '@energyweb/origin-backend';
+import { IDeviceProductInfo, IDeviceWithRelationsIds } from '@energyweb/origin-backend-core';
+import { INestApplication } from '@nestjs/common';
+import { Contract, ethers } from 'ethers';
+import moment from 'moment';
+import request from 'supertest';
+
+import { AccountService } from '../src/pods/account/account.service';
+import { OrderStatus } from '../src/pods/order/order-status.enum';
+import { Order } from '../src/pods/order/order.entity';
+import { DatabaseService } from './database.service';
+import { bootstrapTestInstance } from './exchange';
+import { depositToken, issueToken, provider } from './utils';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('Deposits automatic posting for sale', () => {
+    let app: INestApplication;
+    let databaseService: DatabaseService;
+    let accountService: AccountService;
+
+    const user1Id = '1';
+
+    let registry: Contract;
+    let issuer: Contract;
+
+    let depositAddress: string;
+
+    const defaultAskPrice = 1000;
+
+    const deviceServiceMock = ({
+        findDeviceProductInfo: async (): Promise<IDeviceProductInfo> => {
+            return {
+                deviceType: 'Solar;Photovoltaic;Classic silicon',
+                country: 'Thailand',
+                region: 'Central',
+                province: 'Nakhon Pathom',
+                operationalSince: 2016,
+                gridOperator: 'TH-PEA'
+            };
+        },
+        findByExternalId: async (): Promise<ExtendedBaseEntity & IDeviceWithRelationsIds> => {
+            return {
+                deviceType: 'Solar;Photovoltaic;Classic silicon',
+                country: 'Thailand',
+                region: 'Central',
+                province: 'Nakhon Pathom',
+                operationalSince: 2016,
+                gridOperator: 'TH-PEA',
+                automaticPostForSale: true,
+                defaultAskPrice
+            } as ExtendedBaseEntity & IDeviceWithRelationsIds;
+        }
+    } as unknown) as DeviceService;
+
+    beforeAll(async () => {
+        ({ accountService, databaseService, registry, issuer, app } = await bootstrapTestInstance(
+            deviceServiceMock
+        ));
+
+        await app.init();
+
+        ({ address: depositAddress } = await accountService.getOrCreateAccount(user1Id));
+    });
+
+    afterAll(async () => {
+        await databaseService.cleanUp();
+        await app.close();
+    });
+
+    const tokenReceiverPrivateKey =
+        '0xca77c9b06fde68bcbcc09f603c958620613f4be79f3abb4b2032131d0229462e';
+    const tokenReceiver = new ethers.Wallet(tokenReceiverPrivateKey, provider);
+
+    const generationFrom = moment('2020-01-01').unix();
+    const generationTo = moment('2020-01-31').unix();
+
+    it('should automatically post deposit token to sell', async () => {
+        const depositAmount = '10';
+
+        const id = await issueToken(
+            issuer,
+            tokenReceiver.address,
+            '1000',
+            generationFrom,
+            generationTo
+        );
+        await depositToken(registry, tokenReceiver, depositAddress, depositAmount, id);
+
+        await sleep(3000);
+
+        await request(app.getHttpServer())
+            .get('/orders')
+            .expect(200)
+            .expect((res) => {
+                const [ask] = res.body as Order[];
+
+                expect(ask.currentVolume).toBe(depositAmount);
+                expect(ask.status).toBe(OrderStatus.Active);
+                expect(ask.side).toBe(OrderSide.Ask);
+                expect(ask.price).toBe(defaultAskPrice);
+            });
+    });
+});

--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Contracts } from '@energyweb/issuer';
-import { ConfigurationService, DeviceService } from '@energyweb/origin-backend';
-import { IDeviceProductInfo } from '@energyweb/origin-backend-core';
+import { ConfigurationService, DeviceService, ExtendedBaseEntity } from '@energyweb/origin-backend';
+import { IDeviceProductInfo, IDeviceWithRelationsIds } from '@energyweb/origin-backend-core';
 import { CanActivate, ExecutionContext, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AuthGuard } from '@nestjs/passport';
@@ -75,7 +75,7 @@ const deviceTypes = [
     ['Marine', 'Tidal', 'Offshore']
 ];
 
-export const bootstrapTestInstance = async () => {
+export const bootstrapTestInstance = async (deviceServiceMock?: DeviceService) => {
     const registry = await deployRegistry();
     const issuer = await deployIssuer(registry.address);
 
@@ -108,18 +108,34 @@ export const bootstrapTestInstance = async () => {
             },
             {
                 provide: DeviceService,
-                useValue: ({
-                    findDeviceProductInfo: async (): Promise<IDeviceProductInfo> => {
-                        return {
-                            deviceType: 'Solar;Photovoltaic;Classic silicon',
-                            country: 'Thailand',
-                            region: 'Central',
-                            province: 'Nakhon Pathom',
-                            operationalSince: 2016,
-                            gridOperator: 'TH-PEA'
-                        };
-                    }
-                } as unknown) as DeviceService
+                useValue:
+                    deviceServiceMock ??
+                    (({
+                        findDeviceProductInfo: async (): Promise<IDeviceProductInfo> => {
+                            return {
+                                deviceType: 'Solar;Photovoltaic;Classic silicon',
+                                country: 'Thailand',
+                                region: 'Central',
+                                province: 'Nakhon Pathom',
+                                operationalSince: 2016,
+                                gridOperator: 'TH-PEA'
+                            };
+                        },
+                        findByExternalId: async (): Promise<
+                            ExtendedBaseEntity & IDeviceWithRelationsIds
+                        > => {
+                            return {
+                                deviceType: 'Solar;Photovoltaic;Classic silicon',
+                                country: 'Thailand',
+                                region: 'Central',
+                                province: 'Nakhon Pathom',
+                                operationalSince: 2016,
+                                gridOperator: 'TH-PEA',
+                                automaticPostForSale: false,
+                                defaultAskPrice: null
+                            } as ExtendedBaseEntity & IDeviceWithRelationsIds;
+                        }
+                    } as unknown) as DeviceService)
             }
         ]
     })

--- a/packages/exchange/test/utils.ts
+++ b/packages/exchange/test/utils.ts
@@ -1,0 +1,60 @@
+import { ContractTransaction, Contract, ethers } from 'ethers';
+import { Contracts } from '@energyweb/issuer';
+
+const registryInterface = new ethers.utils.Interface(Contracts.IssuerJSON.abi);
+
+const web3 = 'http://localhost:8580';
+
+export const issueToken = async (
+    issuer: Contract,
+    address: string,
+    amount: string,
+    generationFrom: number,
+    generationTo: number
+) => {
+    const deviceId = 'QWERTY123';
+
+    const data = await issuer.encodeData(generationFrom, generationTo, deviceId);
+
+    const requestReceipt = await ((await issuer.requestCertificationFor(
+        data,
+        address,
+        false
+    )) as ContractTransaction).wait();
+
+    const {
+        values: { _id: requestId }
+    } = registryInterface.parseLog(requestReceipt.logs[0]);
+
+    const validityData = registryInterface.functions.isRequestValid.encode([requestId.toString()]);
+
+    const approvalReceipt = await ((await issuer.approveCertificationRequest(
+        requestId,
+        amount,
+        validityData
+    )) as ContractTransaction).wait();
+
+    const { args } = approvalReceipt.events.find((e) => e.event === 'CertificationRequestApproved');
+
+    return args[2].toString();
+};
+
+export const depositToken = async (
+    registry: Contract,
+    sender: ethers.Wallet,
+    to: string,
+    amount: string,
+    id: number
+) => {
+    const registryWithUserAsSigner = registry.connect(sender);
+
+    await registryWithUserAsSigner.functions.safeTransferFrom(
+        sender.address,
+        to,
+        id,
+        amount,
+        '0x0'
+    );
+};
+
+export const provider = new ethers.providers.JsonRpcProvider(web3);

--- a/packages/origin-backend-core/src/Device.ts
+++ b/packages/origin-backend-core/src/Device.ts
@@ -60,6 +60,8 @@ export interface IDeviceProperties extends IDeviceProductInfo {
     lastSmartMeterReading?: ISmartMeterRead;
     deviceGroup?: string;
     smartMeterReads?: ISmartMeterRead[];
+    defaultAskPrice: number;
+    automaticPostForSale: boolean;
 }
 
 export interface IDevice extends IDeviceProperties {
@@ -76,3 +78,4 @@ export interface IDeviceWithRelations extends IDevice {
 
 export type DeviceCreateData = Omit<IDeviceProperties, 'id'>;
 export type DeviceUpdateData = Pick<IDevice, 'status'>;
+export type DeviceSettingsUpdateData = Pick<IDevice, 'defaultAskPrice' | 'automaticPostForSale'>;

--- a/packages/origin-backend/migrations/1587979261608-DefaultAskPriceColumnInDevice.ts
+++ b/packages/origin-backend/migrations/1587979261608-DefaultAskPriceColumnInDevice.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DefaultAskPriceColumnInDevice1587979261608 implements MigrationInterface {
+    name = 'DefaultAskPriceColumnInDevice1587979261608';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "device" ADD "defaultAskPrice" integer`, undefined);
+        await queryRunner.query(
+            `ALTER TABLE "certification_request" ALTER COLUMN "id" DROP DEFAULT`,
+            undefined
+        );
+        await queryRunner.query(`DROP SEQUENCE "certification_request_id_seq"`, undefined);
+        await queryRunner.query(
+            `ALTER TABLE "certification_request" DROP COLUMN "energy"`,
+            undefined
+        );
+        await queryRunner.query(
+            `ALTER TABLE "certification_request" ADD "energy" character varying NOT NULL`,
+            undefined
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "certification_request" DROP COLUMN "energy"`,
+            undefined
+        );
+        await queryRunner.query(
+            `ALTER TABLE "certification_request" ADD "energy" bigint NOT NULL`,
+            undefined
+        );
+        await queryRunner.query(
+            `CREATE SEQUENCE "certification_request_id_seq" OWNED BY "certification_request"."id"`,
+            undefined
+        );
+        await queryRunner.query(
+            `ALTER TABLE "certification_request" ALTER COLUMN "id" SET DEFAULT nextval('certification_request_id_seq')`,
+            undefined
+        );
+        await queryRunner.query(`ALTER TABLE "device" DROP COLUMN "defaultAskPrice"`, undefined);
+    }
+}

--- a/packages/origin-backend/migrations/1588072060552-AutomaticPostForSaleFlag.ts
+++ b/packages/origin-backend/migrations/1588072060552-AutomaticPostForSaleFlag.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AutomaticPostForSaleFlag1588072060552 implements MigrationInterface {
+    name = 'AutomaticPostForSaleFlag1588072060552';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "device" ADD "automaticPostForSale" boolean NOT NULL DEFAULT false`,
+            undefined
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "device" DROP COLUMN "automaticPostForSale"`,
+            undefined
+        );
+    }
+}

--- a/packages/origin-backend/package.json
+++ b/packages/origin-backend/package.json
@@ -14,7 +14,7 @@
         "build": "yarn build:ts",
         "build:ts": "tsc -b tsconfig.build.json --verbose --pretty && cp migrations/initial.sql dist/js/migrations/",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
-        "test:e2e": "jest --runInBand --verbose --config ./test/jest-e2e.json --forceExit",
+        "test:e2e": "yarn typeorm:run && jest --runInBand --verbose --config ./test/jest-e2e.json --forceExit",
         "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/.bin/typeorm --config ormconfig-dev.ts",
         "typeorm:migrate": "yarn typeorm migration:generate -- -n",
         "typeorm:run": "yarn typeorm migration:run",

--- a/packages/origin-backend/package.json
+++ b/packages/origin-backend/package.json
@@ -14,7 +14,7 @@
         "build": "yarn build:ts",
         "build:ts": "tsc -b tsconfig.build.json --verbose --pretty && cp migrations/initial.sql dist/js/migrations/",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
-        "test:e2e": "TS_NODE_PROJECT=tsconfig.build.json TS_NODE_FILES=true mocha -r ts-node/register src/test/e2e/*.test.ts --timeout 60000 --exit",
+        "test:e2e": "jest --runInBand --verbose --config ./test/jest-e2e.json --forceExit",
         "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/.bin/typeorm --config ormconfig-dev.ts",
         "typeorm:migrate": "yarn typeorm migration:generate -- -n",
         "typeorm:run": "yarn typeorm migration:run",
@@ -96,7 +96,8 @@
         "nodemailer": "6.4.6",
         "supertest": "4.0.2",
         "ts-jest": "25.4.0",
-        "tsconfig-paths": "3.9.0"
+        "tsconfig-paths": "3.9.0",
+        "polly-js": "1.6.5"
     },
     "files": [
         "dist",

--- a/packages/origin-backend/src/pods/device/device.entity.ts
+++ b/packages/origin-backend/src/pods/device/device.entity.ts
@@ -83,4 +83,7 @@ export class Device extends ExtendedBaseEntity implements IDevice {
 
     @Column({ nullable: true })
     gridOperator: string;
+
+    @Column({ nullable: true })
+    defaultAskPrice: number;
 }

--- a/packages/origin-backend/src/pods/device/device.entity.ts
+++ b/packages/origin-backend/src/pods/device/device.entity.ts
@@ -86,4 +86,7 @@ export class Device extends ExtendedBaseEntity implements IDevice {
 
     @Column({ nullable: true })
     defaultAskPrice: number;
+
+    @Column({ default: false })
+    automaticPostForSale: boolean;
 }

--- a/packages/origin-backend/src/pods/device/device.service.ts
+++ b/packages/origin-backend/src/pods/device/device.service.ts
@@ -1,5 +1,6 @@
 import {
     DeviceCreateData,
+    DeviceStatusChangedEvent,
     DeviceUpdateData,
     IDevice,
     IDeviceProductInfo,
@@ -7,11 +8,9 @@ import {
     IExternalDeviceId,
     ISmartMeterRead,
     ISmartMeterReadingsAdapter,
-    DeviceStatusChangedEvent,
     SupportedEvents
 } from '@energyweb/origin-backend-core';
 import {
-    BadRequestException,
     Inject,
     Injectable,
     NotFoundException,
@@ -23,12 +22,12 @@ import { FindOneOptions, Repository } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import { SM_READS_ADAPTER } from '../../const';
-import { ConfigurationService } from '../configuration';
 import { StorageErrors } from '../../enums/StorageErrors';
+import { ConfigurationService } from '../configuration';
 import { ExtendedBaseEntity } from '../ExtendedBaseEntity';
+import { NotificationService } from '../notification';
 import { OrganizationService } from '../organization';
 import { Device } from './device.entity';
-import { NotificationService } from '../notification';
 
 @Injectable()
 export class DeviceService {
@@ -103,14 +102,9 @@ export class DeviceService {
             });
         }
 
-        try {
-            await this.repository.save(newEntity);
+        await this.repository.save(newEntity);
 
-            return newEntity;
-        } catch (error) {
-            console.warn('Error while saving entity', error);
-            throw new BadRequestException('Could not save device.');
-        }
+        return newEntity;
     }
 
     async remove(entity: Device | (ExtendedBaseEntity & IDeviceWithRelationsIds)) {

--- a/packages/origin-backend/src/pods/device/device.service.ts
+++ b/packages/origin-backend/src/pods/device/device.service.ts
@@ -8,7 +8,8 @@ import {
     IExternalDeviceId,
     ISmartMeterRead,
     ISmartMeterReadingsAdapter,
-    SupportedEvents
+    SupportedEvents,
+    DeviceSettingsUpdateData
 } from '@energyweb/origin-backend-core';
 import {
     Inject,
@@ -205,6 +206,31 @@ export class DeviceService {
                 type: SupportedEvents.DEVICE_STATUS_CHANGED,
                 data: event
             });
+
+            return {
+                message: `Device ${id} successfully updated`
+            };
+        } catch (error) {
+            throw new UnprocessableEntityException({
+                message: `Device ${id} could not be updated due to an error ${error.message}`
+            });
+        }
+    }
+
+    async updateSettings(id: string, update: DeviceSettingsUpdateData) {
+        const device = await this.findOne(id);
+
+        if (!device) {
+            throw new NotFoundException(StorageErrors.NON_EXISTENT);
+        }
+
+        device.automaticPostForSale = update.automaticPostForSale;
+        if (update.automaticPostForSale) {
+            device.defaultAskPrice = update.defaultAskPrice;
+        }
+
+        try {
+            await this.repository.save(device);
 
             return {
                 message: `Device ${id} successfully updated`

--- a/packages/origin-backend/src/pods/organization/organization.service.ts
+++ b/packages/origin-backend/src/pods/organization/organization.service.ts
@@ -104,4 +104,14 @@ export class OrganizationService {
 
         return this.findOne(id);
     }
+
+    async hasDevice(id: number, deviceId: string) {
+        const devicesCount = await this.repository
+            .createQueryBuilder('organization')
+            .leftJoinAndSelect('organization.devices', 'device')
+            .where('device.id = :deviceId AND organization.id = :id', { id, deviceId })
+            .getCount();
+
+        return devicesCount === 1;
+    }
 }

--- a/packages/origin-backend/src/pods/organization/organization.service.ts
+++ b/packages/origin-backend/src/pods/organization/organization.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnprocessableEntityException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, FindOneOptions } from 'typeorm';
 import {
@@ -7,8 +7,11 @@ import {
     IUserWithRelationsIds,
     isRole,
     Role,
-    OrganizationUpdateData
+    OrganizationUpdateData,
+    OrganizationPostData,
+    OrganizationStatus
 } from '@energyweb/origin-backend-core';
+import { validate } from 'class-validator';
 import { Organization } from './organization.entity';
 import { UserService } from '../user';
 import { ExtendedBaseEntity } from '../ExtendedBaseEntity';
@@ -20,6 +23,35 @@ export class OrganizationService {
         private readonly repository: Repository<Organization>,
         private readonly userService: UserService
     ) {}
+
+    async create(userId: number, data: OrganizationPostData) {
+        const newEntity = new Organization();
+
+        const user = await this.userService.findById(userId);
+
+        const newOrganization: Omit<IOrganization, 'id'> = {
+            ...data,
+            status: OrganizationStatus.Submitted,
+            leadUser: user,
+            users: [user],
+            devices: []
+        };
+
+        Object.assign(newEntity, newOrganization);
+
+        const validationErrors = await validate(newEntity);
+
+        if (validationErrors.length > 0) {
+            throw new UnprocessableEntityException({
+                success: false,
+                errors: validationErrors.map((e) => e?.toString())
+            });
+        } else {
+            await this.repository.save(newEntity);
+
+            return newEntity;
+        }
+    }
 
     async findOne(
         id: string | number,

--- a/packages/origin-backend/src/pods/user/user.service.ts
+++ b/packages/origin-backend/src/pods/user/user.service.ts
@@ -143,7 +143,7 @@ export class UserService {
         return this.repository.save(user);
     }
 
-    private findOne(conditions: FindConditions<User>): Promise<TUserBaseEntity> {
+    async findOne(conditions: FindConditions<User>): Promise<TUserBaseEntity> {
         return (this.repository.findOne(conditions, {
             loadRelationIds: true
         }) as Promise<IUser>) as Promise<TUserBaseEntity>;

--- a/packages/origin-backend/test/database.service.ts
+++ b/packages/origin-backend/test/database.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { InjectConnection } from '@nestjs/typeorm';
+import polly from 'polly-js';
+import { Connection } from 'typeorm';
+
+@Injectable()
+export class DatabaseService {
+    constructor(
+        @InjectConnection()
+        private readonly connection: Connection
+    ) {}
+
+    public async cleanUp() {
+        const tables = this.connection.entityMetadatas.map((e) => `"${e.tableName}"`).join(', ');
+
+        try {
+            await polly()
+                .waitAndRetry(3)
+                .executeForPromise(() => this.connection.query(`TRUNCATE ${tables} CASCADE;`));
+        } catch (error) {
+            throw new Error(`ERROR: Cleaning test db: ${error}`);
+        }
+    }
+
+    public async truncate(table: string) {
+        return this.connection.query(`TRUNCATE "${table}" CASCADE;`);
+    }
+}

--- a/packages/origin-backend/test/device.e2e-spec.ts
+++ b/packages/origin-backend/test/device.e2e-spec.ts
@@ -1,0 +1,122 @@
+/* eslint-disable no-return-assign */
+import {
+    DeviceStatus,
+    IDeviceWithRelationsIds,
+    DeviceSettingsUpdateData,
+    Role
+} from '@energyweb/origin-backend-core';
+import request from 'supertest';
+
+import { registerAndLogin, bootstrapTestInstance } from './origin-backend';
+
+describe('Device e2e tests', () => {
+    it('should allow to edit settings for organization member with DeviceManager role', async () => {
+        const {
+            app,
+            userService,
+            databaseService,
+            deviceService,
+            organizationService,
+            configurationService
+        } = await bootstrapTestInstance();
+
+        await app.init();
+
+        await databaseService.cleanUp();
+
+        const { accessToken, organization } = await registerAndLogin(
+            app,
+            configurationService,
+            userService,
+            organizationService,
+            [Role.Trader, Role.DeviceManager]
+        );
+
+        const { id: deviceId } = await deviceService.create({
+            address: '',
+            capacityInW: 1000,
+            complianceRegistry: 'I-REC',
+            country: 'EU',
+            description: '',
+            deviceType: 'Solar',
+            facilityName: 'Test',
+            gpsLatitude: '10',
+            gpsLongitude: '10',
+            gridOperator: 'OP',
+            images: '',
+            operationalSince: 2000,
+            organization: organization.id,
+            otherGreenAttributes: '',
+            province: '',
+            region: '',
+            status: DeviceStatus.Active,
+            timezone: '',
+            typeOfPublicSupport: '',
+            deviceGroup: '',
+            smartMeterReads: [],
+            externalDeviceIds: [],
+            automaticPostForSale: false,
+            defaultAskPrice: null
+        });
+
+        await request(app.getHttpServer())
+            .get(`/device/${deviceId}`)
+            .set('Authorization', `Bearer ${accessToken}`)
+            .expect((res) => {
+                const device = res.body as IDeviceWithRelationsIds;
+
+                expect(device.defaultAskPrice).toBe(null);
+                expect(device.automaticPostForSale).toBe(false);
+            });
+
+        await request(app.getHttpServer())
+            .put(`/device/${deviceId}/settings`)
+            .set('Authorization', `Bearer ${accessToken}`)
+            .expect(422);
+
+        const settingWithZeroPrice: DeviceSettingsUpdateData = {
+            defaultAskPrice: 0,
+            automaticPostForSale: true
+        };
+
+        await request(app.getHttpServer())
+            .put(`/device/${deviceId}/settings`)
+            .set('Authorization', `Bearer ${accessToken}`)
+            .send(settingWithZeroPrice)
+            .expect(422);
+
+        const settingWithNonIntegerPrice: DeviceSettingsUpdateData = {
+            defaultAskPrice: 1.3,
+            automaticPostForSale: true
+        };
+
+        await request(app.getHttpServer())
+            .put(`/device/${deviceId}/settings`)
+            .set('Authorization', `Bearer ${accessToken}`)
+            .send(settingWithNonIntegerPrice)
+            .expect(422);
+
+        const settingWithCorrectPrice: DeviceSettingsUpdateData = {
+            defaultAskPrice: 1000,
+            automaticPostForSale: true
+        };
+
+        await request(app.getHttpServer())
+            .put(`/device/${deviceId}/settings`)
+            .set('Authorization', `Bearer ${accessToken}`)
+            .send(settingWithCorrectPrice)
+            .expect(200);
+
+        await request(app.getHttpServer())
+            .get(`/device/${deviceId}`)
+            .set('Authorization', `Bearer ${accessToken}`)
+            .expect((res) => {
+                const device = res.body as IDeviceWithRelationsIds;
+
+                expect(device.defaultAskPrice).toBe(settingWithCorrectPrice.defaultAskPrice);
+                expect(device.automaticPostForSale).toBe(true);
+            });
+
+        await app.close();
+    });
+});

--- a/packages/origin-backend/test/jest-e2e.json
+++ b/packages/origin-backend/test/jest-e2e.json
@@ -1,0 +1,8 @@
+{
+    "moduleFileExtensions": ["js", "json", "ts", "d.ts"],
+    "testEnvironment": "node",
+    "testRegex": ".e2e-spec.ts$",
+    "transform": {
+        "^.+\\.(t|j)s$": "ts-jest"
+    }
+}

--- a/packages/origin-backend/test/organization.e2e-spec.ts
+++ b/packages/origin-backend/test/organization.e2e-spec.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-return-assign */
-import { DeviceStatus } from '@energyweb/origin-backend-core';
+import { DeviceStatus, Role } from '@energyweb/origin-backend-core';
 import request from 'supertest';
 
 import { Device } from '../src/pods/device';
-import { basicSetup, bootstrapTestInstance } from './origin-backend';
+import { registerAndLogin, bootstrapTestInstance } from './origin-backend';
 
 describe('Organization e2e tests', () => {
     it('should return organization devices only', async () => {
@@ -20,11 +20,12 @@ describe('Organization e2e tests', () => {
 
         await databaseService.cleanUp();
 
-        const { accessToken, organization } = await basicSetup(
+        const { accessToken, organization } = await registerAndLogin(
             app,
             configurationService,
             userService,
-            organizationService
+            organizationService,
+            [Role.DeviceManager]
         );
 
         await deviceService.create({
@@ -49,7 +50,9 @@ describe('Organization e2e tests', () => {
             typeOfPublicSupport: '',
             deviceGroup: '',
             smartMeterReads: [],
-            externalDeviceIds: []
+            externalDeviceIds: [],
+            automaticPostForSale: false,
+            defaultAskPrice: 0
         });
 
         await request(app.getHttpServer())

--- a/packages/origin-backend/test/organization.e2e-spec.ts
+++ b/packages/origin-backend/test/organization.e2e-spec.ts
@@ -1,0 +1,66 @@
+/* eslint-disable no-return-assign */
+import { DeviceStatus } from '@energyweb/origin-backend-core';
+import request from 'supertest';
+
+import { Device } from '../src/pods/device';
+import { basicSetup, bootstrapTestInstance } from './origin-backend';
+
+describe('Organization e2e tests', () => {
+    it('should return organization devices only', async () => {
+        const {
+            app,
+            userService,
+            databaseService,
+            deviceService,
+            organizationService,
+            configurationService
+        } = await bootstrapTestInstance();
+
+        await app.init();
+
+        await databaseService.cleanUp();
+
+        const { accessToken, organization } = await basicSetup(
+            app,
+            configurationService,
+            userService,
+            organizationService
+        );
+
+        await deviceService.create({
+            address: '',
+            capacityInW: 1000,
+            complianceRegistry: 'I-REC',
+            country: 'EU',
+            description: '',
+            deviceType: 'Solar',
+            facilityName: 'Test',
+            gpsLatitude: '10',
+            gpsLongitude: '10',
+            gridOperator: 'OP',
+            images: '',
+            operationalSince: 2000,
+            organization: organization.id,
+            otherGreenAttributes: '',
+            province: '',
+            region: '',
+            status: DeviceStatus.Active,
+            timezone: '',
+            typeOfPublicSupport: '',
+            deviceGroup: '',
+            smartMeterReads: [],
+            externalDeviceIds: []
+        });
+
+        await request(app.getHttpServer())
+            .get(`/organization/${organization.id}/devices`)
+            .set('Authorization', `Bearer ${accessToken}`)
+            .expect((res) => {
+                const devices = res.body as Device[];
+
+                expect(devices).toHaveLength(1);
+            });
+
+        await app.close();
+    });
+});

--- a/packages/origin-backend/test/origin-backend.ts
+++ b/packages/origin-backend/test/origin-backend.ts
@@ -47,51 +47,71 @@ export const bootstrapTestInstance = async () => {
     };
 };
 
-export const basicSetup = async (
+export const registerAndLogin = async (
     app: any,
     configurationService: ConfigurationService,
     userService: UserService,
-    organizationService: OrganizationService
+    organizationService: OrganizationService,
+    roles: Role[] = [Role.UserAdmin],
+    userNonce = 0,
+    orgNonce = 0
 ) => {
     await configurationService.update({
         contractsLookup: { registry: '', issuer: '' }
     });
 
-    const userRegistration: UserRegisterData = {
-        email: 'test@example.com',
-        password: '123',
-        firstName: 'Name',
-        lastName: 'Name',
-        title: 'Sir',
-        rights: buildRights([Role.UserAdmin, Role.DeviceManager]),
-        telephone: '991'
-    };
+    const userEmail = `user${userNonce}@example.com`;
 
-    const organizationRegistration = {
-        email: 'org@example.com',
-        code: '',
-        contact: '',
-        telephone: '',
-        address: '',
-        shareholders: '',
-        ceoName: 'John',
-        vatNumber: '',
-        postcode: '',
-        businessTypeSelect: '',
-        businessTypeInput: '',
-        activeCountries: 'EU',
-        name: 'Test',
-        ceoPassportNumber: '1',
-        companyNumber: '2',
-        headquartersCountry: 1,
-        country: 1,
-        yearOfRegistration: 2000,
-        numberOfEmployees: 1,
-        website: 'http://example.com'
-    } as OrganizationPostData;
+    let user = await userService.findOne({ email: userEmail });
+    if (!user) {
+        const userRegistration: UserRegisterData = {
+            email: userEmail,
+            password: '123',
+            firstName: 'Name',
+            lastName: 'Name',
+            title: 'Sir',
+            rights: buildRights(roles),
+            telephone: '991'
+        };
+        await userService.create(userRegistration);
+        user = await userService.findOne({ email: userEmail });
+    }
 
-    const user = await userService.create(userRegistration);
-    const organization = await organizationService.create(user.id, organizationRegistration);
+    const organizationEmail = `org${orgNonce}@example.com`;
+
+    let organization = await organizationService.findOne(null, {
+        where: { email: organizationEmail }
+    });
+
+    if (!organization) {
+        const organizationRegistration = {
+            email: organizationEmail,
+            code: '',
+            contact: '',
+            telephone: '',
+            address: '',
+            shareholders: '',
+            ceoName: 'John',
+            vatNumber: '',
+            postcode: '',
+            businessTypeSelect: '',
+            businessTypeInput: '',
+            activeCountries: 'EU',
+            name: 'Test',
+            ceoPassportNumber: '1',
+            companyNumber: '2',
+            headquartersCountry: 1,
+            country: 1,
+            yearOfRegistration: 2000,
+            numberOfEmployees: 1,
+            website: 'http://example.com'
+        } as OrganizationPostData;
+
+        await organizationService.create(user.id, organizationRegistration);
+        organization = await organizationService.findOne(null, {
+            where: { email: organizationEmail }
+        });
+    }
 
     let accessToken: string;
 

--- a/packages/origin-backend/test/origin-backend.ts
+++ b/packages/origin-backend/test/origin-backend.ts
@@ -1,0 +1,107 @@
+/* eslint-disable no-return-assign */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+    buildRights,
+    OrganizationPostData,
+    Role,
+    UserRegisterData
+} from '@energyweb/origin-backend-core';
+import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+import { AppModule } from '../src/app.module';
+import { ConfigurationService } from '../src/pods/configuration';
+import { DeviceService } from '../src/pods/device';
+import { OrganizationService } from '../src/pods/organization';
+import { UserService } from '../src/pods/user';
+import { DatabaseService } from './database.service';
+
+const testLogger = new Logger('e2e');
+
+export const bootstrapTestInstance = async () => {
+    const moduleFixture = await Test.createTestingModule({
+        imports: [AppModule.register(null)],
+        providers: [DatabaseService]
+    }).compile();
+
+    const app = moduleFixture.createNestApplication();
+
+    const userService = await app.resolve<UserService>(UserService);
+    const databaseService = await app.resolve<DatabaseService>(DatabaseService);
+    const organizationService = await app.resolve<OrganizationService>(OrganizationService);
+    const deviceService = await app.resolve<DeviceService>(DeviceService);
+    const configurationService = await app.resolve<ConfigurationService>(ConfigurationService);
+
+    app.useLogger(testLogger);
+    app.enableCors();
+
+    return {
+        app,
+        databaseService,
+        userService,
+        testLogger,
+        organizationService,
+        deviceService,
+        configurationService
+    };
+};
+
+export const basicSetup = async (
+    app: any,
+    configurationService: ConfigurationService,
+    userService: UserService,
+    organizationService: OrganizationService
+) => {
+    await configurationService.update({
+        contractsLookup: { registry: '', issuer: '' }
+    });
+
+    const userRegistration: UserRegisterData = {
+        email: 'test@example.com',
+        password: '123',
+        firstName: 'Name',
+        lastName: 'Name',
+        title: 'Sir',
+        rights: buildRights([Role.UserAdmin, Role.DeviceManager]),
+        telephone: '991'
+    };
+
+    const organizationRegistration = {
+        email: 'org@example.com',
+        code: '',
+        contact: '',
+        telephone: '',
+        address: '',
+        shareholders: '',
+        ceoName: 'John',
+        vatNumber: '',
+        postcode: '',
+        businessTypeSelect: '',
+        businessTypeInput: '',
+        activeCountries: 'EU',
+        name: 'Test',
+        ceoPassportNumber: '1',
+        companyNumber: '2',
+        headquartersCountry: 1,
+        country: 1,
+        yearOfRegistration: 2000,
+        numberOfEmployees: 1,
+        website: 'http://example.com'
+    } as OrganizationPostData;
+
+    const user = await userService.create(userRegistration);
+    const organization = await organizationService.create(user.id, organizationRegistration);
+
+    let accessToken: string;
+
+    await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({
+            username: user.email,
+            password: '123'
+        })
+        .expect((res) => ({ accessToken } = res.body));
+
+    return { accessToken, user, organization };
+};

--- a/packages/origin-backend/tsconfig.json
+++ b/packages/origin-backend/tsconfig.json
@@ -1,14 +1,12 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "lib": [
-      "es6"
-    ],
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "removeComments": true,
-    "outDir": "./dist",
-    "types": ["node"]
-  },
-  "exclude": ["node_modules", "dist"]
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "lib": ["es6"],
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "removeComments": true,
+        "outDir": "./dist",
+        "types": ["node", "jest"]
+    },
+    "exclude": ["node_modules", "dist"]
 }

--- a/packages/origin-ui-core/src/components/AddDevice.tsx
+++ b/packages/origin-ui-core/src/components/AddDevice.tsx
@@ -167,7 +167,9 @@ export function AddDevice() {
                     description: values.projectStory,
                     images: JSON.stringify(imagesUploadedList),
                     externalDeviceIds,
-                    gridOperator: (selectedGridOperator && selectedGridOperator[0]) || ''
+                    gridOperator: (selectedGridOperator && selectedGridOperator[0]) || '',
+                    automaticPostForSale: false,
+                    defaultAskPrice: null
                 },
                 callback: () => {
                     formikActions.setSubmitting(false);

--- a/packages/origin-ui-core/src/components/DeviceGroupForm.tsx
+++ b/packages/origin-ui-core/src/components/DeviceGroupForm.tsx
@@ -232,7 +232,9 @@ export function DeviceGroupForm(props: IProps) {
                     images: JSON.stringify([]),
                     deviceGroup: JSON.stringify(values.children),
                     externalDeviceIds,
-                    gridOperator: ''
+                    gridOperator: '',
+                    automaticPostForSale: false,
+                    defaultAskPrice: null
                 },
                 callback: () => {
                     formikActions.setSubmitting(false);


### PR DESCRIPTION
This PR provides

- [x] API for setting the price per device
- [x] Exchange watcher creating Asks automatically
- [x] e2e test setup for `origin-backend`

New API endpoint added:

PUT `device/id/settings` was added and accepts `{ defaultAskPrice: number, automaticPostForSale: boolean}` Role.Trader is required to alter those settings.