### PR TITLE
Last traded price based on product filter

### DIFF
--- a/packages/exchange/src/pods/account-balance/account-balance.service.spec.ts
+++ b/packages/exchange/src/pods/account-balance/account-balance.service.spec.ts
@@ -40,7 +40,7 @@ describe('AccountBalanceService', () => {
     };
 
     const registerTrade = (...trades: Partial<Trade>[]) => {
-        jest.spyOn(tradeService, 'getAll').mockImplementation(async () => trades as Trade[]);
+        jest.spyOn(tradeService, 'getAllByUser').mockImplementation(async () => trades as Trade[]);
     };
 
     const registerOrder = (...orders: Partial<Order>[]) => {

--- a/packages/exchange/src/pods/account-balance/account-balance.service.ts
+++ b/packages/exchange/src/pods/account-balance/account-balance.service.ts
@@ -123,7 +123,7 @@ export class AccountBalanceService {
     }
 
     private async getTrades(userId: string) {
-        const trades = await this.tradeService.getAll(userId, false);
+        const trades = await this.tradeService.getAllByUser(userId, false);
 
         return this.sumByAsset(
             trades,

--- a/packages/exchange/src/pods/matching-engine/order-mapper.ts
+++ b/packages/exchange/src/pods/matching-engine/order-mapper.ts
@@ -1,0 +1,25 @@
+import { Ask, Bid, OrderSide } from '@energyweb/exchange-core';
+
+import { Order } from '../order/order.entity';
+import { ProductDTO } from '../order/product.dto';
+
+export const toMatchingEngineOrder = (order: Order) => {
+    return order.side === OrderSide.Ask
+        ? new Ask(
+              order.id,
+              order.price,
+              order.currentVolume,
+              ProductDTO.toProduct(order.product),
+              order.validFrom,
+              order.userId,
+              order.assetId
+          )
+        : new Bid(
+              order.id,
+              order.price,
+              order.currentVolume,
+              ProductDTO.toProduct(order.product),
+              order.validFrom,
+              order.userId
+          );
+};

--- a/packages/exchange/src/pods/order-book/order-book.controller.ts
+++ b/packages/exchange/src/pods/order-book/order-book.controller.ts
@@ -6,10 +6,14 @@ import { AuthGuard } from '@nestjs/passport';
 import { OrderBookOrderDTO } from './order-book-order.dto';
 import { OrderBookService } from './order-book.service';
 import { ProductFilterDTO } from './product-filter.dto';
+import { TradeService } from '../trade/trade.service';
 
 @Controller('orderbook')
 export class OrderBookController {
-    constructor(private readonly orderBookService: OrderBookService) {}
+    constructor(
+        private readonly orderBookService: OrderBookService,
+        private readonly tradeService: TradeService
+    ) {}
 
     @Post('/search')
     @UseGuards(AuthGuard())
@@ -26,14 +30,15 @@ export class OrderBookController {
         return this.filterOrderBook(productFilter);
     }
 
-    private filterOrderBook(productFilter: ProductFilterDTO, userId?: string) {
-        const { asks, bids } = this.orderBookService.getByProduct(
-            ProductFilterDTO.toProductFilter(productFilter)
-        );
+    private async filterOrderBook(productFilterDTO: ProductFilterDTO, userId?: string) {
+        const productFilter = ProductFilterDTO.toProductFilter(productFilterDTO);
+        const { asks, bids } = this.orderBookService.getByProduct(productFilter);
+        const lastTradedPrice = await this.tradeService.getLastTradedPrice(productFilter);
 
         return {
             asks: asks.map((ask) => OrderBookOrderDTO.fromOrder(ask, userId)).toArray(),
-            bids: bids.map((bid) => OrderBookOrderDTO.fromOrder(bid, userId)).toArray()
+            bids: bids.map((bid) => OrderBookOrderDTO.fromOrder(bid, userId)).toArray(),
+            lastTradedPrice
         };
     }
 }

--- a/packages/exchange/src/pods/order-book/order-book.module.ts
+++ b/packages/exchange/src/pods/order-book/order-book.module.ts
@@ -6,10 +6,11 @@ import { MatchingEngineModule } from '../matching-engine/matching-engine.module'
 import { OrderBookController } from './order-book.controller';
 import { OrderBookService } from './order-book.service';
 import { RunnerModule } from '../runner/runner.module';
+import { TradeModule } from '../trade/trade.module';
 
 @Module({
     providers: [OrderBookService, DeviceTypeValidator, GridOperatorValidator],
-    imports: [MatchingEngineModule, RunnerModule],
+    imports: [MatchingEngineModule, RunnerModule, TradeModule],
     controllers: [OrderBookController]
 })
 export class OrderBookModule {}

--- a/packages/exchange/src/pods/trade/trade.controller.ts
+++ b/packages/exchange/src/pods/trade/trade.controller.ts
@@ -16,7 +16,7 @@ export class TradeController {
     @Get()
     public async getAll(@UserDecorator() user: ILoggedInUser): Promise<TradeDTO[]> {
         const userId = user.id.toString();
-        const trades = await this.tradeService.getAll(userId, false);
+        const trades = await this.tradeService.getAllByUser(userId, false);
 
         return trades.map((trade) =>
             TradeDTO.fromTrade(trade.withMaskedOrder(userId), trade.ask.assetId, trade.ask.product)

--- a/packages/exchange/src/pods/trade/trade.entity.ts
+++ b/packages/exchange/src/pods/trade/trade.entity.ts
@@ -7,6 +7,11 @@ import { Order } from '../order/order.entity';
 
 @Entity()
 export class Trade extends ExtendedBaseEntity {
+    constructor(partial: Partial<Trade>) {
+        super();
+        Object.assign(this, partial);
+    }
+
     @PrimaryGeneratedColumn('uuid')
     id: string;
 

--- a/packages/exchange/src/pods/trade/trade.module.ts
+++ b/packages/exchange/src/pods/trade/trade.module.ts
@@ -4,11 +4,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Trade } from './trade.entity';
 import { TradeService } from './trade.service';
 import { TradeController } from './trade.controller';
+import { RunnerModule } from '../runner/runner.module';
 
 @Module({
     providers: [TradeService],
     exports: [TradeService],
-    imports: [TypeOrmModule.forFeature([Trade])],
+    imports: [TypeOrmModule.forFeature([Trade]), RunnerModule],
     controllers: [TradeController]
 })
 export class TradeModule {}

--- a/packages/exchange/src/pods/trade/trade.service.ts
+++ b/packages/exchange/src/pods/trade/trade.service.ts
@@ -1,28 +1,53 @@
-import { TradeExecutedEvent } from '@energyweb/exchange-core';
-import { Injectable, Logger } from '@nestjs/common';
+import { Ask, Bid, ProductFilter, TradeExecutedEvent } from '@energyweb/exchange-core';
+import { IDeviceTypeService, LocationService } from '@energyweb/utils-general';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { List } from 'immutable';
 import { Connection, Repository } from 'typeorm';
 
-import { Order } from '../order/order.entity';
-import { Trade } from './trade.entity';
+import { toMatchingEngineOrder } from '../matching-engine/order-mapper';
 import { OrderStatus } from '../order/order-status.enum';
+import { Order } from '../order/order.entity';
+import { DeviceTypeServiceWrapper } from '../runner/deviceTypeServiceWrapper';
+import { Trade } from './trade.entity';
+
+type TradeCacheItem = {
+    ask: Ask;
+    bid: Bid;
+    price: number;
+};
 
 @Injectable()
-export class TradeService {
+export class TradeService implements OnModuleInit {
     private readonly logger = new Logger(TradeService.name);
+
+    private readonly locationService = new LocationService();
+
+    private deviceTypeService: IDeviceTypeService;
+
+    private tradeCache: TradeCacheItem[];
 
     constructor(
         private readonly connection: Connection,
         @InjectRepository(Trade)
-        private readonly repository: Repository<Trade>
+        private readonly repository: Repository<Trade>,
+        private readonly deviceTypeServiceWrapper: DeviceTypeServiceWrapper
     ) {}
+
+    public async onModuleInit() {
+        this.logger.log(`Initializing trade service`);
+        this.deviceTypeService = this.deviceTypeServiceWrapper.deviceTypeService;
+
+        await this.loadTradesCache();
+    }
 
     public async persist(event: List<TradeExecutedEvent>) {
         this.logger.log(`Persisting trades and updating orders: ${event.size}`);
         this.logger.debug(`Persisting trades and updating orders: ${JSON.stringify(event)}`);
 
-        return this.connection.transaction(async (entityManager) => {
+        const trades: string[] = [];
+
+        await this.connection.transaction(async (entityManager) => {
             for (const { bid, ask, trade } of event) {
                 await entityManager.update<Order>(Order, ask.id, {
                     currentVolume: ask.volume,
@@ -32,27 +57,86 @@ export class TradeService {
                     currentVolume: bid.volume,
                     status: bid.volume.isZero() ? OrderStatus.Filled : OrderStatus.PartiallyFilled
                 });
-                await entityManager.insert<Trade>(Trade, {
+
+                const tradeToStore = new Trade({
                     created: trade.created,
                     price: trade.price,
                     volume: trade.volume,
-                    bid,
-                    ask
+                    bid: { id: bid.id } as Order,
+                    ask: { id: ask.id } as Order
                 });
+                await entityManager.insert<Trade>(Trade, tradeToStore);
+
+                trades.push(tradeToStore.id);
             }
             this.logger.debug(`Persisting trades and orders completed`);
         });
+
+        await this.updateTradesCache(trades);
     }
 
-    public async getAll(userId: string, maskOrders = true) {
-        const trades = await this.repository
-            .createQueryBuilder('trade')
-            .leftJoinAndSelect('trade.bid', 'bid')
-            .leftJoinAndSelect('trade.ask', 'ask')
-            .leftJoinAndSelect('ask.asset', 'asset')
+    public getLastTradedPrice(productFilter: ProductFilter) {
+        this.logger.debug(`Finding last traded price for ${JSON.stringify(productFilter)}`);
+
+        const lastTrade = this.tradeCache.find(({ ask, bid }) => {
+            return (
+                ask.filterBy(productFilter, this.deviceTypeService, this.locationService) &&
+                bid.filterBy(productFilter, this.deviceTypeService, this.locationService)
+            );
+        });
+
+        return lastTrade?.price;
+    }
+
+    private async getAll() {
+        return this.buildGetAllQuery().orderBy('trade.created', 'DESC').getMany();
+    }
+
+    public async getAllByUser(userId: string, maskOrders = true) {
+        const trades = await this.buildGetAllQuery()
             .where('ask.userId = :userId OR bid.userId = :userId', { userId })
             .getMany();
 
         return maskOrders ? trades.map((trade) => trade.withMaskedOrder(userId)) : trades;
+    }
+
+    private buildGetAllQuery() {
+        return this.repository
+            .createQueryBuilder('trade')
+            .leftJoinAndSelect('trade.bid', 'bid')
+            .leftJoinAndSelect('trade.ask', 'ask')
+            .leftJoinAndSelect('ask.asset', 'asset');
+    }
+
+    private async loadTradesCache() {
+        this.logger.debug(`Loading trades cache`);
+
+        const trades = await this.getAll();
+
+        this.logger.debug(`Found ${trades.length} trades to load`);
+
+        this.tradeCache = trades.map((trade) => this.toTradeCacheItem(trade));
+    }
+
+    private toTradeCacheItem(trade: Trade): TradeCacheItem {
+        return {
+            ask: toMatchingEngineOrder({
+                ...trade.ask,
+                currentVolume: trade.ask.startVolume
+            } as Order) as Ask,
+            bid: toMatchingEngineOrder({
+                ...trade.bid,
+                currentVolume: trade.bid.startVolume
+            } as Order) as Bid,
+            price: trade.price
+        };
+    }
+
+    private async updateTradesCache(tradeIds: string[]) {
+        this.logger.debug(`Updating trades cache with trade ${tradeIds}`);
+        const trades = await this.repository.findByIds(tradeIds, { order: { created: 'DESC' } });
+        const cacheItems = trades.map((trade) => this.toTradeCacheItem(trade));
+
+        this.tradeCache = [...cacheItems, ...this.tradeCache];
     }
 }

--- a/packages/exchange/src/pods/trade/trade.service.ts
+++ b/packages/exchange/src/pods/trade/trade.service.ts
@@ -17,6 +17,8 @@ type TradeCacheItem = {
     price: number;
 };
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 @Injectable()
 export class TradeService implements OnModuleInit {
     private readonly logger = new Logger(TradeService.name);
@@ -59,7 +61,7 @@ export class TradeService implements OnModuleInit {
                 });
 
                 const tradeToStore = new Trade({
-                    created: trade.created,
+                    created: new Date(),
                     price: trade.price,
                     volume: trade.volume,
                     bid: { id: bid.id } as Order,
@@ -68,6 +70,9 @@ export class TradeService implements OnModuleInit {
                 await entityManager.insert<Trade>(Trade, tradeToStore);
 
                 trades.push(tradeToStore.id);
+
+                // This is to force each trade have unique created timestamp making the trades order deterministic
+                await sleep(1);
             }
             this.logger.debug(`Persisting trades and orders completed`);
         });

--- a/packages/exchange/test/orderbook.e2e-spec.ts
+++ b/packages/exchange/test/orderbook.e2e-spec.ts
@@ -1,20 +1,27 @@
 import { Filter } from '@energyweb/exchange-core';
+import { DeviceService } from '@energyweb/origin-backend';
+import { IDeviceProductInfo, IExternalDeviceId } from '@energyweb/origin-backend-core';
 import { INestApplication } from '@nestjs/common';
 import moment from 'moment';
 import request from 'supertest';
 
 import { AccountService } from '../src/pods/account/account.service';
+import { CreateAssetDTO } from '../src/pods/asset/asset.entity';
 import { OrderBookOrderDTO } from '../src/pods/order-book/order-book-order.dto';
-import { ProductFilterDTO } from '../src/pods/order-book/product-filter.dto';
 import { CreateAskDTO } from '../src/pods/order/create-ask.dto';
 import { CreateBidDTO } from '../src/pods/order/create-bid.dto';
 import { OrderService } from '../src/pods/order/order.service';
-import { Transfer } from '../src/pods/transfer/transfer.entity';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
 import { bootstrapTestInstance } from './exchange';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+type OrderBook = {
+    asks: OrderBookOrderDTO[];
+    bids: OrderBookOrderDTO[];
+    lastTradedPrice: number;
+};
 
 describe('orderbook tests', () => {
     let app: INestApplication;
@@ -26,48 +33,45 @@ describe('orderbook tests', () => {
     const user1Id = '1';
     const user2Id = '2';
 
-    const dummyAsset = {
+    const solarAsset: CreateAssetDTO = {
         address: '0x9876',
         tokenId: '0',
-        deviceId: '0',
+        deviceId: 'deviceId1',
         generationFrom: new Date('2020-01-01'),
         generationTo: new Date('2020-01-31')
     };
 
-    const transactionHash = `0x${((Math.random() * 0xffffff) << 0).toString(16)}`;
+    const windAsset: CreateAssetDTO = {
+        address: '0x9876',
+        tokenId: '1',
+        deviceId: 'deviceId2',
+        generationFrom: new Date('2020-01-01'),
+        generationTo: new Date('2020-01-31')
+    };
 
-    let user1Address: string;
-    let deposit: Transfer;
+    const marineAsset: CreateAssetDTO = {
+        address: '0x9876',
+        tokenId: '2',
+        deviceId: 'deviceId3',
+        generationFrom: new Date('2020-01-01'),
+        generationTo: new Date('2020-01-31')
+    };
 
-    const createDeposit = (address: string, amount = '1000', asset = dummyAsset) => {
-        return transferService.createDeposit({
+    const createDeposit = async (address: string, amount = '1000', asset: CreateAssetDTO) => {
+        const deposit = await transferService.createDeposit({
             address,
-            transactionHash,
+            transactionHash: `0x${((Math.random() * 0xffffff) << 0).toString(16)}`,
             amount,
             asset
         });
+
+        await transferService.setAsConfirmed(deposit.transactionHash, 10000);
+
+        return deposit;
     };
 
-    const confirmDeposit = () => {
-        return transferService.setAsConfirmed(transactionHash, 10000);
-    };
-
-    beforeAll(async () => {
-        jest.setTimeout(10000);
-
-        ({
-            transferService,
-            orderService,
-            databaseService,
-            accountService,
-            app
-        } = await bootstrapTestInstance());
-
-        await app.init();
-
-        ({ address: user1Address } = await accountService.getOrCreateAccount(user1Id));
-        deposit = await createDeposit(user1Address);
-        await confirmDeposit();
+    const createAsks = async (address: string) => {
+        const deposit = await createDeposit(address, '1000', solarAsset);
 
         const createAsk1: CreateAskDTO = {
             assetId: deposit.asset.id,
@@ -85,7 +89,9 @@ describe('orderbook tests', () => {
 
         await orderService.createAsk(user1Id, createAsk1);
         await orderService.createAsk(user1Id, createAsk2);
+    };
 
+    const createBids = async () => {
         const createBid1: CreateBidDTO = {
             price: 50,
             volume: '100',
@@ -106,6 +112,136 @@ describe('orderbook tests', () => {
 
         await orderService.createBid(user2Id, createBid1);
         await orderService.createBid(user2Id, createBid2);
+    };
+
+    const windTradeLastTradePrice = 1100;
+
+    const createWindTrades = async (address: string) => {
+        const deposit = await createDeposit(address, '1000', windAsset);
+
+        const createAsk1: CreateAskDTO = {
+            assetId: deposit.asset.id,
+            volume: '500',
+            price: 1000,
+            validFrom: new Date()
+        };
+        const createAsk2: CreateAskDTO = {
+            assetId: deposit.asset.id,
+            volume: '500',
+            price: 1100,
+            validFrom: new Date()
+        };
+
+        await orderService.createAsk(user1Id, createAsk1);
+        await orderService.createAsk(user1Id, createAsk2);
+
+        const createBid1: CreateBidDTO = {
+            price: 1200,
+            volume: '500',
+            validFrom: new Date(),
+            product: {
+                deviceType: ['Wind']
+            }
+        };
+
+        await orderService.createBid(user2Id, createBid1);
+        await orderService.createBid(user2Id, createBid1);
+    };
+
+    const marineTradeLastTradePrice = 3000;
+
+    const createMarineTrades = async (address: string) => {
+        const deposit = await createDeposit(address, '1000', marineAsset);
+
+        const createAsk1: CreateAskDTO = {
+            assetId: deposit.asset.id,
+            volume: '500',
+            price: 3000,
+            validFrom: new Date()
+        };
+
+        await orderService.createAsk(user1Id, createAsk1);
+
+        const createBid1: CreateBidDTO = {
+            price: 3000,
+            volume: '500',
+            validFrom: new Date(),
+            product: {
+                deviceType: ['Marine']
+            }
+        };
+
+        await orderService.createBid(user2Id, createBid1);
+    };
+
+    const createTrades = async (address: string) => {
+        await createWindTrades(address);
+        await sleep(2000);
+
+        await createMarineTrades(address);
+        await sleep(2000);
+    };
+
+    const productByDeviceId = new Map<string, IDeviceProductInfo>([
+        [
+            'deviceId1',
+            {
+                deviceType: 'Solar;Photovoltaic;Classic silicon',
+                country: 'Thailand',
+                region: 'Central',
+                province: 'Nakhon Pathom',
+                operationalSince: 2016,
+                gridOperator: 'TH-PEA'
+            }
+        ],
+        [
+            'deviceId2',
+            {
+                deviceType: 'Wind;Onshore',
+                country: 'Thailand',
+                region: 'Central',
+                province: 'Nakhon Pathom',
+                operationalSince: 2016,
+                gridOperator: 'TH-PEA'
+            }
+        ],
+        [
+            'deviceId3',
+            {
+                deviceType: 'Marine;Tidal;Offshore',
+                country: 'Thailand',
+                region: 'Central',
+                province: 'Nakhon Pathom',
+                operationalSince: 2016,
+                gridOperator: 'TH-PEA'
+            }
+        ]
+    ]);
+
+    const deviceServiceMock = ({
+        findDeviceProductInfo: async ({ id }: IExternalDeviceId): Promise<IDeviceProductInfo> => {
+            return productByDeviceId.get(id);
+        }
+    } as unknown) as DeviceService;
+
+    beforeAll(async () => {
+        jest.setTimeout(10000);
+
+        ({
+            transferService,
+            orderService,
+            databaseService,
+            accountService,
+            app
+        } = await bootstrapTestInstance(deviceServiceMock));
+
+        await app.init();
+
+        const { address } = await accountService.getOrCreateAccount(user1Id);
+        await createTrades(address);
+
+        await createAsks(address);
+        await createBids();
 
         await sleep(2000);
     });
@@ -115,37 +251,32 @@ describe('orderbook tests', () => {
         await app.close();
     });
 
+    const defaultAllFilter = {
+        deviceVintageFilter: Filter.All,
+        generationTimeFilter: Filter.All,
+        locationFilter: Filter.All,
+        deviceTypeFilter: Filter.All,
+        gridOperatorFilter: Filter.All
+    };
+
     it('should return orders based on the filter', async () => {
         await request(app.getHttpServer())
             .post('/orderbook/search')
-            .send({
-                deviceVintageFilter: Filter.All,
-                generationTimeFilter: Filter.All,
-                locationFilter: Filter.All,
-                deviceTypeFilter: Filter.All,
-                gridOperatorFilter: Filter.All
-            } as ProductFilterDTO)
+            .send(defaultAllFilter)
             .expect(200)
             .expect((res) => {
-                console.log(res.body);
-                const { asks, bids } = res.body as {
-                    asks: OrderBookOrderDTO[];
-                    bids: OrderBookOrderDTO[];
-                };
+                const { asks, bids, lastTradedPrice } = res.body as OrderBook;
 
                 expect(asks).toHaveLength(2);
                 expect(bids).toHaveLength(2);
+                expect(lastTradedPrice).toBe(marineTradeLastTradePrice); // marine asset trade
             });
 
         await request(app.getHttpServer())
             .post('/orderbook/search')
             .expect(200)
             .expect((res) => {
-                console.log(res.body);
-                const { asks, bids } = res.body as {
-                    asks: OrderBookOrderDTO[];
-                    bids: OrderBookOrderDTO[];
-                };
+                const { asks, bids } = res.body as OrderBook;
 
                 expect(asks).toHaveLength(2);
                 expect(bids).toHaveLength(2);
@@ -154,22 +285,33 @@ describe('orderbook tests', () => {
         await request(app.getHttpServer())
             .post('/orderbook/search')
             .send({
-                deviceVintageFilter: Filter.All,
-                generationTimeFilter: Filter.All,
-                locationFilter: Filter.All,
+                ...defaultAllFilter,
                 deviceTypeFilter: Filter.Specific,
-                deviceType: ['Solar'],
-                gridOperatorFilter: Filter.All
-            } as ProductFilterDTO)
+                deviceType: ['Solar']
+            })
             .expect(200)
             .expect((res) => {
-                const { asks, bids } = res.body as {
-                    asks: OrderBookOrderDTO[];
-                    bids: OrderBookOrderDTO[];
-                };
+                const { asks, bids } = res.body as OrderBook;
 
                 expect(asks).toHaveLength(2);
                 expect(bids).toHaveLength(1);
+            });
+
+        await request(app.getHttpServer())
+            .post('/orderbook/search')
+            .send({
+                ...defaultAllFilter,
+                deviceTypeFilter: Filter.Specific,
+                deviceType: ['Wind']
+            })
+            .expect(200)
+            .expect((res) => {
+                const { asks, bids, lastTradedPrice } = res.body as OrderBook;
+
+                expect(asks).toHaveLength(0);
+                expect(bids).toHaveLength(1);
+
+                expect(lastTradedPrice).toBe(windTradeLastTradePrice);
             });
     });
 
@@ -177,34 +319,26 @@ describe('orderbook tests', () => {
         await request(app.getHttpServer())
             .post('/orderbook/search')
             .send({
-                deviceVintageFilter: Filter.All,
-                generationTimeFilter: Filter.All,
-                locationFilter: Filter.All,
-                deviceTypeFilter: Filter.Specific,
-                gridOperatorFilter: Filter.All
-            } as ProductFilterDTO)
+                ...defaultAllFilter,
+                deviceTypeFilter: Filter.Specific
+            })
             .expect(400);
 
         await request(app.getHttpServer())
             .post('/orderbook/search')
             .send({
-                deviceVintageFilter: Filter.Specific,
-                generationTimeFilter: Filter.All,
-                locationFilter: Filter.All,
-                deviceTypeFilter: Filter.All
-            } as ProductFilterDTO)
+                ...defaultAllFilter,
+                deviceVintageFilter: Filter.Specific
+            })
             .expect(400);
 
         await request(app.getHttpServer())
             .post('/orderbook/search')
             .send({
-                deviceVintageFilter: Filter.All,
+                ...defaultAllFilter,
                 generationTimeFilter: Filter.Specific,
-                generationFrom: new Date().toISOString(),
-                locationFilter: Filter.All,
-                deviceTypeFilter: Filter.All,
-                gridOperatorFilter: Filter.All
-            } as ProductFilterDTO)
+                generationFrom: new Date().toISOString()
+            })
             .expect(400);
     });
 
@@ -212,13 +346,10 @@ describe('orderbook tests', () => {
         await request(app.getHttpServer())
             .post('/orderbook/search')
             .send({
-                deviceVintageFilter: Filter.All,
-                generationTimeFilter: Filter.All,
-                locationFilter: Filter.All,
+                ...defaultAllFilter,
                 deviceTypeFilter: Filter.Specific,
-                deviceType: ['LOL'],
-                gridOperatorFilter: Filter.All
-            } as ProductFilterDTO)
+                deviceType: ['LOL']
+            })
             .expect(400);
     });
 
@@ -226,12 +357,9 @@ describe('orderbook tests', () => {
         await request(app.getHttpServer())
             .post('/orderbook/search')
             .send({
-                deviceVintageFilter: ('LOL' as unknown) as Filter,
-                generationTimeFilter: Filter.All,
-                locationFilter: Filter.All,
-                deviceTypeFilter: Filter.All,
-                gridOperatorFilter: Filter.All
-            } as ProductFilterDTO)
+                ...defaultAllFilter,
+                deviceVintageFilter: ('LOL' as unknown) as Filter
+            })
             .expect(400);
     });
 });


### PR DESCRIPTION
This PR adds `lastTradedPrice` in the `POST /orderbook/search` response. 

The algorithm for finding the last traded price is:
- fetch all trades sorted DESC by creation
- create cache based on those trades, cache is sorted DESC by trade creation
- every new incoming trade is stored in the cache
- when looking for last traded price 
   - iterate over cache
   - return first item that satisfies `ask.filterBy(productFilter) && bid.filterBy(productFilter)`