### PR TITLE
Use same typeorm version in origin-backend

### DIFF
--- a/packages/origin-backend/package.json
+++ b/packages/origin-backend/package.json
@@ -69,7 +69,7 @@
         "precise-proofs-js": "^1.0.2",
         "reflect-metadata": "0.1.13",
         "rxjs": "6.5.5",
-        "typeorm": "0.2.24",
+        "typeorm": "0.2.22",
         "uuid": "7.0.3"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19119,7 +19119,7 @@ setprototypeof@1.1.1:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
-sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8:
+sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
@@ -21118,27 +21118,6 @@ typeorm@0.2.22:
     js-yaml "^3.13.1"
     mkdirp "^0.5.1"
     reflect-metadata "^0.1.13"
-    tslib "^1.9.0"
-    xml2js "^0.4.17"
-    yargonaut "^1.1.2"
-    yargs "^13.2.1"
-
-typeorm@0.2.24:
-  version "0.2.24"
-  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.2.24.tgz#cd0fbd907326873a96c98e290fca49c589f0ffa8"
-  integrity sha512-L9tQv6nNLRyh+gex/qc8/CyLs8u0kXKqk1OjYGF13k/KOg6N2oibwkuGgv0FuoTGYx2ta2NmqvuMUAMrHIY5ew==
-  dependencies:
-    app-root-path "^3.0.0"
-    buffer "^5.1.0"
-    chalk "^2.4.2"
-    cli-highlight "^2.0.0"
-    debug "^4.1.1"
-    dotenv "^6.2.0"
-    glob "^7.1.2"
-    js-yaml "^3.13.1"
-    mkdirp "^0.5.1"
-    reflect-metadata "^0.1.13"
-    sha.js "^2.4.11"
     tslib "^1.9.0"
     xml2js "^0.4.17"
     yargonaut "^1.1.2"


### PR DESCRIPTION
Downgrade to 0.2.22 since @energyweb/exchange is not compatible with typeorm 0.2.24 as reported in #901 and occasionally we see the error:

```
2020-05-07T11:01:43.696646+00:00 app[web.1]: [Nest] 3   - 05/07/2020, 11:01:43 AM   [ExceptionHandler] No repository for "Account" was found. Looks like this entity is not registered in current "ExchangeConnection" connection? +2ms
2020-05-07T11:01:43.696758+00:00 app[web.1]: RepositoryNotFoundError: No repository for "Account" was found. Looks like this entity is not registered in current "ExchangeConnection" connection?
```
