### PR TITLE
feat(exchange): add publishing trade event to messaging queue for external services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,7 @@ ISSUER_ID=Issuer ID
 # Possible options: GRID_OPERATOR and LOCATION, should be comma separated
 DEVICE_PROPERTIES_ENABLED=GRID_OPERATOR,LOCATION
 
-QUEUE_CONNECTION_STRING=amqp://reacc:cai8ydlaDA@localhost:5672
-QUEUE_NAME=trade
-QUEUE_TOPIC_TRADE=marketplace.trade
+USE_MESSAGE_QUEUE=false
+QUEUE_CONNECTION_STRING=amqp://username:password@localhost:5672
+QUEUE_NAME=queue_name
+QUEUE_TOPIC_TRADE=queue_topic

--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,7 @@ ISSUER_ID=Issuer ID
 
 # Possible options: GRID_OPERATOR and LOCATION, should be comma separated
 DEVICE_PROPERTIES_ENABLED=GRID_OPERATOR,LOCATION
+
+QUEUE_CONNECTION_STRING=amqp://reacc:cai8ydlaDA@localhost:5672
+QUEUE_NAME=trade
+QUEUE_TOPIC_TRADE=marketplace.trade

--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -52,6 +52,8 @@
         "@nestjs/schedule": "0.4.0",
         "@nestjs/swagger": "4.5.7",
         "@nestjs/typeorm": "7.0.0",
+        "@types/amqplib": "^0.5.13",
+        "amqplib": "^0.5.6",
         "bn.js": "^5.1.1",
         "class-transformer": "0.2.3",
         "class-validator": "0.12.2",

--- a/packages/exchange/src/app.module.ts
+++ b/packages/exchange/src/app.module.ts
@@ -21,6 +21,7 @@ import { TradeModule } from './pods/trade/trade.module';
 import { TransferModule } from './pods/transfer/transfer.module';
 import { WithdrawalProcessorModule } from './pods/withdrawal-processor/withdrawal-processor.module';
 import { HTTPLoggingInterceptor } from './utils/httpLoggingInterceptor';
