### PR TITLE
Single connection pool for origin-backend and exchange

### DIFF
--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -51,7 +51,7 @@
         "@nestjs/platform-express": "7.0.9",
         "@nestjs/schedule": "0.3.1",
         "@nestjs/swagger": "4.5.3",
-        "@nestjs/typeorm": "6.3.4",
+        "@nestjs/typeorm": "7.0.0",
         "bn.js": "^5.1.1",
         "class-transformer": "0.2.3",
         "class-validator": "0.12.2",

--- a/packages/exchange/src/app.module.ts
+++ b/packages/exchange/src/app.module.ts
@@ -2,30 +2,22 @@ import { Module, ValidationPipe } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
 import { ScheduleModule } from '@nestjs/schedule';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import fs from 'fs';
 import path from 'path';
-import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 
 import { EmptyResultInterceptor } from './empty-result.interceptor';
 import { AccountBalanceModule } from './pods/account-balance/account-balance.module';
 import { AccountDeployerModule } from './pods/account-deployer/account-deployer.module';
-import { Account } from './pods/account/account.entity';
 import { AccountModule } from './pods/account/account.module';
-import { Asset } from './pods/asset/asset.entity';
 import { AssetModule } from './pods/asset/asset.module';
-import { Demand } from './pods/demand/demand.entity';
 import { DemandModule } from './pods/demand/demand.module';
 import { DepositWatcherModule } from './pods/deposit-watcher/deposit-watcher.module';
 import { MatchingEngineModule } from './pods/matching-engine/matching-engine.module';
 import { OrderBookModule } from './pods/order-book/order-book.module';
-import { Order } from './pods/order/order.entity';
 import { OrderModule } from './pods/order/order.module';
 import { ProductModule } from './pods/product/product.module';
 import { RunnerModule } from './pods/runner/runner.module';
-import { Trade } from './pods/trade/trade.entity';
 import { TradeModule } from './pods/trade/trade.module';
-import { Transfer } from './pods/transfer/transfer.entity';
 import { TransferModule } from './pods/transfer/transfer.module';
 import { WithdrawalProcessorModule } from './pods/withdrawal-processor/withdrawal-processor.module';
 import { HTTPLoggingInterceptor } from './utils/httpLoggingInterceptor';
@@ -47,37 +39,11 @@ const getEnvFilePath = () => {
     return finalPath;
 };
 
