### PR TITLE
Request certificates with organization deposit account as default

### DIFF
--- a/packages/exchange/src/pods/account/account.controller.ts
+++ b/packages/exchange/src/pods/account/account.controller.ts
@@ -21,7 +21,7 @@ export class AccountController {
     @Get()
     @UseGuards(AuthGuard())
     public async getAccount(@UserDecorator() user: ILoggedInUser): Promise<AccountDTO> {
-        const account = await this.accountService.getAccount(user.id.toString());
+        const account = await this.accountService.getAccount(user.ownerId.toString());
 
         return account;
     }

--- a/packages/issuer/contracts/Issuer.sol
+++ b/packages/issuer/contracts/Issuer.sol
@@ -40,6 +40,7 @@ contract Issuer is Initializable, Ownable {
         bool approved;
         bool revoked;
         bool isPrivate;
+        address sender;
     }
 
     struct PrivateTransferRequest {
@@ -89,7 +90,8 @@ contract Issuer is Initializable, Ownable {
             data: _data,
             approved: false,
             revoked: false,
-            isPrivate: _private
+            isPrivate: _private,
+            sender: msg.sender
         });
 
         (,, string memory deviceId) = decodeData(_data);

--- a/packages/issuer/src/test/Issuer.test.ts
+++ b/packages/issuer/src/test/Issuer.test.ts
@@ -39,7 +39,8 @@ describe('Issuer', () => {
         isPrivate = false,
         fromTime?: number,
         toTime?: number,
-        deviceId?: string
+        deviceId?: string,
+        forAddress?: string
     ) => {
         setActiveUser(deviceOwnerWallet);
 
@@ -56,12 +57,14 @@ describe('Issuer', () => {
             device,
             conf,
             [],
-            isPrivate
+            isPrivate,
+            forAddress
         );
 
         (conf.offChainDataSource.certificateClient as any).mockBlockchainData(
             certificationRequest.id,
             {
+                sender: forAddress || deviceOwnerWallet.address,
                 owner: deviceOwnerWallet.address,
                 fromTime: generationFromTime,
                 toTime: generationToTime,
@@ -341,5 +344,27 @@ describe('Issuer', () => {
             Number(certificateId)
         );
         assert.equal(deviceOwnerBalance.toString(), '0');
+    });
+
+    it('should be able to request for other address', async () => {
+        setActiveUser(deviceOwnerWallet);
+
+        const fromTime = timestamp;
+        // Simulate time moving forward 1 month
+        timestamp += 30 * 24 * 3600;
+        const toTime = timestamp;
+        const device = '1';
+        const volume = new BigNumber(1e9);
+
+        const certificationRequest = await createCertificationRequest(
+            volume,
+            false,
+            fromTime,
+            toTime,
+            device,
+            issuerWallet.address
+        );
+
+        assert.isOk(certificationRequest);
     });
 });

--- a/packages/migrations/tsconfig.build.json
+++ b/packages/migrations/tsconfig.build.json
@@ -7,10 +7,10 @@
     "include": ["src/**/*"],
     "references": [
         {
-            "path": "../utils-general/tsconfig.build.json"
+            "path": "../issuer/tsconfig.build.json"
         },
         {
-            "path": "../device-registry/tsconfig.build.json"
+            "path": "../origin-backend-core/tsconfig.build.json"
         }
     ]
 }

--- a/packages/origin-backend/src/pods/certificate/certification-request-watcher.service.ts
+++ b/packages/origin-backend/src/pods/certificate/certification-request-watcher.service.ts
@@ -91,7 +91,13 @@ export class CertificationRequestWatcherService implements OnModuleInit {
             return;
         }
 
-        const { owner, revoked, approved, data } = await this.issuer.getCertificationRequest(_id);
+        const {
+            owner,
+            revoked,
+            approved,
+            data,
+            sender
+        } = await this.issuer.getCertificationRequest(_id);
         const [fromTime, toTime, deviceId] = await this.issuer.decodeData(data);
 
         const device = await this.deviceService.findByExternalId({
@@ -105,10 +111,10 @@ export class CertificationRequestWatcherService implements OnModuleInit {
         }
 
         const { timestamp: created } = await this.issuer.provider.getBlock(event.blockNumber);
-        const user = await this.userService.findByBlockchainAccount(owner);
+        const user = await this.userService.findByBlockchainAccount(sender);
 
         if (!user) {
-            this.logger.error(`Encountered request from unknown address ${owner}`);
+            this.logger.error(`Encountered request from unknown address ${sender}`);
             return;
         }
 

--- a/packages/origin-ui-core/src/components/CertificateTable.tsx
+++ b/packages/origin-ui-core/src/components/CertificateTable.tsx
@@ -111,6 +111,8 @@ export function CertificateTable(props: IProps) {
         });
 
         const filteredIEnrichedCertificateData = enrichedData.filter((enrichedCertificateData) => {
+            console.log(enrichedCertificateData.certificate);
+
             const ownerOf =
                 enrichedCertificateData.certificate.isOwned ||
                 enrichedCertificateData.certificate.source === CertificateSource.Exchange;

--- a/packages/origin-ui-core/src/features/certificates/sagas.ts
+++ b/packages/origin-ui-core/src/features/certificates/sagas.ts
@@ -67,13 +67,18 @@ function* requestCertificatesSaga(): SagaIterator {
             const shouldContinue: boolean = yield call(assertCorrectBlockchainAccount);
 
             if (shouldContinue) {
+                const exchangeClient: IExchangeClient = yield select(getExchangeClient);
+                const { address } = yield call([exchangeClient, exchangeClient.getAccount]);
+
                 yield apply(CertificationRequest, CertificationRequest.create, [
                     startTime,
                     endTime,
                     energy,
                     deviceId,
                     configuration,
-                    files
+                    files,
+                    false,
+                    address
                 ]);
 
                 showNotification(`Certificates requested.`, NotificationType.Success);

--- a/yarn.lock
+++ b/yarn.lock
@@ -19278,7 +19278,7 @@ setprototypeof@1.1.1:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
-sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8:
+sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
@@ -21317,27 +21317,6 @@ typeorm@0.2.22:
     yargonaut "^1.1.2"
     yargs "^13.2.1"
 
-typeorm@0.2.24:
-  version "0.2.24"
-  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.2.24.tgz#cd0fbd907326873a96c98e290fca49c589f0ffa8"
-  integrity sha512-L9tQv6nNLRyh+gex/qc8/CyLs8u0kXKqk1OjYGF13k/KOg6N2oibwkuGgv0FuoTGYx2ta2NmqvuMUAMrHIY5ew==
-  dependencies:
-    app-root-path "^3.0.0"
-    buffer "^5.1.0"
-    chalk "^2.4.2"
-    cli-highlight "^2.0.0"
-    debug "^4.1.1"
-    dotenv "^6.2.0"
-    glob "^7.1.2"
-    js-yaml "^3.13.1"
-    mkdirp "^0.5.1"
-    reflect-metadata "^0.1.13"
-    sha.js "^2.4.11"
-    tslib "^1.9.0"
-    xml2js "^0.4.17"
-    yargonaut "^1.1.2"
-    yargs "^13.2.1"
-
 typescript-compare@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/typescript-compare/-/typescript-compare-0.0.2.tgz#7ee40a400a406c2ea0a7e551efd3309021d5f425"
@@ -21705,11 +21684,6 @@ uuid@7.0.2, uuid@^7.0.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.2.tgz#7ff5c203467e91f5e0d85cfcbaaf7d2ebbca9be6"
   integrity sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==
 
-uuid@7.0.3, uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
-
 uuid@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
@@ -21724,6 +21698,11 @@ uuid@^3.1.0, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 v8-compile-cache@2.0.3:
   version "2.0.3"


### PR DESCRIPTION
This PR changes the way certificates requests are being handled. 

Before:
1) device manager requested certificate
2) issuer approves
3) certificate issued to the `sender` account (device manager in this case)
4) device manager transfer certificates to the exchange

Current:
1) device manager requested certificate
2) issuer approves
3) certificate issued to the organization deposit account on exchange