+import { MessageModule } from './pods/message/message.module';
 
 const getEnvFilePath = () => {
     const pathsToTest = ['../../../../../.env', '../../../../../../.env'];
@@ -59,7 +60,8 @@ const getEnvFilePath = () => {
         AccountBalanceModule,
         DepositWatcherModule,
         WithdrawalProcessorModule,
-        RunnerModule
+        RunnerModule,
+        MessageModule
     ],
     providers: [
         { provide: APP_PIPE, useClass: ValidationPipe },

--- a/packages/exchange/src/pods/matching-engine/matching-engine.module.ts
+++ b/packages/exchange/src/pods/matching-engine/matching-engine.module.ts
@@ -4,10 +4,15 @@ import { TradeModule } from '../trade/trade.module';
 import { MatchingEngineService } from './matching-engine.service';
 import { OrderModule } from '../order/order.module';
 import { RunnerModule } from '../runner/runner.module';
+import { MessageModule } from '../message/message.module';
 
 @Module({
     providers: [MatchingEngineService],
     exports: [MatchingEngineService],
-    imports: [TradeModule, forwardRef(() => OrderModule), RunnerModule]
+    imports: [
+        TradeModule, forwardRef(() => OrderModule), 
+        RunnerModule, 
+        MessageModule
+    ]
 })
 export class MatchingEngineModule {}

--- a/packages/exchange/src/pods/matching-engine/matching-engine.module.ts
+++ b/packages/exchange/src/pods/matching-engine/matching-engine.module.ts
@@ -9,10 +9,6 @@ import { MessageModule } from '../message/message.module';
 @Module({
     providers: [MatchingEngineService],
     exports: [MatchingEngineService],
-    imports: [
-        TradeModule, forwardRef(() => OrderModule), 
-        RunnerModule, 
-        MessageModule
-    ]
+    imports: [TradeModule, forwardRef(() => OrderModule), RunnerModule, MessageModule]
 })
 export class MatchingEngineModule {}

--- a/packages/exchange/src/pods/matching-engine/matching-engine.module.ts
+++ b/packages/exchange/src/pods/matching-engine/matching-engine.module.ts
@@ -4,11 +4,11 @@ import { TradeModule } from '../trade/trade.module';
 import { MatchingEngineService } from './matching-engine.service';
 import { OrderModule } from '../order/order.module';
 import { RunnerModule } from '../runner/runner.module';
-import { MessageModule } from '../message/message.module';
+// import { MessageModule } from '../message/message.module';
 
 @Module({
     providers: [MatchingEngineService],
     exports: [MatchingEngineService],
-    imports: [TradeModule, forwardRef(() => OrderModule), RunnerModule, MessageModule]
+    imports: [TradeModule, forwardRef(() => OrderModule), RunnerModule]
 })
 export class MatchingEngineModule {}

--- a/packages/exchange/src/pods/matching-engine/matching-engine.service.ts
+++ b/packages/exchange/src/pods/matching-engine/matching-engine.service.ts
@@ -13,14 +13,14 @@ import { forwardRef, Inject, Injectable, Logger, OnModuleInit } from '@nestjs/co
 import { Interval } from '@nestjs/schedule';
 import { List } from 'immutable';
 
-import { ConfigService } from '@nestjs/config';
+// import { ConfigService } from '@nestjs/config';
 import { OrderType } from '../order/order-type.enum';
 import { Order } from '../order/order.entity';
 import { OrderService } from '../order/order.service';
 import { ProductDTO } from '../order/product.dto';
 import { DeviceTypeServiceWrapper } from '../runner/deviceTypeServiceWrapper';
 import { TradeService } from '../trade/trade.service';
-import { MessageService } from '../message/message.service';
+// import { MessageService } from '../message/message.service';
 
 @Injectable()
 export class MatchingEngineService implements OnModuleInit {
@@ -30,17 +30,17 @@ export class MatchingEngineService implements OnModuleInit {
 
     private matchingEngine: MatchingEngine;
 
-    private tradeTopic: string;
+    // private tradeTopic: string;
 
     constructor(
         private readonly tradeService: TradeService,
         @Inject(forwardRef(() => OrderService))
         private readonly orderService: OrderService,
-        private readonly deviceTypeServiceWrapper: DeviceTypeServiceWrapper,
-        private readonly messageService: MessageService,
-        private readonly configService: ConfigService
+        private readonly deviceTypeServiceWrapper: DeviceTypeServiceWrapper//,
+        // private readonly messageService: MessageService,
+        // private readonly configService: ConfigService
     ) {
-        this.tradeTopic = this.configService.get<string>('QUEUE_TOPIC_TRADE');
+        // this.tradeTopic = this.configService.get<string>('QUEUE_TOPIC_TRADE');
     }
 
     public async onModuleInit() {
@@ -101,7 +101,7 @@ export class MatchingEngineService implements OnModuleInit {
 
         await this.tradeService.persist(trades);
 
-        this.messageService.publish(JSON.stringify(trades), this.tradeTopic);
+        //this.messageService.publish(JSON.stringify(trades), this.tradeTopic);
     }
 
     private async onActionResultEvent(statusChanges: List<ActionResultEvent>) {

--- a/packages/exchange/src/pods/matching-engine/matching-engine.service.ts
+++ b/packages/exchange/src/pods/matching-engine/matching-engine.service.ts
@@ -13,6 +13,7 @@ import { forwardRef, Inject, Injectable, Logger, OnModuleInit } from '@nestjs/co
 import { Interval } from '@nestjs/schedule';
 import { List } from 'immutable';
 
+import { ConfigService } from '@nestjs/config';
 import { OrderType } from '../order/order-type.enum';
 import { Order } from '../order/order.entity';
 import { OrderService } from '../order/order.service';
@@ -20,7 +21,6 @@ import { ProductDTO } from '../order/product.dto';
 import { DeviceTypeServiceWrapper } from '../runner/deviceTypeServiceWrapper';
 import { TradeService } from '../trade/trade.service';
 import { MessageService } from '../message/message.service';
-import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class MatchingEngineService implements OnModuleInit {
@@ -114,22 +114,22 @@ export class MatchingEngineService implements OnModuleInit {
     private toOrder(order: Order) {
         return order.side === OrderSide.Ask
             ? new Ask(
-                order.id,
-                order.price,
-                order.currentVolume,
-                ProductDTO.toProduct(order.product),
-                order.validFrom,
-                order.userId,
-                order.assetId
-            )
+                  order.id,
+                  order.price,
+                  order.currentVolume,
+                  ProductDTO.toProduct(order.product),
+                  order.validFrom,
+                  order.userId,
+                  order.assetId
+              )
             : new Bid(
-                order.id,
-                order.price,
-                order.currentVolume,
-                ProductDTO.toProduct(order.product),
-                order.validFrom,
-                order.userId
-            );
+                  order.id,
+                  order.price,
+                  order.currentVolume,
+                  ProductDTO.toProduct(order.product),
+                  order.validFrom,
+                  order.userId
+              );
     }
 
     private toDirectBuy(order: Order) {

--- a/packages/exchange/src/pods/matching-engine/matching-engine.service.ts
+++ b/packages/exchange/src/pods/matching-engine/matching-engine.service.ts
@@ -101,7 +101,6 @@ export class MatchingEngineService implements OnModuleInit {
 
         await this.tradeService.persist(trades);
 
-        this.logger.log('Publish TradeExecutedEvent to external');
         this.messageService.publish(JSON.stringify(trades), this.tradeTopic);
     }
 

--- a/packages/exchange/src/pods/message/message.module.ts
+++ b/packages/exchange/src/pods/message/message.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { MessageService } from './message.service';
+
+@Module({
+    providers: [MessageService],
+    exports: [MessageService]
+})
+export class MessageModule {}

--- a/packages/exchange/src/pods/message/message.service.ts
+++ b/packages/exchange/src/pods/message/message.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from "@nestjs/common";
+import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common';
 import { connect, Connection, Channel } from 'amqplib/callback_api';
 import { ConfigService } from '@nestjs/config';
 

--- a/packages/exchange/src/pods/message/message.service.ts
+++ b/packages/exchange/src/pods/message/message.service.ts
@@ -67,7 +67,7 @@ export class MessageService implements OnModuleInit, OnModuleDestroy {
         }
 
         this.logger.log('Publish item to external by messaging queue');
-        this.logger.debug(message);
+        this.logger.log(message);
         if (this.channel) {
             this.channel.publish(this.exchange, topic, Buffer.from(message));
         } else {

--- a/packages/exchange/src/pods/message/message.service.ts
+++ b/packages/exchange/src/pods/message/message.service.ts
@@ -1,20 +1,28 @@
 import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from "@nestjs/common";
 import { connect, Connection, Channel } from 'amqplib/callback_api';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
-export class MessageService implements OnModuleInit {
+export class MessageService implements OnModuleInit, OnModuleDestroy {
     private readonly logger = new Logger(MessageService.name);
 
     private connection: Connection;
 
     private channel: Channel;
 
-    private exchange = 'trade';
+    private exchange: string;
+
+    private queueConnectionString: string;
+
+    constructor(private readonly configService: ConfigService) {
+        this.queueConnectionString = this.configService.get<string>('QUEUE_CONNECTION_STRING');
+        this.exchange = this.configService.get<string>('QUEUE_NAME');
+    }
 
     public onModuleInit() {
         this.logger.log('onModuleInit');
         this.logger.log('Initializing MessageService');
-        connect('amqp://reacc:cai8ydlaDA@localhost:5672', (conErr, con: Connection) => {
+        connect(this.queueConnectionString, (conErr, con: Connection) => {
             if (conErr) {
                 this.logger.error(conErr);
                 throw conErr;

--- a/packages/exchange/src/pods/message/message.service.ts
+++ b/packages/exchange/src/pods/message/message.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from "@nestjs/common";
+import { connect, Connection, Channel } from 'amqplib/callback_api';
+
+@Injectable()
+export class MessageService implements OnModuleInit {
+    private readonly logger = new Logger(MessageService.name);
+
+    private connection: Connection;
+
+    private channel: Channel;
+
+    private exchange = 'trade';
+
+    public onModuleInit() {
+        this.logger.log('onModuleInit');
+        this.logger.log('Initializing MessageService');
+        connect('amqp://reacc:cai8ydlaDA@localhost:5672', (conErr, con: Connection) => {
+            if (conErr) {
+                this.logger.error(conErr);
+                throw conErr;
+            }
+            this.connection = con;
+            this.logger.log('Connected to messaging queue');
+
+            this.logger.log('Creating channel');
+            this.connection.createChannel((chanErr, channel: Channel) => {
+                if (chanErr) {
+                    this.logger.error(chanErr);
+                    throw chanErr;
+                }
+                this.channel = channel;
+                this.logger.log('Channel created');
+
+                this.channel.assertExchange(this.exchange, 'topic', {
+                    durable: false
+                });
+            });
+        });
+    }
+
+    public onModuleDestroy() {
+        if (this.connection) {
+            this.connection.close();
+        }
+    }
+
+    public publish(message: string, topic: string) {
+        if (this.channel) {
+            this.channel.publish(this.exchange, topic, Buffer.from(message));
+        } else {
+            this.logger.warn('Messaging queue has not been initialized');
+        }
+    }
+}

--- a/packages/exchange/src/pods/trade/trade.module.ts
+++ b/packages/exchange/src/pods/trade/trade.module.ts
@@ -4,11 +4,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Trade } from './trade.entity';
 import { TradeService } from './trade.service';
 import { TradeController } from './trade.controller';
+import { MessageModule } from '../message/message.module';
 
 @Module({
     providers: [TradeService],
     exports: [TradeService],
-    imports: [TypeOrmModule.forFeature([Trade])],
+    imports: [TypeOrmModule.forFeature([Trade]), MessageModule],
     controllers: [TradeController]
 })
 export class TradeModule {}

--- a/packages/exchange/src/pods/trade/trade.service.ts
+++ b/packages/exchange/src/pods/trade/trade.service.ts
@@ -4,21 +4,31 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { List } from 'immutable';
 import { Connection, Repository } from 'typeorm';
 
+import { ConfigService } from '@nestjs/config';
 import { Order } from '../order/order.entity';
 import { Trade } from './trade.entity';
 import { OrderStatus } from '../order/order-status.enum';
+import { MessageService } from '../message/message.service';
 
 @Injectable()
 export class TradeService {
     private readonly logger = new Logger(TradeService.name);
 
+    private readonly tradeTopic: string;
+
     constructor(
         private readonly connection: Connection,
         @InjectRepository(Trade)
-        private readonly repository: Repository<Trade>
-    ) {}
+        private readonly repository: Repository<Trade>,
+        private readonly messageService: MessageService,
+        private readonly configService: ConfigService
+    ) {
+        this.tradeTopic = this.configService.get<string>('QUEUE_TOPIC_TRADE');
+    }
 
     public async persist(event: List<TradeExecutedEvent>) {
+        const persistedId: string[] = [];
+
         this.logger.log(`Persisting trades and updating orders: ${event.size}`);
         this.logger.debug(`Persisting trades and updating orders: ${JSON.stringify(event)}`);
 
@@ -32,15 +42,20 @@ export class TradeService {
                     currentVolume: bid.volume,
                     status: bid.volume.isZero() ? OrderStatus.Filled : OrderStatus.PartiallyFilled
                 });
-                await entityManager.insert<Trade>(Trade, {
+                const { identifiers } = await entityManager.insert<Trade>(Trade, {
                     created: trade.created,
                     price: trade.price,
                     volume: trade.volume,
                     bid,
                     ask
                 });
+
+                persistedId.push(identifiers[0].id);
             }
             this.logger.debug(`Persisting trades and orders completed`);
+
+            const persistedTrades = await entityManager.findByIds(Trade, persistedId);
+            this.messageService.publish(JSON.stringify(persistedTrades), this.tradeTopic);
         });
     }
 

--- a/packages/origin-backend/src/pods/certificate/certification-request-watcher.service.ts
+++ b/packages/origin-backend/src/pods/certificate/certification-request-watcher.service.ts
@@ -98,6 +98,7 @@ export class CertificationRequestWatcherService implements OnModuleInit {
             data,
             sender
         } = await this.issuer.getCertificationRequest(_id);
+
         const [fromTime, toTime, deviceId] = await this.issuer.decodeData(data);
 
         const device = await this.deviceService.findByExternalId({

--- a/packages/origin-backend/src/pods/certificate/certification-request-watcher.service.ts
+++ b/packages/origin-backend/src/pods/certificate/certification-request-watcher.service.ts
@@ -111,7 +111,8 @@ export class CertificationRequestWatcherService implements OnModuleInit {
         }
 
         const { timestamp: created } = await this.issuer.provider.getBlock(event.blockNumber);
-        const user = await this.userService.findByBlockchainAccount(sender);
+        // const user = await this.userService.findByBlockchainAccount(sender);
+        const user = await this.userService.findByBlockchainAccount(owner); // workaround
 
         if (!user) {
             this.logger.error(`Encountered request from unknown address ${sender}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4032,6 +4032,14 @@
   dependencies:
     "@turf/helpers" "6.x"
 
+"@types/amqplib@^0.5.13":
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/@types/amqplib/-/amqplib-0.5.13.tgz#a0dc9be08f38b91e5f7532acf0c89b0e515cdc6c"
+  integrity sha512-0r8cJfUajAlcHxlJsZyqRrSAYzv+pJPsaAQjDC6e5rACi3AOIuR0AfevJG7NLvw3Qu4EGhf3KS/ECwd5cUAY2A==
+  dependencies:
+    "@types/bluebird" "*"
+    "@types/node" "*"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -4104,6 +4112,11 @@
   integrity sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==
   dependencies:
     bignumber.js "*"
+
+"@types/bluebird@*":
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.32.tgz#381e7b59e39f010d20bbf7e044e48f5caf1ab620"
+  integrity sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g==
 
 "@types/bn.js@^4.11.3", "@types/bn.js@^4.11.4":
   version "4.11.5"
@@ -5453,6 +5466,18 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
+amqplib@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.5.6.tgz#86a7850f4f39c568eaa0dd0300ef374e17941cf4"
+  integrity sha512-J4TR0WAMPBHN+tgTuhNsSObfM9eTVTZm/FNw0LyaGfbiLsBxqSameDNYpChUFXW4bnTKHDXy0ab+nuLhumnRrQ==
+  dependencies:
+    bitsyntax "~0.1.0"
+    bluebird "^3.5.2"
+    buffer-more-ints "~1.0.0"
+    readable-stream "1.x >=1.1.9"
+    safe-buffer "~5.1.2"
+    url-parse "~1.4.3"
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
@@ -6440,6 +6465,15 @@ bip66@^1.1.5:
   dependencies:
     safe-buffer "^5.0.1"
 
+bitsyntax@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/bitsyntax/-/bitsyntax-0.1.0.tgz#b0c59acef03505de5a2ed62a2f763c56ae1d6205"
+  integrity sha512-ikAdCnrloKmFOugAfxWws89/fPc+nw0OOG1IzIE72uSOg/A3cYptKCjSUhDTuj7fhsJtzkzlv7l3b8PzRHLN0Q==
+  dependencies:
+    buffer-more-ints "~1.0.0"
+    debug "~2.6.9"
+    safe-buffer "~5.1.2"
+
 bl@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
@@ -6455,7 +6489,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.3.5:
+bluebird@^3.3.5, bluebird@^3.5.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -6743,6 +6777,11 @@ buffer-indexof@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
   integrity sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==
+
+buffer-more-ints@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz#ef4f8e2dddbad429ed3828a9c55d44f05c611422"
+  integrity sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==
 
 buffer-to-arraybuffer@^0.0.5:
   version "0.0.5"
@@ -8391,7 +8430,7 @@ dayjs@^1.8.16:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.26.tgz#c6d62ccdf058ca72a8d14bb93a23501058db9f1e"
   integrity sha512-KqtAuIfdNfZR5sJY1Dixr2Is4ZvcCqhb0dZpCOt5dGEFiMzoIbjkTSzUb4QKTCsP+WNpGwUjAFIZrnZvUxxkhw==
 
-debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
+debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9, debug@~2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -18443,7 +18482,7 @@ read@1, read@~1.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@1.1.x:
+readable-stream@1.1.x, "readable-stream@1.x >=1.1.9":
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
@@ -19101,7 +19140,7 @@ safe-buffer@5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
   integrity sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==
 
-safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1, safe-buffer@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -21307,12 +21346,12 @@ tsconfig-paths@3.9.0, tsconfig-paths@^3.4.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tslib@1.11.1, tslib@>=1.9.0:
+tslib@1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
@@ -21322,10 +21361,10 @@ tslib@2.0.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
   integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
 
-tslib@^1.10.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.0.tgz#f1f3528301621a53220d58373ae510ff747a66bc"
-  integrity sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==
+tslib@>=1.9.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.2.tgz#9c79d83272c9a7aaf166f73915c9667ecdde3cc9"
+  integrity sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==
 
 tsort@0.0.1:
   version "0.0.1"
@@ -21766,7 +21805,7 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.3:
+url-parse@^1.4.3, url-parse@~1.4.3:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
   integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==


### PR DESCRIPTION
This PR adds publishing trade event to messaging queue for external services. The published item is trade item in TradeExecutedEvent.

The feature is feature toggle-able by setting `USE_MESSAGE_QUEUE` in .env file, default is `false`. Other configuration, like queue connection string, queue name, and queue topic, please see in `.env.example`.