### PR TITLE
Fix invalid type when query for Certification Request record

### DIFF
--- a/packages/origin-backend/src/pods/certificate/certification-request-watcher.service.ts
+++ b/packages/origin-backend/src/pods/certificate/certification-request-watcher.service.ts
@@ -26,7 +26,7 @@ export class CertificationRequestWatcherService implements OnModuleInit {
         private readonly certificationRequestService: CertificationRequestService,
         private readonly deviceService: DeviceService,
         private readonly userService: UserService
-    ) {}
+    ) { }
 
     public async onModuleInit() {
         this.logger.log('onModuleInit');
@@ -148,7 +148,7 @@ export class CertificationRequestWatcherService implements OnModuleInit {
             return;
         }
 
-        await this.certificationRequestService.registerApproved(_id);
+        await this.certificationRequestService.registerApproved(_id.toNumber());
 
         this.logger.log(
             `Registered approved certification request with ID ${certificationRequest.id}.`

--- a/packages/origin-backend/src/pods/certificate/certification-request-watcher.service.ts
+++ b/packages/origin-backend/src/pods/certificate/certification-request-watcher.service.ts
@@ -26,7 +26,7 @@ export class CertificationRequestWatcherService implements OnModuleInit {
         private readonly certificationRequestService: CertificationRequestService,
         private readonly deviceService: DeviceService,
         private readonly userService: UserService
-    ) { }
+    ) {}
 
     public async onModuleInit() {
         this.logger.log('onModuleInit');


### PR DESCRIPTION
https://github.com/energywebfoundation/origin/blob/d12e551b12e8832b0d31dc9d3f8dd835cad5c6d9/packages/origin-backend/src/pods/certificate/certification-request.service.ts#L44



https://github.com/energywebfoundation/origin/blob/d12e551b12e8832b0d31dc9d3f8dd835cad5c6d9/packages/origin-backend/src/pods/certificate/certification-request-watcher.service.ts#L151

Since`registerApproved` take an arguement as `number`, We should convert them as type number instead of BigNumber.