### PR TITLE
Bundles trading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,5 @@ ISSUER_ID=Issuer ID
 
 # Possible options: GRID_OPERATOR and LOCATION, should be comma separated
 DEVICE_PROPERTIES_ENABLED=GRID_OPERATOR,LOCATION
+# Amount of energy in single certificate 
+ENERGY_PER_UNIT=1000000

--- a/packages/exchange/migrations/1590407732107-Bundles.ts
+++ b/packages/exchange/migrations/1590407732107-Bundles.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Bundles1590407732107 implements MigrationInterface {
+    name = 'Bundles1590407732107';
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(
+            `CREATE TABLE "bundle" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "userId" character varying NOT NULL, "price" integer NOT NULL, CONSTRAINT "PK_637e3f87e837d6532109c198dea" PRIMARY KEY ("id"))`,
+            undefined
+        );
+        await queryRunner.query(
+            `CREATE TABLE "bundle_item" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "startVolume" character varying NOT NULL, "currentVolume" character varying NOT NULL, "assetId" uuid, "bundleId" uuid, CONSTRAINT "PK_c89b429c5d069d3399b935327f4" PRIMARY KEY ("id"))`,
+            undefined
+        );
+        await queryRunner.query(
+            `CREATE TABLE "bundle_trade" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "buyerId" character varying NOT NULL, "volume" character varying NOT NULL, "bundleId" uuid, CONSTRAINT "PK_d6947e1c1bffc399636a49a3243" PRIMARY KEY ("id"))`,
+            undefined
+        );
+        await queryRunner.query(
+            `ALTER TABLE "bundle_item" ADD CONSTRAINT "FK_45559b6111bf0664b49243bc67c" FOREIGN KEY ("assetId") REFERENCES "asset"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+            undefined
+        );
+        await queryRunner.query(
+            `ALTER TABLE "bundle_item" ADD CONSTRAINT "FK_21f62678875562cfa8afe7257a2" FOREIGN KEY ("bundleId") REFERENCES "bundle"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+            undefined
+        );
+        await queryRunner.query(
+            `ALTER TABLE "bundle_trade" ADD CONSTRAINT "FK_84d0a546dc26d9d4d0a1f484492" FOREIGN KEY ("bundleId") REFERENCES "bundle"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+            undefined
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(
+            `ALTER TABLE "bundle_trade" DROP CONSTRAINT "FK_84d0a546dc26d9d4d0a1f484492"`,
+            undefined
+        );
+        await queryRunner.query(
+            `ALTER TABLE "bundle_item" DROP CONSTRAINT "FK_21f62678875562cfa8afe7257a2"`,
+            undefined
+        );
+        await queryRunner.query(
+            `ALTER TABLE "bundle_item" DROP CONSTRAINT "FK_45559b6111bf0664b49243bc67c"`,
+            undefined
+        );
+        await queryRunner.query(`DROP TABLE "bundle_trade"`, undefined);
+        await queryRunner.query(`DROP TABLE "bundle_item"`, undefined);
+        await queryRunner.query(`DROP TABLE "bundle"`, undefined);
+    }
+}

--- a/packages/exchange/migrations/1590407732107-Bundles.ts
+++ b/packages/exchange/migrations/1590407732107-Bundles.ts
@@ -28,6 +28,10 @@ export class Bundles1590407732107 implements MigrationInterface {
             `ALTER TABLE "bundle_trade" ADD CONSTRAINT "FK_84d0a546dc26d9d4d0a1f484492" FOREIGN KEY ("bundleId") REFERENCES "bundle"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
             undefined
         );
+        await queryRunner.query(
+            `ALTER TABLE "bundle" ADD "isCancelled" boolean NOT NULL`,
+            undefined
+        );
     }
 
     public async down(queryRunner: QueryRunner): Promise<any> {

--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -22,7 +22,7 @@
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\"",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --fix",
-        "test": "jest",
+        "test": "jest --env 'node'",
         "test:concurrent": "yarn test",
         "test:watch": "jest --watch",
         "test:cov": "jest --coverage",

--- a/packages/exchange/src/app.module.ts
+++ b/packages/exchange/src/app.module.ts
@@ -21,6 +21,7 @@ import { TradeModule } from './pods/trade/trade.module';
 import { TransferModule } from './pods/transfer/transfer.module';
 import { WithdrawalProcessorModule } from './pods/withdrawal-processor/withdrawal-processor.module';
 import { HTTPLoggingInterceptor } from './utils/httpLoggingInterceptor';
+import { BundleModule } from './pods/bundle/bundle.module';
 
 const getEnvFilePath = () => {
     const pathsToTest = ['../../../../../.env', '../../../../../../.env'];
@@ -59,7 +60,8 @@ const getEnvFilePath = () => {
         AccountBalanceModule,
         DepositWatcherModule,
         WithdrawalProcessorModule,
-        RunnerModule
+        RunnerModule,
+        BundleModule
     ],
     providers: [
         { provide: APP_PIPE, useClass: ValidationPipe },

--- a/packages/exchange/src/index.ts
+++ b/packages/exchange/src/index.ts
@@ -1,5 +1,8 @@
 import { Account } from './pods/account/account.entity';
 import { Asset } from './pods/asset/asset.entity';
+import { BundleItem } from './pods/bundle/bundle-item.entity';
+import { BundleTrade } from './pods/bundle/bundle-trade.entity';
+import { Bundle } from './pods/bundle/bundle.entity';
 import { Demand } from './pods/demand/demand.entity';
 import { Order } from './pods/order/order.entity';
 import { Trade } from './pods/trade/trade.entity';
@@ -7,4 +10,14 @@ import { Transfer } from './pods/transfer/transfer.entity';
 
 export { AppModule } from './app.module';
 
-export const entities = [Demand, Trade, Order, Transfer, Account, Asset];
+export const entities = [
+    Demand,
+    Trade,
+    Order,
+    Transfer,
+    Account,
+    Asset,
+    Bundle,
+    BundleItem,
+    BundleTrade
+];

--- a/packages/exchange/src/pods/account-balance/account-balance.module.ts
+++ b/packages/exchange/src/pods/account-balance/account-balance.module.ts
@@ -3,10 +3,16 @@ import { AccountBalanceService } from './account-balance.service';
 import { OrderModule } from '../order/order.module';
 import { TradeModule } from '../trade/trade.module';
 import { TransferModule } from '../transfer/transfer.module';
+import { BundleModule } from '../bundle/bundle.module';
 
 @Module({
     providers: [AccountBalanceService],
     exports: [AccountBalanceService],
-    imports: [forwardRef(() => OrderModule), TradeModule, TransferModule]
+    imports: [
+        forwardRef(() => OrderModule),
+        TradeModule,
+        TransferModule,
+        forwardRef(() => BundleModule)
+    ]
 })
 export class AccountBalanceModule {}

--- a/packages/exchange/src/pods/account-balance/account-balance.service.spec.ts
+++ b/packages/exchange/src/pods/account-balance/account-balance.service.spec.ts
@@ -1,8 +1,13 @@
 import { OrderSide } from '@energyweb/exchange-core';
 import { Test, TestingModule } from '@nestjs/testing';
 import BN from 'bn.js';
+import { plainToClass } from 'class-transformer';
 
 import { Asset } from '../asset/asset.entity';
+import { BundleItem } from '../bundle/bundle-item.entity';
+import { BundleTrade } from '../bundle/bundle-trade.entity';
+import { Bundle } from '../bundle/bundle.entity';
+import { BundleService } from '../bundle/bundle.service';
 import { Order } from '../order/order.entity';
 import { OrderService } from '../order/order.service';
 import { Trade } from '../trade/trade.entity';
@@ -11,11 +16,6 @@ import { TransferDirection } from '../transfer/transfer-direction';
 import { Transfer } from '../transfer/transfer.entity';
 import { TransferService } from '../transfer/transfer.service';
 import { AccountBalanceService } from './account-balance.service';
-import { BundleService } from '../bundle/bundle.service';
-import { Bundle } from '../bundle/bundle.entity';
-import { BundleItem } from '../bundle/bundle-item.entity';
-import { BundleTrade } from '../bundle/bundle-trade.entity';
-import { plainToClass } from 'class-transformer';
 
 jest.mock('../trade/trade.service');
 jest.mock('../transfer/transfer.service');

--- a/packages/exchange/src/pods/account-balance/account-balance.service.spec.ts
+++ b/packages/exchange/src/pods/account-balance/account-balance.service.spec.ts
@@ -15,6 +15,7 @@ import { BundleService } from '../bundle/bundle.service';
 import { Bundle } from '../bundle/bundle.entity';
 import { BundleItem } from '../bundle/bundle-item.entity';
 import { BundleTrade } from '../bundle/bundle-trade.entity';
+import { plainToClass } from 'class-transformer';
 
 jest.mock('../trade/trade.service');
 jest.mock('../transfer/transfer.service');
@@ -228,28 +229,43 @@ describe('AccountBalanceService', () => {
     });
 
     it('should return asset from bundles as available', async () => {
-        registerBundleTrades(
-            {
-                volume: new BN('60'),
-                bundle: {
-                    items: [
-                        { asset: asset1, startVolume: new BN('100') } as BundleItem,
-                        { asset: asset2, startVolume: new BN('200') } as BundleItem
-                    ],
-                    volume: new BN('300')
-                } as Bundle
-            },
-            {
-                volume: new BN('10'),
-                bundle: {
-                    items: [
-                        { asset: asset1, startVolume: new BN('50') } as BundleItem,
-                        { asset: asset2, startVolume: new BN('50') } as BundleItem
-                    ],
-                    volume: new BN('100')
-                } as Bundle
-            }
-        );
+        const trade1 = plainToClass(BundleTrade, {
+            volume: new BN('60'),
+            bundle: plainToClass(Bundle, {
+                items: [
+                    {
+                        asset: asset1,
+                        startVolume: new BN('100'),
+                        currentVolume: new BN('100')
+                    },
+                    {
+                        asset: asset2,
+                        startVolume: new BN('200'),
+                        currentVolume: new BN('200')
+                    }
+                ]
+            })
+        });
+
+        const trade2 = plainToClass(BundleTrade, {
+            volume: new BN('10'),
+            bundle: plainToClass(Bundle, {
+                items: [
+                    {
+                        asset: asset1,
+                        startVolume: new BN('50'),
+                        currentVolume: new BN('50')
+                    },
+                    {
+                        asset: asset2,
+                        startVolume: new BN('50'),
+                        currentVolume: new BN('50')
+                    }
+                ]
+            })
+        });
+
+        registerBundleTrades(trade1, trade2);
 
         const res = await service.getAccountBalance(userId);
 

--- a/packages/exchange/src/pods/bundle/bundle-item.dto.ts
+++ b/packages/exchange/src/pods/bundle/bundle-item.dto.ts
@@ -1,0 +1,11 @@
+import { IsUUID, Validate } from 'class-validator';
+
+import { PositiveBNStringValidator } from '../../utils/positiveBNStringValidator';
+
+export class BundleItemDTO {
+    @IsUUID()
+    assetId: string;
+
+    @Validate(PositiveBNStringValidator)
+    volume: string;
+}

--- a/packages/exchange/src/pods/bundle/bundle-item.entity.ts
+++ b/packages/exchange/src/pods/bundle/bundle-item.entity.ts
@@ -1,6 +1,6 @@
 import { ExtendedBaseEntity } from '@energyweb/origin-backend';
 import BN from 'bn.js';
-import { Transform } from 'class-transformer';
+import { Transform, Exclude } from 'class-transformer';
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 
 import { BNTransformer } from '../../utils/valueTransformers';
@@ -24,5 +24,6 @@ export class BundleItem extends ExtendedBaseEntity {
     currentVolume: BN;
 
     @ManyToOne(() => Bundle, (bundle) => bundle.items)
+    @Exclude()
     bundle: Bundle;
 }

--- a/packages/exchange/src/pods/bundle/bundle-item.entity.ts
+++ b/packages/exchange/src/pods/bundle/bundle-item.entity.ts
@@ -1,0 +1,28 @@
+import { ExtendedBaseEntity } from '@energyweb/origin-backend';
+import BN from 'bn.js';
+import { Transform } from 'class-transformer';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+
+import { BNTransformer } from '../../utils/valueTransformers';
+import { Asset } from '../asset/asset.entity';
+import { Bundle } from './bundle.entity';
+
+@Entity()
+export class BundleItem extends ExtendedBaseEntity {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @ManyToOne(() => Asset, { eager: true })
+    asset: Asset;
+
+    @Column('varchar', { transformer: BNTransformer })
+    @Transform((v: BN) => v.toString(10))
+    startVolume: BN;
+
+    @Column('varchar', { transformer: BNTransformer })
+    @Transform((v: BN) => v.toString(10))
+    currentVolume: BN;
+
+    @ManyToOne(() => Bundle, (bundle) => bundle.items)
+    bundle: Bundle;
+}

--- a/packages/exchange/src/pods/bundle/bundle-trade-item.dto.ts
+++ b/packages/exchange/src/pods/bundle/bundle-trade-item.dto.ts
@@ -1,0 +1,21 @@
+import { Transform, Expose, Exclude } from 'class-transformer';
+import BN from 'bn.js';
+import { Asset } from '../asset/asset.entity';
+
+export class BundleTradeItemDTO {
+    constructor(asset: Asset, volume: BN) {
+        this.asset = asset;
+        this.volume = volume;
+    }
+
+    @Exclude()
+    asset: Asset;
+
+    @Expose()
+    get assetId() {
+        return this.asset.id;
+    }
+
+    @Transform((v: BN) => v.toString(10))
+    volume: BN;
+}

--- a/packages/exchange/src/pods/bundle/bundle-trade.entity.ts
+++ b/packages/exchange/src/pods/bundle/bundle-trade.entity.ts
@@ -21,7 +21,7 @@ export class BundleTrade extends ExtendedBaseEntity {
     buyerId: string;
 
     @Column('varchar', { transformer: BNTransformer })
-    @Transform((v: BN) => v.toString(10))
+    @Transform((v: BN) => v.toString(10), { toPlainOnly: true })
     volume: BN;
 
     @ManyToOne(() => Bundle, { eager: true })

--- a/packages/exchange/src/pods/bundle/bundle.controller.ts
+++ b/packages/exchange/src/pods/bundle/bundle.controller.ts
@@ -53,6 +53,19 @@ export class BundleController {
         }
     }
 
+    @Get('/trade')
+    @UseGuards(AuthGuard())
+    public async getTrades(@UserDecorator() user: ILoggedInUser): Promise<BundleTrade[]> {
+        try {
+            const bundleTrade = await this.bundleService.getTrades(user.ownerId.toString());
+            return bundleTrade;
+        } catch (error) {
+            this.logger.error(error.message);
+
+            throw error;
+        }
+    }
+
     @Post()
     @UseGuards(AuthGuard())
     public async createBundle(

--- a/packages/exchange/src/pods/bundle/bundle.controller.ts
+++ b/packages/exchange/src/pods/bundle/bundle.controller.ts
@@ -8,7 +8,10 @@ import {
     UseGuards,
     UseInterceptors,
     ClassSerializerInterceptor,
-    Get
+    Get,
+    Param,
+    ParseUUIDPipe,
+    Put
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
@@ -84,6 +87,22 @@ export class BundleController {
                 bundleToCreate
             );
             return bundleTrade;
+        } catch (error) {
+            this.logger.error(error.message);
+
+            throw error;
+        }
+    }
+
+    @Put('/:id/cancel')
+    @UseGuards(AuthGuard())
+    public async cancelBundle(
+        @UserDecorator() user: ILoggedInUser,
+        @Param('id', new ParseUUIDPipe({ version: '4' })) bundleId: string
+    ): Promise<Bundle> {
+        try {
+            const bundle = await this.bundleService.cancel(user.ownerId.toString(), bundleId);
+            return bundle;
         } catch (error) {
             this.logger.error(error.message);
 

--- a/packages/exchange/src/pods/bundle/bundle.controller.ts
+++ b/packages/exchange/src/pods/bundle/bundle.controller.ts
@@ -1,0 +1,81 @@
+import { ILoggedInUser } from '@energyweb/origin-backend-core';
+import { UserDecorator } from '@energyweb/origin-backend-utils';
+import {
+    Body,
+    Controller,
+    Logger,
+    Post,
+    UseGuards,
+    UseInterceptors,
+    ClassSerializerInterceptor,
+    Get
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+import { Bundle } from './bundle.entity';
+import { BundleService } from './bundle.service';
+import { CreateBundleDTO } from './create-bundle.dto';
+import { BuyBundleDTO } from './buy-bundle.dto';
+import { BundleTrade } from './bundle-trade.entity';
+
+@UseInterceptors(ClassSerializerInterceptor)
+@Controller('bundle')
+export class BundleController {
+    private readonly logger = new Logger(BundleController.name);
+
+    constructor(private readonly bundleService: BundleService) {}
+
+    @Get()
+    @UseGuards(AuthGuard())
+    public async getBundles(@UserDecorator() user: ILoggedInUser): Promise<Bundle[]> {
+        try {
+            const bundles = await this.bundleService.getByUser(user.ownerId.toString());
+            return bundles;
+        } catch (error) {
+            this.logger.error(error.message);
+
+            throw error;
+        }
+    }
+
+    @Post()
+    @UseGuards(AuthGuard())
+    public async createBundle(
+        @UserDecorator() user: ILoggedInUser,
+        @Body() bundleToCreate: CreateBundleDTO
+    ): Promise<Bundle> {
+        this.logger.log(
+            `Creating new bundle ${JSON.stringify(bundleToCreate)} from userId ${user.ownerId}`
+        );
+
+        try {
+            const bundle = await this.bundleService.create(user.ownerId.toString(), bundleToCreate);
+            return bundle;
+        } catch (error) {
+            this.logger.error(error.message);
+
+            throw error;
+        }
+    }
+
+    @Post('/buy')
+    @UseGuards(AuthGuard())
+    public async buyBundle(
+        @UserDecorator() user: ILoggedInUser,
+        @Body() bundleToCreate: BuyBundleDTO
+    ): Promise<BundleTrade> {
+        this.logger.log(`Buy bundle ${JSON.stringify(bundleToCreate)}`);
+
+        try {
+            const bundleTrade = await this.bundleService.buy(
+                user.ownerId.toString(),
+                bundleToCreate
+            );
+            return bundleTrade;
+        } catch (error) {
+            this.logger.error(error.message);
+
+            throw error;
+        }
+    }
+}

--- a/packages/exchange/src/pods/bundle/bundle.controller.ts
+++ b/packages/exchange/src/pods/bundle/bundle.controller.ts
@@ -25,6 +25,18 @@ export class BundleController {
 
     constructor(private readonly bundleService: BundleService) {}
 
+    @Get('/available')
+    public async getAvailableBundles(): Promise<Bundle[]> {
+        try {
+            const bundles = await this.bundleService.getAvailable();
+            return bundles;
+        } catch (error) {
+            this.logger.error(error.message);
+
+            throw error;
+        }
+    }
+
     @Get()
     @UseGuards(AuthGuard())
     public async getBundles(@UserDecorator() user: ILoggedInUser): Promise<Bundle[]> {

--- a/packages/exchange/src/pods/bundle/bundle.entity.spec.ts
+++ b/packages/exchange/src/pods/bundle/bundle.entity.spec.ts
@@ -1,0 +1,76 @@
+import BN from 'bn.js';
+
+import { BundleItem } from './bundle-item.entity';
+import { Bundle } from './bundle.entity';
+
+describe('Bundle canSplit', () => {
+    const MWh = 10 ** 6;
+
+    it('should allow split with full volume', () => {
+        const bundle = new Bundle({
+            items: [
+                {
+                    startVolume: new BN(50 * MWh),
+                    currentVolume: new BN(50 * MWh)
+                } as BundleItem,
+                {
+                    startVolume: new BN(50 * MWh),
+                    currentVolume: new BN(50 * MWh)
+                } as BundleItem
+            ]
+        });
+
+        expect(bundle.canSplit(new BN(100 * MWh), new BN(MWh))).toBeTruthy();
+    });
+
+    it('should allow split with partial volume', () => {
+        const bundle = new Bundle({
+            items: [
+                {
+                    startVolume: new BN(50 * MWh),
+                    currentVolume: new BN(50 * MWh)
+                } as BundleItem,
+                {
+                    startVolume: new BN(50 * MWh),
+                    currentVolume: new BN(50 * MWh)
+                } as BundleItem
+            ]
+        });
+
+        expect(bundle.canSplit(new BN(50 * MWh), new BN(MWh))).toBeTruthy();
+    });
+
+    it('should not allow split when split results in decimal volumes', () => {
+        const bundle = new Bundle({
+            items: [
+                {
+                    startVolume: new BN(30 * MWh),
+                    currentVolume: new BN(30 * MWh)
+                } as BundleItem,
+                {
+                    startVolume: new BN(30 * MWh),
+                    currentVolume: new BN(30 * MWh)
+                } as BundleItem
+            ]
+        });
+
+        expect(bundle.canSplit(new BN(55 * MWh), new BN(MWh))).toBeFalsy();
+    });
+
+    it('should not allow split when split when requested volume is lower than energyPerUnit * amount of items', () => {
+        const bundle = new Bundle({
+            items: [
+                {
+                    startVolume: new BN(30 * MWh),
+                    currentVolume: new BN(30 * MWh)
+                } as BundleItem,
+                {
+                    startVolume: new BN(30 * MWh),
+                    currentVolume: new BN(30 * MWh)
+                } as BundleItem
+            ]
+        });
+
+        expect(bundle.canSplit(new BN(1 * MWh), new BN(MWh))).toBeFalsy();
+    });
+});

--- a/packages/exchange/src/pods/bundle/bundle.entity.ts
+++ b/packages/exchange/src/pods/bundle/bundle.entity.ts
@@ -16,6 +16,7 @@ export class Bundle extends ExtendedBaseEntity {
     id: string;
 
     @Column()
+    @Expose()
     userId: string;
 
     @Column()

--- a/packages/exchange/src/pods/bundle/bundle.entity.ts
+++ b/packages/exchange/src/pods/bundle/bundle.entity.ts
@@ -22,6 +22,9 @@ export class Bundle extends ExtendedBaseEntity {
     @Column()
     price: number;
 
+    @Column()
+    isCancelled: boolean;
+
     @OneToMany(() => BundleItem, (bundleItem) => bundleItem.bundle, { eager: true, cascade: true })
     items: BundleItem[];
 

--- a/packages/exchange/src/pods/bundle/bundle.entity.ts
+++ b/packages/exchange/src/pods/bundle/bundle.entity.ts
@@ -1,0 +1,49 @@
+import { ExtendedBaseEntity } from '@energyweb/origin-backend';
+import BN from 'bn.js';
+import { Transform, Expose } from 'class-transformer';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+
+import { BundleItem } from './bundle-item.entity';
+
+@Entity()
+export class Bundle extends ExtendedBaseEntity {
+    constructor(bundle: Partial<Bundle>) {
+        super();
+        Object.assign(this, bundle);
+    }
+
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    userId: string;
+
+    @Column()
+    price: number;
+
+    @OneToMany(() => BundleItem, (bundleItem) => bundleItem.bundle, { eager: true, cascade: true })
+    items: BundleItem[];
+
+    @Transform((v: BN) => v.toString(10))
+    @Expose()
+    get available() {
+        return this.items.reduce((sum: BN, item) => sum.add(item.currentVolume), new BN(0));
+    }
+
+    @Transform((v: BN) => v.toString(10))
+    @Expose()
+    get volume() {
+        return this.items.reduce((sum: BN, item) => sum.add(item.startVolume), new BN(0));
+    }
+
+    canSplit(volume: BN, energyPerUnit: BN) {
+        if (!volume.mod(energyPerUnit).isZero()) {
+            return false;
+        }
+
+        const precision = new BN(1000);
+        const ratio = volume.mul(precision).div(volume);
+
+        return this.items.every((item) => item.currentVolume.mul(precision).mod(ratio).isZero());
+    }
+}

--- a/packages/exchange/src/pods/bundle/bundle.entity.ts
+++ b/packages/exchange/src/pods/bundle/bundle.entity.ts
@@ -41,12 +41,15 @@ export class Bundle extends ExtendedBaseEntity {
     }
 
     canSplit(volume: BN, energyPerUnit: BN) {
-        if (!volume.mod(energyPerUnit).isZero()) {
+        if (
+            !volume.mod(energyPerUnit).isZero() ||
+            volume.lt(energyPerUnit.mul(new BN(this.items.length)))
+        ) {
             return false;
         }
 
         const precision = new BN(1000);
-        const ratio = volume.mul(precision).div(volume);
+        const ratio = this.volume.mul(precision).div(volume);
 
         return this.items.every((item) => item.currentVolume.mul(precision).mod(ratio).isZero());
     }

--- a/packages/exchange/src/pods/bundle/bundle.module.ts
+++ b/packages/exchange/src/pods/bundle/bundle.module.ts
@@ -1,0 +1,20 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { BundleItem } from './bundle-item.entity';
+import { BundleTrade } from './bundle-trade.entity';
+import { Bundle } from './bundle.entity';
+import { BundleService } from './bundle.service';
+import { AccountBalanceModule } from '../account-balance/account-balance.module';
+import { BundleController } from './bundle.controller';
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([Bundle, BundleTrade, BundleItem]),
+        forwardRef(() => AccountBalanceModule)
+    ],
+    providers: [BundleService],
+    exports: [BundleService],
+    controllers: [BundleController]
+})
+export class BundleModule {}

--- a/packages/exchange/src/pods/bundle/bundle.service.ts
+++ b/packages/exchange/src/pods/bundle/bundle.service.ts
@@ -1,0 +1,119 @@
+import {
+    BadRequestException,
+    ForbiddenException,
+    forwardRef,
+    Inject,
+    Injectable,
+    Logger
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import BN from 'bn.js';
+import { Repository } from 'typeorm';
+
+import { AccountBalanceService } from '../account-balance/account-balance.service';
+import { Asset } from '../asset/asset.entity';
+import { BundleItem } from './bundle-item.entity';
+import { BundleTrade } from './bundle-trade.entity';
+import { Bundle } from './bundle.entity';
+import { BuyBundleDTO } from './buy-bundle.dto';
+import { CreateBundleDTO } from './create-bundle.dto';
+
+@Injectable()
+export class BundleService {
+    private readonly logger = new Logger(BundleService.name);
+
+    private energyPerUnit: BN;
+
+    constructor(
+        private readonly configService: ConfigService,
+        @InjectRepository(Bundle)
+        private readonly bundleRepository: Repository<Bundle>,
+        @InjectRepository(BundleTrade)
+        private readonly bundleTradeRepository: Repository<BundleTrade>,
+        @Inject(forwardRef(() => AccountBalanceService))
+        private readonly accountBalanceService: AccountBalanceService
+    ) {
+        this.energyPerUnit = new BN(this.configService.get<string>('ENERGY_PER_UNIT'));
+    }
+
+    public async get(id: string): Promise<Bundle> {
+        return this.bundleRepository.findOne(id);
+    }
+
+    public async getByUser(userId: string): Promise<Bundle[]> {
+        return this.bundleRepository.find({ userId });
+    }
+
+    public async getTrades(userId: string): Promise<BundleTrade[]> {
+        return this.bundleTradeRepository.find({ where: { buyerId: userId } });
+    }
+
+    public async create(userId: string, createBundle: CreateBundleDTO): Promise<Bundle> {
+        this.logger.debug(
+            `Bundle creation requested by userId=${userId} ${JSON.stringify(createBundle)}`
+        );
+
+        if (!(await this.hasEnoughAssets(userId, createBundle))) {
+            throw new ForbiddenException('Not enough assets');
+        }
+
+        const bundle: Bundle = {
+            userId,
+            price: createBundle.price,
+            items: createBundle.items.map(
+                (item): BundleItem =>
+                    ({
+                        asset: { id: item.assetId } as Asset,
+                        startVolume: new BN(item.volume),
+                        currentVolume: new BN(item.volume)
+                    } as BundleItem)
+            )
+        } as Bundle;
+
+        const createdBundle = await this.bundleRepository.save(bundle);
+        return new Bundle(createdBundle);
+    }
+
+    public async buy(userId: string, buyBundle: BuyBundleDTO) {
+        const bundle = await this.get(buyBundle.bundleId);
+
+        this.logger.debug(
+            `User ${userId} requested ${JSON.stringify(buyBundle)} from bundle ${JSON.stringify(
+                bundle
+            )}`
+        );
+
+        if (bundle.userId === userId) {
+            throw new ForbiddenException('Unable to buy owned bundle');
+        }
+
+        const volumeToBuy = new BN(buyBundle.volume);
+        if (bundle.available.lt(volumeToBuy)) {
+            throw new ForbiddenException('Request volume is greater than available');
+        }
+
+        if (!bundle.canSplit(volumeToBuy, this.energyPerUnit)) {
+            throw new BadRequestException('Unable to split bundle');
+        }
+
+        const trade: BundleTrade = {
+            bundle: { id: bundle.id },
+            buyerId: userId,
+            volume: new BN(buyBundle.volume)
+        } as BundleTrade;
+
+        const { id } = await this.bundleTradeRepository.save(trade);
+
+        return this.bundleTradeRepository.findOne(id);
+    }
+
+    private async hasEnoughAssets(userId: string, createBundle: CreateBundleDTO) {
+        const assets = createBundle.items.map((item) => ({
+            id: item.assetId,
+            amount: new BN(item.volume)
+        }));
+
+        return this.accountBalanceService.hasEnoughAssetAmount(userId, ...assets);
+    }
+}

--- a/packages/exchange/src/pods/bundle/bundle.service.ts
+++ b/packages/exchange/src/pods/bundle/bundle.service.ts
@@ -89,6 +89,10 @@ export class BundleService {
             )}`
         );
 
+        if (bundle.isCancelled) {
+            throw new ForbiddenException('Unable to buy cancelled bundle');
+        }
+
         if (bundle.userId === userId) {
             throw new ForbiddenException('Unable to buy owned bundle');
         }

--- a/packages/exchange/src/pods/bundle/bundle.service.ts
+++ b/packages/exchange/src/pods/bundle/bundle.service.ts
@@ -50,7 +50,7 @@ export class BundleService {
     }
 
     public async getAvailable(): Promise<Bundle[]> {
-        return this.bundleRepository.find();
+        return this.bundleRepository.find({ isCancelled: false });
     }
 
     public async create(userId: string, createBundle: CreateBundleDTO): Promise<Bundle> {
@@ -64,6 +64,7 @@ export class BundleService {
 
         const bundle: Bundle = {
             userId,
+            isCancelled: false,
             price: createBundle.price,
             items: createBundle.items.map(
                 (item): BundleItem =>
@@ -110,6 +111,12 @@ export class BundleService {
         const { id } = await this.bundleTradeRepository.save(trade);
 
         return this.bundleTradeRepository.findOne(id);
+    }
+
+    public async cancel(userId: string, bundleId: string) {
+        await this.bundleRepository.update({ userId, id: bundleId }, { isCancelled: true });
+
+        return this.get(bundleId);
     }
 
     private async hasEnoughAssets(userId: string, createBundle: CreateBundleDTO) {

--- a/packages/exchange/src/pods/bundle/bundle.service.ts
+++ b/packages/exchange/src/pods/bundle/bundle.service.ts
@@ -49,6 +49,10 @@ export class BundleService {
         return this.bundleTradeRepository.find({ where: { buyerId: userId } });
     }
 
+    public async getAvailable(): Promise<Bundle[]> {
+        return this.bundleRepository.find();
+    }
+
     public async create(userId: string, createBundle: CreateBundleDTO): Promise<Bundle> {
         this.logger.debug(
             `Bundle creation requested by userId=${userId} ${JSON.stringify(createBundle)}`

--- a/packages/exchange/src/pods/bundle/buy-bundle.dto.ts
+++ b/packages/exchange/src/pods/bundle/buy-bundle.dto.ts
@@ -1,0 +1,11 @@
+import { IsUUID, Validate } from 'class-validator';
+
+import { PositiveBNStringValidator } from '../../utils/positiveBNStringValidator';
+
+export class BuyBundleDTO {
+    @IsUUID()
+    readonly bundleId: string;
+
+    @Validate(PositiveBNStringValidator)
+    readonly volume: string;
+}

--- a/packages/exchange/src/pods/bundle/create-bundle.dto.ts
+++ b/packages/exchange/src/pods/bundle/create-bundle.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsPositive, ValidateNested } from 'class-validator';
+import { IsInt, IsPositive, ValidateNested, ArrayMinSize } from 'class-validator';
 
 import { BundleItemDTO } from './bundle-item.dto';
 
@@ -8,5 +8,6 @@ export class CreateBundleDTO {
     price: number;
 
     @ValidateNested()
+    @ArrayMinSize(2)
     items: BundleItemDTO[];
 }

--- a/packages/exchange/src/pods/bundle/create-bundle.dto.ts
+++ b/packages/exchange/src/pods/bundle/create-bundle.dto.ts
@@ -1,0 +1,12 @@
+import { IsInt, IsPositive, ValidateNested } from 'class-validator';
+
+import { BundleItemDTO } from './bundle-item.dto';
+
+export class CreateBundleDTO {
+    @IsInt()
+    @IsPositive()
+    price: number;
+
+    @ValidateNested()
+    items: BundleItemDTO[];
+}

--- a/packages/exchange/src/pods/order/order.service.ts
+++ b/packages/exchange/src/pods/order/order.service.ts
@@ -85,11 +85,10 @@ export class OrderService {
         this.logger.debug(`Requested ask creation for user:${userId} ask:${JSON.stringify(ask)}`);
 
         if (
-            !(await this.accountBalanceService.hasEnoughAssetAmount(
-                userId,
-                ask.assetId,
-                ask.volume
-            ))
+            !(await this.accountBalanceService.hasEnoughAssetAmount(userId, {
+                id: ask.assetId,
+                amount: new BN(ask.volume)
+            }))
         ) {
             throw new Error('Not enough assets');
         }

--- a/packages/exchange/src/pods/transfer/transfer.service.ts
+++ b/packages/exchange/src/pods/transfer/transfer.service.ts
@@ -1,17 +1,18 @@
-import { Injectable, forwardRef, Inject, Logger } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Connection, EntityManager, FindOneOptions } from 'typeorm';
+import BN from 'bn.js';
+import { Connection, EntityManager, FindOneOptions, Repository } from 'typeorm';
 
-import { Transfer } from './transfer.entity';
-import { TransferDirection } from './transfer-direction';
-import { CreateDepositDTO } from './create-deposit.dto';
-import { AssetService } from '../asset/asset.service';
-import { Asset } from '../asset/asset.entity';
-import { AccountService } from '../account/account.service';
-import { RequestWithdrawalDTO } from './create-withdrawal.dto';
 import { AccountBalanceService } from '../account-balance/account-balance.service';
-import { TransferStatus } from './transfer-status';
+import { AccountService } from '../account/account.service';
+import { Asset } from '../asset/asset.entity';
+import { AssetService } from '../asset/asset.service';
 import { WithdrawalProcessorService } from '../withdrawal-processor/withdrawal-processor.service';
+import { CreateDepositDTO } from './create-deposit.dto';
+import { RequestWithdrawalDTO } from './create-withdrawal.dto';
+import { TransferDirection } from './transfer-direction';
+import { TransferStatus } from './transfer-status';
+import { Transfer } from './transfer.entity';
 
 @Injectable()
 export class TransferService {
@@ -56,11 +57,10 @@ export class TransferService {
         withdrawalDTO: RequestWithdrawalDTO,
         transaction?: EntityManager
     ) {
-        const hasEnoughFunds = await this.accountBalanceService.hasEnoughAssetAmount(
-            userId,
-            withdrawalDTO.assetId,
-            withdrawalDTO.amount
-        );
+        const hasEnoughFunds = await this.accountBalanceService.hasEnoughAssetAmount(userId, {
+            id: withdrawalDTO.assetId,
+            amount: new BN(withdrawalDTO.amount)
+        });
 
         if (!hasEnoughFunds) {
             throw new Error('Not enough funds');

--- a/packages/exchange/src/pods/withdrawal-processor/withdrawal-processor.service.ts
+++ b/packages/exchange/src/pods/withdrawal-processor/withdrawal-processor.service.ts
@@ -3,6 +3,7 @@ import { ConfigurationService } from '@energyweb/origin-backend';
 import { forwardRef, Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ModuleRef } from '@nestjs/core';
+import BN from 'bn.js';
 import { Contract, ContractTransaction, ethers, Wallet } from 'ethers';
 import { Subject } from 'rxjs';
 import { concatMap, tap } from 'rxjs/operators';
@@ -133,8 +134,7 @@ export class WithdrawalProcessorService implements OnModuleInit {
 
         const hasEnoughFunds = await this.accountBalanceService.hasEnoughAssetAmount(
             withdrawal.userId,
-            withdrawal.asset.id,
-            withdrawal.amount
+            { id: withdrawal.asset.id, amount: new BN(withdrawal.amount) }
         );
         if (!hasEnoughFunds) {
             this.logger.error(

--- a/packages/exchange/test/bundles.e2e-spec.ts
+++ b/packages/exchange/test/bundles.e2e-spec.ts
@@ -1,0 +1,183 @@
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+
+import { AccountService } from '../src/pods/account/account.service';
+import { Bundle } from '../src/pods/bundle/bundle.entity';
+import { BundleService } from '../src/pods/bundle/bundle.service';
+import { CreateBundleDTO } from '../src/pods/bundle/create-bundle.dto';
+import { TransferService } from '../src/pods/transfer/transfer.service';
+import { DatabaseService } from './database.service';
+import { bootstrapTestInstance } from './exchange';
+import { CreateAssetDTO } from '../src/pods/asset/asset.entity';
+import { BuyBundleDTO } from '../src/pods/bundle/buy-bundle.dto';
+import { BundleTrade } from '../src/pods/bundle/bundle-trade.entity';
+import { AccountDTO } from '../src/pods/account/account.dto';
+
+describe('Bundles', () => {
+    let app: INestApplication;
+    let transferService: TransferService;
+    let databaseService: DatabaseService;
+    let accountService: AccountService;
+    let bundleService: BundleService;
+
+    const user1Id = '1';
+    const MWh = 10 ** 6;
+
+    const assetOne = {
+        address: '0x9876',
+        tokenId: '0',
+        deviceId: '0',
+        generationFrom: new Date('2020-01-01'),
+        generationTo: new Date('2020-01-31')
+    };
+
+    const assetTwo = {
+        address: '0x9876',
+        tokenId: '1',
+        deviceId: '0',
+        generationFrom: new Date('2020-01-01'),
+        generationTo: new Date('2020-01-31')
+    };
+
+    const createTransactionHash = () => `0x${((Math.random() * 0xffffff) << 0).toString(16)}`;
+
+    const createDeposit = (address: string, amount = '1000', asset = assetOne) => {
+        return transferService.createDeposit({
+            address,
+            transactionHash: createTransactionHash(),
+            amount,
+            asset
+        });
+    };
+
+    const confirmDeposit = (transactionHash: string) => {
+        return transferService.setAsConfirmed(transactionHash, 10000);
+    };
+
+    beforeAll(async () => {
+        ({
+            transferService,
+            accountService,
+            databaseService,
+            bundleService,
+            app
+        } = await bootstrapTestInstance());
+
+        await app.init();
+        await databaseService.cleanUp();
+    });
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    afterEach(async () => {
+        await databaseService.cleanUp();
+    });
+
+    it('should be able to create a bundle', async () => {
+        const { address: user1Address } = await accountService.getOrCreateAccount(user1Id);
+
+        const depositOne = await createDeposit(user1Address, `${10 * MWh}`, assetOne);
+        const depositTwo = await createDeposit(user1Address, `${10 * MWh}`, assetTwo);
+
+        await confirmDeposit(depositOne.transactionHash);
+        await confirmDeposit(depositTwo.transactionHash);
+
+        const bundleToCreate: CreateBundleDTO = {
+            price: 1000,
+            items: [
+                { assetId: depositOne.asset.id, volume: `${10 * MWh}` },
+                { assetId: depositTwo.asset.id, volume: `${10 * MWh}` }
+            ]
+        };
+
+        const assertBundle = (bundle: Bundle) => {
+            expect(bundle).toBeDefined();
+            expect(bundle.items).toHaveLength(2);
+            expect(bundle.price).toBe(bundleToCreate.price);
+            expect(bundle.userId).toBe(user1Id);
+            expect(bundle.available).toBe(`${20 * MWh}`);
+        };
+
+        await request(app.getHttpServer())
+            .post('/bundle')
+            .send(bundleToCreate)
+            .expect(201)
+            .expect((res) => {
+                const bundle = res.body as Bundle;
+
+                assertBundle(bundle);
+            });
+
+        await request(app.getHttpServer())
+            .get('/bundle')
+            .expect(200)
+            .expect((res) => {
+                const [bundle] = res.body as Bundle[];
+
+                assertBundle(bundle);
+            });
+    });
+
+    it('should be able to buy part of the bundle', async () => {
+        const user2Id = '2';
+        const { address: user2Address } = await accountService.getOrCreateAccount(user2Id);
+        const depositOne = await createDeposit(user2Address, `${10 * MWh}`, assetOne);
+        const depositTwo = await createDeposit(user2Address, `${10 * MWh}`, assetTwo);
+
+        await confirmDeposit(depositOne.transactionHash);
+        await confirmDeposit(depositTwo.transactionHash);
+
+        const bundleToCreate: CreateBundleDTO = {
+            price: 1000,
+            items: [
+                { assetId: depositOne.asset.id, volume: `${10 * MWh}` },
+                { assetId: depositTwo.asset.id, volume: `${10 * MWh}` }
+            ]
+        };
+
+        const bundle = await bundleService.create(user2Id, bundleToCreate);
+
+        const bundleToBuy: BuyBundleDTO = {
+            bundleId: bundle.id,
+            volume: `${10 * MWh}`
+        };
+
+        await request(app.getHttpServer())
+            .post('/bundle/buy')
+            .send(bundleToBuy)
+            .expect(201)
+            .expect((res) => {
+                const trade = res.body as BundleTrade;
+
+                expect(trade).toBeDefined();
+                expect(trade.buyerId).toBe('1');
+                expect(trade.volume).toBe(`${10 * MWh}`);
+                expect(trade.items).toHaveLength(2);
+
+                const itemOne = trade.items.find((item) => item.assetId === depositOne.asset.id);
+                const itemTwo = trade.items.find((item) => item.assetId === depositTwo.asset.id);
+
+                expect(itemOne.volume).toBe(`${5 * MWh}`);
+                expect(itemTwo.volume).toBe(`${5 * MWh}`);
+            });
+
+        await request(app.getHttpServer())
+            .get('/account')
+            .expect(200)
+            .expect((res) => {
+                const {
+                    balances: { available }
+                } = res.body as AccountDTO;
+
+                expect(available.length).toBe(2);
+
+                const itemOne = available.find((item) => item.asset.id === depositOne.asset.id);
+                const itemTwo = available.find((item) => item.asset.id === depositTwo.asset.id);
+
+                expect(itemOne.amount).toBe(`${5 * MWh}`);
+                expect(itemTwo.amount).toBe(`${5 * MWh}`);
+            });
+    });
+});

--- a/packages/exchange/test/bundles.e2e-spec.ts
+++ b/packages/exchange/test/bundles.e2e-spec.ts
@@ -218,6 +218,19 @@ describe('Bundles', () => {
                 expect(itemOne.amount).toBe(`${5 * MWh}`);
                 expect(itemTwo.amount).toBe(`${5 * MWh}`);
             });
+
+        await request(app.getHttpServer())
+            .get('/bundle/trade')
+            .expect(200)
+            .expect((res) => {
+                const trades = res.body as BundleTrade[];
+
+                expect(trades).toHaveLength(1);
+
+                const [trade] = trades;
+                expect(trade.bundle.id).toBe(bundle.id);
+                expect(trade.buyerId).toBe(user1Id);
+            });
     });
 
     it('should not return cancelled bundles', async () => {

--- a/packages/exchange/test/bundles.e2e-spec.ts
+++ b/packages/exchange/test/bundles.e2e-spec.ts
@@ -8,7 +8,6 @@ import { CreateBundleDTO } from '../src/pods/bundle/create-bundle.dto';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
 import { bootstrapTestInstance } from './exchange';
-import { CreateAssetDTO } from '../src/pods/asset/asset.entity';
 import { BuyBundleDTO } from '../src/pods/bundle/buy-bundle.dto';
 import { BundleTrade } from '../src/pods/bundle/bundle-trade.entity';
 import { AccountDTO } from '../src/pods/account/account.dto';

--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -13,6 +13,7 @@ import { ethers } from 'ethers';
 import { entities } from '../src';
 import { AppModule } from '../src/app.module';
 import { AccountService } from '../src/pods/account/account.service';
+import { BundleService } from '../src/pods/bundle/bundle.service';
 import { DemandService } from '../src/pods/demand/demand.service';
 import { OrderService } from '../src/pods/order/order.service';
 import { ProductService } from '../src/pods/product/product.service';
@@ -89,7 +90,8 @@ export const bootstrapTestInstance = async (deviceServiceMock?: DeviceService) =
         // ganache account 1
         EXCHANGE_WALLET_PUB: '0xd46aC0Bc23dB5e8AfDAAB9Ad35E9A3bA05E092E8',
         EXCHANGE_WALLET_PRIV: '0xd9bc30dc17023fbb68fe3002e0ff9107b241544fd6d60863081c55e383f1b5a3',
-        ISSUER_ID: 'Issuer ID'
+        ISSUER_ID: 'Issuer ID',
+        ENERGY_PER_UNIT: 1000000
     });
 
     const moduleFixture = await Test.createTestingModule({
@@ -167,6 +169,7 @@ export const bootstrapTestInstance = async (deviceServiceMock?: DeviceService) =
     const demandService = await app.resolve<DemandService>(DemandService);
     const orderService = await app.resolve<OrderService>(OrderService);
     const productService = await app.resolve<ProductService>(ProductService);
+    const bundleService = await app.resolve<BundleService>(BundleService);
 
     app.useLogger(testLogger);
     app.enableCors();
@@ -180,6 +183,7 @@ export const bootstrapTestInstance = async (deviceServiceMock?: DeviceService) =
         demandService,
         orderService,
         productService,
+        bundleService,
         registry,
         issuer,
         app

--- a/packages/exchange/tsconfig.json
+++ b/packages/exchange/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "lib": ["es6"],
+        "lib": ["es2019"],
         "types": ["node", "jest"],
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,

--- a/provision-heroku-origin.sh
+++ b/provision-heroku-origin.sh
@@ -26,7 +26,8 @@ heroku config:set --app ${PREFIX}-origin-api-${STAGE} \
   EXCHANGE_WALLET_PRIV='<KEY>' \
   EXCHANGE_WALLET_PUB='<KEY>' \
   JWT_SECRET='<SECRET>' \
-  MANDRILL_API_KEY='<KEY>'
+  MANDRILL_API_KEY='<KEY>' \
+  ENERGY_PER_UNIT=1000000
 
 heroku config:set --app ${PREFIX}-origin-ui-${STAGE} \
   BACKEND_PORT=443 \

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,7 +10,7 @@
         "allowSyntheticDefaultImports": true,
         "resolveJsonModule": true,
         "esModuleInterop": true,
-        "lib": ["es2018", "dom"],
+        "lib": ["es2019", "dom"],
         "skipLibCheck": true,
         "preserveSymlinks": true,
         "pretty": true


### PR DESCRIPTION
This PR introduces the ability to create and manage bundles of tradable certificates.

- Certificates locked in bundles for sale are accounted as `locked`, unless bundle is cancelled
- Certificates bought as a part of bundle are accounted as `available` and can be used for withdrawals, posting for sale or creating bundles
- Bundle API
   - `GET /bundle/available` - bundles available to buy
   - `GET /bundle` - my bundles for sale
   - `GET /bundle/trade` - bought bundles 
   - `POST /bundle/buy` - buying the bundle
   - `PUT /bundle/id/cancel` - cancelling the bundle
- `ENERGY_PER_UNIT` configuration item which defines the amount of energy in single certificate in Wh for e.g 1000000 for 1MWh certificates