### PR TITLE
Revert "fix(deps): update dependency @date-io/moment to v2"

### DIFF
--- a/packages/origin-ui-core/package.json
+++ b/packages/origin-ui-core/package.json
@@ -25,7 +25,7 @@
     "test:e2e:watch": "yarn config-env && jest -u --watchAll -c jest.config.e2e.js"
   },
   "dependencies": {
-    "@date-io/moment": "2.6.0",
+    "@date-io/moment": "1.3.13",
     "@energyweb/device-registry": "6.2.0",
     "@energyweb/exchange-core": "3.0.1",
     "@energyweb/issuer": "2.1.0",

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
         "@energyweb/utils-general",
         "@energyweb/origin-backend",
         "ganache-cli",
-        "solc"
+        "solc",
+        "@date-io/moment"
     ],
     "labels": ["dependencies"],
     "packageRules": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,22 +1205,17 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@date-io/core@1.x":
+"@date-io/core@1.x", "@date-io/core@^1.3.13":
   version "1.3.13"
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
   integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
 
-"@date-io/core@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.6.0.tgz#01efa47b225d1a94d3138583588b919442149ee8"
-  integrity sha512-GkM3jTlh9r3MfZEuFKV4g1JSbxz1G0Or1CBKkhPcw7UCJRjjsk5mLVYZYtUQEsOY8rCSFUTdCOm63ulWzAC/pw==
-
-"@date-io/moment@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.6.0.tgz#08e00a8ff86e4d144bb0e465487048c15db3be25"
-  integrity sha512-G2gpe2AEW221lJGNPjy6ImnJuwFWLwkpJ/IfU3EFbblo/tCzyDmREh7spdDW8auqm5a9EOZShcCIpsommf6L0w==
+"@date-io/moment@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-1.3.13.tgz#56c2772bc4f6675fc6970257e6033e7a7c2960f0"
+  integrity sha512-3kJYusJtQuOIxq6byZlzAHoW/18iExJer9qfRF5DyyzdAk074seTuJfdofjz4RFfTd/Idk8WylOQpWtERqvFuQ==
   dependencies:
-    "@date-io/core" "^2.6.0"
+    "@date-io/core" "^1.3.13"
 
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.27"


### PR DESCRIPTION
Reverts energywebfoundation/origin#427 because it causes issues with **@material-ui/pickers v3.** Can be revisited after **@material-ui/pickers v4** reaches stable.

![Screenshot 2020-05-26 at 14 56 51](https://user-images.githubusercontent.com/9353642/82903516-59797e80-9f61-11ea-8982-6e91ea9d36f3.png)