-const getDBConnectionOptions = (): PostgresConnectionOptions => {
-    return process.env.DATABASE_URL
-        ? {
-              type: 'postgres',
-              url: process.env.DATABASE_URL,
-              ssl: {
-                  rejectUnauthorized: false
-              }
-          }
-        : {
-              type: 'postgres',
-              host: process.env.DB_HOST ?? 'localhost',
-              port: Number(process.env.DB_PORT) ?? 5432,
-              username: process.env.DB_USERNAME ?? 'postgres',
-              password: process.env.DB_PASSWORD ?? 'postgres',
-              database: process.env.DB_DATABASE ?? 'origin'
-          };
-};
-
 @Module({
     imports: [
         ConfigModule.forRoot({
             envFilePath: getEnvFilePath(),
             isGlobal: true
-        }),
-        TypeOrmModule.forRoot({
-            ...getDBConnectionOptions(),
-            name: 'ExchangeConnection',
-            entities: [Demand, Order, Trade, Asset, Transfer, Account],
-            synchronize: false,
-            logging: ['info']
         }),
         ScheduleModule.forRoot(),
         MatchingEngineModule,

--- a/packages/exchange/src/index.ts
+++ b/packages/exchange/src/index.ts
@@ -1,10 +1,10 @@
+import { Account } from './pods/account/account.entity';
+import { Asset } from './pods/asset/asset.entity';
+import { Demand } from './pods/demand/demand.entity';
+import { Order } from './pods/order/order.entity';
+import { Trade } from './pods/trade/trade.entity';
+import { Transfer } from './pods/transfer/transfer.entity';
+
 export { AppModule } from './app.module';
 
-export { MatchingEngineModule } from './pods/matching-engine/matching-engine.module';
-export { OrderModule } from './pods/order/order.module';
-export { TradeModule } from './pods/trade/trade.module';
-export { OrderBookModule } from './pods/order-book/order-book.module';
-export { DemandModule } from './pods/demand/demand.module';
-export { Demand } from './pods/demand/demand.entity';
-export { Trade } from './pods/trade/trade.entity';
-export { Order } from './pods/order/order.entity';
+export const entities = [Demand, Trade, Order, Transfer, Account, Asset];

--- a/packages/exchange/src/pods/account/account.module.ts
+++ b/packages/exchange/src/pods/account/account.module.ts
@@ -9,7 +9,7 @@ import { AccountService } from './account.service';
 
 @Module({
     imports: [
-        TypeOrmModule.forFeature([Account], 'ExchangeConnection'),
+        TypeOrmModule.forFeature([Account]),
         forwardRef(() => AccountBalanceModule),
         AccountDeployerModule
     ],

--- a/packages/exchange/src/pods/account/account.service.ts
+++ b/packages/exchange/src/pods/account/account.service.ts
@@ -1,5 +1,4 @@
 import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
-import { InjectConnection } from '@nestjs/typeorm';
 import { Connection, EntityManager } from 'typeorm';
 
 import { AccountBalanceService } from '../account-balance/account-balance.service';
@@ -14,7 +13,6 @@ export class AccountService {
     constructor(
         @Inject(forwardRef(() => AccountBalanceService))
         private readonly accountBalanceService: AccountBalanceService,
-        @InjectConnection('ExchangeConnection')
         private readonly connection: Connection,
         private readonly accountDeployerService: AccountDeployerService
     ) {}

--- a/packages/exchange/src/pods/asset/asset.module.ts
+++ b/packages/exchange/src/pods/asset/asset.module.ts
@@ -6,7 +6,7 @@ import { AssetService } from './asset.service';
 import { AssetController } from './asset.controller';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Asset], 'ExchangeConnection')],
+    imports: [TypeOrmModule.forFeature([Asset])],
     providers: [AssetService],
     exports: [AssetService],
     controllers: [AssetController]

--- a/packages/exchange/src/pods/asset/asset.service.ts
+++ b/packages/exchange/src/pods/asset/asset.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectConnection } from '@nestjs/typeorm';
 import { Connection, EntityManager } from 'typeorm';
 
 import { Asset, CreateAssetDTO } from './asset.entity';
@@ -8,10 +7,7 @@ import { Asset, CreateAssetDTO } from './asset.entity';
 export class AssetService {
     private readonly logger = new Logger(AssetService.name);
 
-    constructor(
-        @InjectConnection('ExchangeConnection')
-        private readonly connection: Connection
-    ) {}
+    constructor(private readonly connection: Connection) {}
 
     public async get(id: string) {
         return this.connection.getRepository<Asset>(Asset).findOne(id);

--- a/packages/exchange/src/pods/demand/demand.module.ts
+++ b/packages/exchange/src/pods/demand/demand.module.ts
@@ -11,11 +11,7 @@ import { DemandTimePeriodService } from './demand-time-period.service';
 @Module({
     providers: [DemandService, DemandTimePeriodService],
     exports: [DemandService],
-    imports: [
-        TypeOrmModule.forFeature([Demand], 'ExchangeConnection'),
-        OrderModule,
-        MatchingEngineModule
-    ],
+    imports: [TypeOrmModule.forFeature([Demand]), OrderModule, MatchingEngineModule],
     controllers: [DemandController]
 })
 export class DemandModule {}

--- a/packages/exchange/src/pods/demand/demand.service.ts
+++ b/packages/exchange/src/pods/demand/demand.service.ts
@@ -19,11 +19,10 @@ export class DemandService {
     private readonly logger = new Logger(DemandService.name);
 
     constructor(
-        @InjectRepository(Demand, 'ExchangeConnection')
+        @InjectRepository(Demand)
         private readonly repository: Repository<Demand>,
         private readonly orderService: OrderService,
         private readonly matchingService: MatchingEngineService,
-        @InjectConnection('ExchangeConnection')
         private readonly connection: Connection,
         private readonly demandTimePeriodService: DemandTimePeriodService
     ) {}

--- a/packages/exchange/src/pods/demand/demand.service.ts
+++ b/packages/exchange/src/pods/demand/demand.service.ts
@@ -1,6 +1,6 @@
 import { DemandStatus } from '@energyweb/utils-general';
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectConnection, InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
 import BN from 'bn.js';
 import { Connection, Repository } from 'typeorm';
 

--- a/packages/exchange/src/pods/order/order.module.ts
+++ b/packages/exchange/src/pods/order/order.module.ts
@@ -12,7 +12,7 @@ import { AccountBalanceModule } from '../account-balance/account-balance.module'
     providers: [OrderService],
     exports: [OrderService],
     imports: [
-        TypeOrmModule.forFeature([Order], 'ExchangeConnection'),
+        TypeOrmModule.forFeature([Order]),
         forwardRef(() => MatchingEngineModule),
         forwardRef(() => AccountBalanceModule),
         ProductModule

--- a/packages/exchange/src/pods/order/order.service.ts
+++ b/packages/exchange/src/pods/order/order.service.ts
@@ -21,7 +21,7 @@ export class OrderService {
     private readonly logger = new Logger(OrderService.name);
 
     constructor(
-        @InjectRepository(Order, 'ExchangeConnection')
+        @InjectRepository(Order)
         private readonly repository: Repository<Order>,
         @Inject(forwardRef(() => MatchingEngineService))
         private readonly matchingEngineService: MatchingEngineService,

--- a/packages/exchange/src/pods/trade/trade.module.ts
+++ b/packages/exchange/src/pods/trade/trade.module.ts
@@ -8,7 +8,7 @@ import { TradeController } from './trade.controller';
 @Module({
     providers: [TradeService],
     exports: [TradeService],
-    imports: [TypeOrmModule.forFeature([Trade], 'ExchangeConnection')],
+    imports: [TypeOrmModule.forFeature([Trade])],
     controllers: [TradeController]
 })
 export class TradeModule {}

--- a/packages/exchange/src/pods/trade/trade.service.ts
+++ b/packages/exchange/src/pods/trade/trade.service.ts
@@ -1,6 +1,6 @@
 import { TradeExecutedEvent } from '@energyweb/exchange-core';
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectConnection, InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
 import { List } from 'immutable';
 import { Connection, Repository } from 'typeorm';
 

--- a/packages/exchange/src/pods/trade/trade.service.ts
+++ b/packages/exchange/src/pods/trade/trade.service.ts
@@ -13,9 +13,8 @@ export class TradeService {
     private readonly logger = new Logger(TradeService.name);
 
     constructor(
-        @InjectConnection('ExchangeConnection')
         private readonly connection: Connection,
-        @InjectRepository(Trade, 'ExchangeConnection')
+        @InjectRepository(Trade)
         private readonly repository: Repository<Trade>
     ) {}
 

--- a/packages/exchange/src/pods/transfer/transfer.module.ts
+++ b/packages/exchange/src/pods/transfer/transfer.module.ts
@@ -12,7 +12,7 @@ import { TransferService } from './transfer.service';
 @Module({
     providers: [TransferService],
     imports: [
-        TypeOrmModule.forFeature([Transfer], 'ExchangeConnection'),
+        TypeOrmModule.forFeature([Transfer]),
         AssetModule,
         forwardRef(() => AccountModule),
         forwardRef(() => AccountBalanceModule),

--- a/packages/exchange/src/pods/transfer/transfer.service.ts
+++ b/packages/exchange/src/pods/transfer/transfer.service.ts
@@ -18,12 +18,11 @@ export class TransferService {
     private readonly logger = new Logger(TransferService.name);
 
     constructor(
-        @InjectRepository(Transfer, 'ExchangeConnection')
+        @InjectRepository(Transfer)
         private readonly repository: Repository<Transfer>,
         private readonly assetService: AssetService,
         @Inject(forwardRef(() => AccountService))
         private readonly accountService: AccountService,
-        @InjectConnection('ExchangeConnection')
         private readonly connection: Connection,
         @Inject(forwardRef(() => AccountBalanceService))
         private readonly accountBalanceService: AccountBalanceService,

--- a/packages/exchange/src/pods/transfer/transfer.service.ts
+++ b/packages/exchange/src/pods/transfer/transfer.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, forwardRef, Inject, Logger } from '@nestjs/common';
-import { InjectRepository, InjectConnection } from '@nestjs/typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Connection, EntityManager, FindOneOptions } from 'typeorm';
 
 import { Transfer } from './transfer.entity';

--- a/packages/exchange/test/database.service.ts
+++ b/packages/exchange/test/database.service.ts
@@ -1,14 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { InjectConnection } from '@nestjs/typeorm';
 import polly from 'polly-js';
 import { Connection } from 'typeorm';
 
 @Injectable()
 export class DatabaseService {
-    constructor(
-        @InjectConnection('ExchangeConnection')
-        private readonly connection: Connection
-    ) {}
+    constructor(private readonly connection: Connection) {}
 
     public async cleanUp() {
         const tables = this.connection.entityMetadatas.map((e) => `"${e.tableName}"`).join(', ');

--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -93,29 +93,15 @@ export const bootstrapTestInstance = async (deviceServiceMock?: DeviceService) =
         ISSUER_ID: 'Issuer ID'
     });
 
-    const getDBConnectionOptions = (): PostgresConnectionOptions => {
-        return process.env.DATABASE_URL
-            ? {
-                  type: 'postgres',
-                  url: process.env.DATABASE_URL,
-                  ssl: {
-                      rejectUnauthorized: false
-                  }
-              }
-            : {
-                  type: 'postgres',
-                  host: process.env.DB_HOST ?? 'localhost',
-                  port: Number(process.env.DB_PORT) ?? 5432,
-                  username: process.env.DB_USERNAME ?? 'postgres',
-                  password: process.env.DB_PASSWORD ?? 'postgres',
-                  database: process.env.DB_DATABASE ?? 'origin'
-              };
-    };
-
     const moduleFixture = await Test.createTestingModule({
         imports: [
             TypeOrmModule.forRoot({
-                ...getDBConnectionOptions(),
+                type: 'postgres',
+                host: process.env.DB_HOST ?? 'localhost',
+                port: Number(process.env.DB_PORT) ?? 5432,
+                username: process.env.DB_USERNAME ?? 'postgres',
+                password: process.env.DB_PASSWORD ?? 'postgres',
+                database: process.env.DB_DATABASE ?? 'origin',
                 entities,
                 logging: ['info']
             }),

--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -9,7 +9,6 @@ import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { useContainer } from 'class-validator';
 import { ethers } from 'ethers';
-import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 
 import { entities } from '../src';
 import { AppModule } from '../src/app.module';

--- a/packages/migrations/deployment/migrations/canary/Dockerfile
+++ b/packages/migrations/deployment/migrations/canary/Dockerfile
@@ -3,7 +3,7 @@ FROM energyweb/origin-backend-app:canary
 RUN mkdir /var/migration-config
 COPY config/* /var/migration-config/
 
-RUN yarn global add typeorm
+RUN yarn global add typeorm@0.2.22
 RUN yarn global add pg
 
 WORKDIR /usr/local/share/.config/yarn/global/node_modules/\@energyweb/

--- a/packages/origin-backend-app/package.json
+++ b/packages/origin-backend-app/package.json
@@ -42,11 +42,13 @@
         "@nestjs/config": "^0.4.0",
         "@nestjs/core": "7.0.9",
         "@nestjs/swagger": "4.5.3",
+        "@nestjs/typeorm": "7.0.0",
         "body-parser": "1.19.0",
         "class-validator": "0.12.2",
         "cors": "2.8.5",
         "dotenv": "8.2.0",
-        "swagger-ui-express": "4.1.4"
+        "swagger-ui-express": "4.1.4",
+        "typeorm": "0.2.24"
     },
     "devDependencies": {
         "jest": "25.5.4",

--- a/packages/origin-backend-app/src/origin-app.module.ts
+++ b/packages/origin-backend-app/src/origin-app.module.ts
@@ -1,14 +1,45 @@
-import { DynamicModule, Module } from '@nestjs/common';
+import { AppModule as ExchangeModule, entities as ExchangeEntities } from '@energyweb/exchange';
+import {
+    AppModule as OriginBackendModule,
+    entities as OriginBackendEntities
+} from '@energyweb/origin-backend';
 import { ISmartMeterReadingsAdapter } from '@energyweb/origin-backend-core';
-import { AppModule as OriginBackendModule } from '@energyweb/origin-backend';
-import { AppModule as ExchangeModule } from '@energyweb/exchange';
+import { DynamicModule, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+const OriginAppTypeOrmModule = () => {
+    return process.env.DATABASE_URL
+        ? TypeOrmModule.forRoot({
+              type: 'postgres',
+              url: process.env.DATABASE_URL,
+              ssl: {
+                  rejectUnauthorized: false
+              },
+              entities: [...OriginBackendEntities, ...ExchangeEntities],
+              logging: ['info']
+          })
+        : TypeOrmModule.forRoot({
+              type: 'postgres',
+              host: process.env.DB_HOST ?? 'localhost',
+              port: Number(process.env.DB_PORT) ?? 5432,
+              username: process.env.DB_USERNAME ?? 'postgres',
+              password: process.env.DB_PASSWORD ?? 'postgres',
+              database: process.env.DB_DATABASE ?? 'origin',
+              entities: [...OriginBackendEntities, ...ExchangeEntities],
+              logging: ['info']
+          });
+};
 
 @Module({})
 export class OriginAppModule {
     static register(smartMeterReadingsAdapter: ISmartMeterReadingsAdapter): DynamicModule {
         return {
             module: OriginAppModule,
-            imports: [OriginBackendModule.register(smartMeterReadingsAdapter), ExchangeModule]
+            imports: [
+                OriginAppTypeOrmModule(),
+                OriginBackendModule.register(smartMeterReadingsAdapter),
+                ExchangeModule
+            ]
         };
     }
 }

--- a/packages/origin-backend/package.json
+++ b/packages/origin-backend/package.json
@@ -49,7 +49,7 @@
         "@nestjs/jwt": "7.0.0",
         "@nestjs/passport": "7.0.0",
         "@nestjs/platform-express": "^7.0.0",
-        "@nestjs/typeorm": "^6.2.0",
+        "@nestjs/typeorm": "7.0.0",
         "@types/node": "^12.12.31",
         "bcryptjs": "2.4.3",
         "body-parser": "1.19.0",

--- a/packages/origin-backend/src/app.module.ts
+++ b/packages/origin-backend/src/app.module.ts
@@ -1,50 +1,21 @@
 import { ISmartMeterReadingsAdapter } from '@energyweb/origin-backend-core';
 import { DynamicModule, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import fs from 'fs';
 import path from 'path';
-import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 
 import { AppController } from './app.controller';
 import { AuthModule } from './auth/auth.module';
 import createConfig from './config/configuration';
-import { Certificate } from './pods/certificate/certificate.entity';
+import { AdminModule } from './pods/admin/admin.module';
 import { CertificateModule } from './pods/certificate/certificate.module';
-import { CertificationRequest } from './pods/certificate/certification-request.entity';
-import { OwnershipCommitment } from './pods/certificate/ownership-commitment.entity';
-import { Configuration } from './pods/configuration/configuration.entity';
 import { ConfigurationModule } from './pods/configuration/configuration.module';
-import { Device } from './pods/device/device.entity';
 import { DeviceModule } from './pods/device/device.module';
 import { FileModule } from './pods/file/file.module';
-import { Organization } from './pods/organization/organization.entity';
 import { OrganizationModule } from './pods/organization/organization.module';
-import { OrganizationInvitation } from './pods/organization/organizationInvitation.entity';
-import { User } from './pods/user/user.entity';
 import { UserModule } from './pods/user/user.module';
-import { AdminModule } from './pods/admin/admin.module';
 
 const ENV_FILE_PATH = path.resolve(__dirname, '../../../../../.env');
-
-const getDBConnectionOptions = (): PostgresConnectionOptions => {
-    return process.env.DATABASE_URL
-        ? {
-              type: 'postgres',
-              url: process.env.DATABASE_URL,
-              ssl: {
-                  rejectUnauthorized: false
-              }
-          }
-        : {
-              type: 'postgres',
-              host: process.env.DB_HOST ?? 'localhost',
-              port: Number(process.env.DB_PORT) ?? 5432,
-              username: process.env.DB_USERNAME ?? 'postgres',
-              password: process.env.DB_PASSWORD ?? 'postgres',
-              database: process.env.DB_DATABASE ?? 'origin'
-          };
-};
 
 @Module({})
 export class AppModule {
@@ -56,20 +27,6 @@ export class AppModule {
                     envFilePath: fs.existsSync(ENV_FILE_PATH) ? ENV_FILE_PATH : null,
                     load: [createConfig],
                     isGlobal: true
-                }),
-                TypeOrmModule.forRoot({
-                    ...getDBConnectionOptions(),
-                    entities: [
-                        OwnershipCommitment,
-                        Configuration,
-                        Device,
-                        Organization,
-                        User,
-                        OrganizationInvitation,
-                        CertificationRequest,
-                        Certificate
-                    ],
-                    logging: ['info']
                 }),
                 FileModule,
                 UserModule,

--- a/packages/origin-backend/src/index.ts
+++ b/packages/origin-backend/src/index.ts
@@ -1,30 +1,24 @@
-import { NestFactory } from '@nestjs/core';
-import { LoggerService } from '@nestjs/common';
+import { Certificate } from './pods/certificate/certificate.entity';
+import { CertificationRequest } from './pods/certificate/certification-request.entity';
+import { OwnershipCommitment } from './pods/certificate/ownership-commitment.entity';
+import { Configuration } from './pods/configuration/configuration.entity';
+import { Device } from './pods/device/device.entity';
+import { Organization } from './pods/organization/organization.entity';
+import { OrganizationInvitation } from './pods/organization/organizationInvitation.entity';
+import { User } from './pods/user/user.entity';
 
-import { AppModule } from './app.module';
-import * as PortUtils from './port';
-import { DeviceModule } from './pods/device/device.module';
-import { DeviceService } from './pods/device/device.service';
-import { ExtendedBaseEntity } from './pods/ExtendedBaseEntity';
+export { AppModule } from './app.module';
+export { ExtendedBaseEntity } from './pods/ExtendedBaseEntity';
+export { ConfigurationService } from './pods/configuration/configuration.service';
+export { DeviceService } from './pods/device/device.service';
 
-export * from './pods/configuration';
-
-export async function startAPI(logger?: LoggerService) {
-    const PORT = PortUtils.getPort();
-
-    console.log(`Backend starting on port: ${PORT}`);
-
-    const app = await NestFactory.create(AppModule.register(null));
-    app.enableCors();
-    app.setGlobalPrefix('api');
-
-    if (logger) {
-        app.useLogger(logger);
-    }
-
-    await app.listen(PORT);
-
-    return app;
-}
-
-export { AppModule, PortUtils, DeviceModule, DeviceService, ExtendedBaseEntity };
+export const entities = [
+    Device,
+    OwnershipCommitment,
+    Configuration,
+    Organization,
+    User,
+    OrganizationInvitation,
+    CertificationRequest,
+    Certificate
+];

--- a/packages/origin-backend/src/main.ts
+++ b/packages/origin-backend/src/main.ts
@@ -1,3 +1,0 @@
-import { startAPI } from '.';
-
-startAPI();

--- a/packages/origin-backend/test/origin-backend.ts
+++ b/packages/origin-backend/test/origin-backend.ts
@@ -13,7 +13,6 @@ import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import dotenv from 'dotenv';
 import request from 'supertest';
-import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 
 import { entities } from '../src';
 import { AppModule } from '../src/app.module';
@@ -27,29 +26,15 @@ import { DatabaseService } from './database.service';
 const testLogger = new Logger('e2e');
 
 export const bootstrapTestInstance = async () => {
-    const getDBConnectionOptions = (): PostgresConnectionOptions => {
-        return process.env.DATABASE_URL
-            ? {
-                  type: 'postgres',
-                  url: process.env.DATABASE_URL,
-                  ssl: {
-                      rejectUnauthorized: false
-                  }
-              }
-            : {
-                  type: 'postgres',
-                  host: process.env.DB_HOST ?? 'localhost',
-                  port: Number(process.env.DB_PORT) ?? 5432,
-                  username: process.env.DB_USERNAME ?? 'postgres',
-                  password: process.env.DB_PASSWORD ?? 'postgres',
-                  database: process.env.DB_DATABASE ?? 'origin'
-              };
-    };
-
     const moduleFixture = await Test.createTestingModule({
         imports: [
             TypeOrmModule.forRoot({
-                ...getDBConnectionOptions(),
+                type: 'postgres',
+                host: process.env.DB_HOST ?? 'localhost',
+                port: Number(process.env.DB_PORT) ?? 5432,
+                username: process.env.DB_USERNAME ?? 'postgres',
+                password: process.env.DB_PASSWORD ?? 'postgres',
+                database: process.env.DB_DATABASE ?? 'origin',
                 entities,
                 logging: ['info']
             }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2914,19 +2914,12 @@
     optional "0.1.4"
     tslib "1.11.1"
 
-"@nestjs/typeorm@6.3.4":
-  version "6.3.4"
-  resolved "https://registry.yarnpkg.com/@nestjs/typeorm/-/typeorm-6.3.4.tgz#d73ee782080500f7d314ec5131fe9cb32817d2a4"
-  integrity sha512-qMUHaTMo+U5WOlMfL0ogNm8C2T/Kej/v+NnjSixx/UmtluLvTbNYuZUfbHI9ePCmtCXDV0lMRvIAi+U5LCjsbA==
+"@nestjs/typeorm@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/typeorm/-/typeorm-7.0.0.tgz#0993a949bba81756317e8e865882184bd7f16133"
+  integrity sha512-oIiQRihMVNQPE6PzEaB7UDfGlktCtkHNxI2HeSf/Uyrjl7DspPSHNLg9IVVSztk+L9kJquYMXhzApr2PxoK3EQ==
   dependencies:
-    uuid "^7.0.2"
-
-"@nestjs/typeorm@^6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@nestjs/typeorm/-/typeorm-6.2.0.tgz#6b8e3d80e3fbd9dc5e0a9d1ebf3028f7adb1ace9"
-  integrity sha512-CRDYV3oxTUa6mTDJfdW+RPLtVUpGx0RpigQdLlvMFLM56v+bYnrTuuy4vurKDgLNFC+AttL9JLZOgRhW8fGdgQ==
-  dependencies:
-    uuid "3.3.3"
+    uuid "7.0.2"
 
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
@@ -21506,11 +21499,6 @@ uuid@3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@3.3.3, uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
-  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
-
 uuid@7.0.2, uuid@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.2.tgz#7ff5c203467e91f5e0d85cfcbaaf7d2ebbca9be6"
@@ -21520,6 +21508,11 @@ uuid@7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+
+uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
 uuid@^3.1.0:
   version "3.4.0"


### PR DESCRIPTION
This PR provides:

- Entities are now registered on a top level package (origin-backend-app) using single connection pool
- @nestjs/typeorm updated to 7.0.0 in all packages