### PR TITLE
Fix account data return values

### DIFF
--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -28,7 +28,7 @@
         "test:cov": "jest --coverage",
         "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
         "test:e2e": "yarn typeorm:run && concurrently --success first --kill-others -n eth,test \"yarn start-ganache\"  \"wait-on tcp:8580 && jest --runInBand --config ./test/jest-e2e.json --forceExit\"",
-        "start-ganache": "ganache-cli -m 'chalk park staff buzz chair purchase wise oak receive avoid avoid home' -l 8000000 -e 1000000 -a 20 -p 8580",
+        "start-ganache": "ganache-cli -m 'chalk park staff buzz chair purchase wise oak receive avoid avoid home' -l 8000000 -e 1000000 -a 20 -p 8580 -q",
         "clean": "shx rm -rf dist dist-shakeable",
         "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/.bin/typeorm --config ormconfig-dev.ts",
         "typeorm:migrate": "yarn typeorm migration:generate -- -n",

--- a/packages/exchange/src/pods/account-balance/account-balance.service.spec.ts
+++ b/packages/exchange/src/pods/account-balance/account-balance.service.spec.ts
@@ -167,4 +167,15 @@ describe('AccountBalanceService', () => {
         expect(res.available[1].amount).toEqual(new BN(expectedAsset2Amount));
         expect(res.available[1].asset).toEqual(asset2);
     });
+
+    it('should return locked asset amount', async () => {
+        registerTransfer({ asset: asset1, amount: '1000', direction: TransferDirection.Deposit });
+        registerOrder({ asset: asset1, side: OrderSide.Ask, currentVolume: new BN(1000) });
+
+        const res = await service.getAccountBalance(userId);
+
+        expect(res.locked.length).toBe(1);
+        expect(res.locked[0].asset).toEqual(asset1);
+        expect(res.locked[0].amount).toEqual(new BN(1000));
+    });
 });

--- a/packages/exchange/src/pods/account-balance/account-balance.service.spec.ts
+++ b/packages/exchange/src/pods/account-balance/account-balance.service.spec.ts
@@ -156,16 +156,11 @@ describe('AccountBalanceService', () => {
 
         const res = await service.getAccountBalance(userId);
 
-        const expectedAsset1Amount = 1000 - 500 - 400 - 100;
-        const expectedAsset2Amount = 2000 - 1000 - 1000;
+        expect(res.available.length).toBe(0);
+        expect(res.locked.length).toBe(1);
 
-        expect(res.available.length).toBe(2);
-
-        expect(res.available[0].amount).toEqual(new BN(expectedAsset1Amount));
-        expect(res.available[0].asset).toEqual(asset1);
-
-        expect(res.available[1].amount).toEqual(new BN(expectedAsset2Amount));
-        expect(res.available[1].asset).toEqual(asset2);
+        expect(res.locked[0].amount).toEqual(new BN(100));
+        expect(res.locked[0].asset).toEqual(asset1);
     });
 
     it('should return locked asset amount', async () => {

--- a/packages/exchange/src/pods/account-balance/account-balance.service.ts
+++ b/packages/exchange/src/pods/account-balance/account-balance.service.ts
@@ -37,7 +37,7 @@ export class AccountBalanceService {
         const available = deposits.mergeWith(sum, trades).mergeWith(sum, sellOrders);
 
         const balances = new AccountBalance({
-            available: Array.from(available.values()),
+            available: Array.from(available.values()).filter((asset) => asset.amount.gt(new BN(0))),
             locked: Array.from(sellOrders.values()).map(
                 (asset) => new AccountAsset({ ...asset, amount: asset.amount.abs() })
             )

--- a/packages/exchange/src/pods/account-balance/account-balance.service.ts
+++ b/packages/exchange/src/pods/account-balance/account-balance.service.ts
@@ -34,11 +34,13 @@ export class AccountBalanceService {
             amount: oldVal.amount.add(newVal.amount)
         });
 
-        const aggregated = deposits.mergeWith(sum, trades).mergeWith(sum, sellOrders);
+        const available = deposits.mergeWith(sum, trades).mergeWith(sum, sellOrders);
 
         const balances = new AccountBalance({
-            available: Array.from(aggregated.values()),
-            locked: Array.from(sellOrders.values())
+            available: Array.from(available.values()),
+            locked: Array.from(sellOrders.values()).map(
+                (asset) => new AccountAsset({ ...asset, amount: asset.amount.abs() })
+            )
         });
 
         this.logger.debug(`[UserId: ${userId}] Balances: ${JSON.stringify(balances)}`);

--- a/packages/exchange/test/api-orders.e2e-spec.ts
+++ b/packages/exchange/test/api-orders.e2e-spec.ts
@@ -170,11 +170,7 @@ describe('account ask order send', () => {
                 const account = res.body as AccountDTO;
 
                 expect(account.address).toBe(user1Address);
-                expect(account.balances.available.length).toBe(1);
-                expect(account.balances.available[0].amount).toEqual('0');
-                expect(account.balances.available[0].asset).toMatchObject(
-                    JSON.parse(JSON.stringify(dummyAsset))
-                );
+                expect(account.balances.available.length).toBe(0);
             });
 
         // wait to withdrawal to be finished to not mess with tx nonces


### PR DESCRIPTION
This PR provides:

- Fix for an issue where `locked` assets were returned with negative sign
- `Available` and `locked` with amount equal 0 are not returned as account assets 