### PR TITLE
fix(exchange): restrict withdrawals to organization admins

### DIFF
--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -34,7 +34,8 @@
         "typeorm:migrate": "yarn typeorm migration:generate -- -n",
         "typeorm:run": "yarn typeorm migration:run",
         "typeorm:drop": "yarn typeorm schema:drop",
-        "typeorm:dropAndMigrate": "yarn typeorm:drop && yarn typeorm:run"
+        "typeorm:dropAndMigrate": "yarn typeorm:drop && yarn typeorm:run",
+        "precommit": "lint-staged"
     },
     "dependencies": {
         "@energyweb/exchange-core": "3.0.1",

--- a/packages/exchange/src/pods/transfer/transfer.controller.ts
+++ b/packages/exchange/src/pods/transfer/transfer.controller.ts
@@ -1,5 +1,5 @@
-import { ILoggedInUser } from '@energyweb/origin-backend-core';
-import { UserDecorator } from '@energyweb/origin-backend-utils';
+import { ILoggedInUser, Role } from '@energyweb/origin-backend-core';
+import { Roles, RolesGuard, UserDecorator } from '@energyweb/origin-backend-utils';
 import { Body, Controller, ForbiddenException, Get, Post, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
@@ -17,7 +17,8 @@ export class TransferController {
     }
 
     @Post('withdrawal')
-    @UseGuards(AuthGuard())
+    @UseGuards(AuthGuard(), RolesGuard)
+    @Roles(Role.OrganizationAdmin)
     public async requestWithdrawal(
         @UserDecorator() user: ILoggedInUser,
         @Body() withdrawal: RequestWithdrawalDTO

--- a/packages/exchange/test/direct-buy.e2e-spec.ts
+++ b/packages/exchange/test/direct-buy.e2e-spec.ts
@@ -95,8 +95,6 @@ describe('DirectBuy orders tests', () => {
             .expect((res) => {
                 createdDirectBuyOrder = res.body as Order;
 
-                console.log(createdDirectBuyOrder);
-
                 expect(createdDirectBuyOrder.type).toBe(OrderType.Direct);
                 expect(createdDirectBuyOrder.price).toBe(directBuyOrder.price);
                 expect(createdDirectBuyOrder.startVolume).toBe(directBuyOrder.volume);

--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -2,6 +2,7 @@
 import { Contracts } from '@energyweb/issuer';
 import { ConfigurationService, DeviceService, ExtendedBaseEntity } from '@energyweb/origin-backend';
 import { IDeviceProductInfo, IDeviceWithRelationsIds } from '@energyweb/origin-backend-core';
+import { RolesGuard } from '@energyweb/origin-backend-utils';
 import { CanActivate, ExecutionContext, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AuthGuard } from '@nestjs/passport';
@@ -19,7 +20,6 @@ import { OrderService } from '../src/pods/order/order.service';
 import { ProductService } from '../src/pods/product/product.service';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
-import { RolesGuard } from '@energyweb/origin-backend-utils';
 
 const web3 = 'http://localhost:8580';
 

--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -19,6 +19,7 @@ import { OrderService } from '../src/pods/order/order.service';
 import { ProductService } from '../src/pods/product/product.service';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
+import { RolesGuard } from '@energyweb/origin-backend-utils';
 
 const web3 = 'http://localhost:8580';
 
@@ -158,6 +159,8 @@ export const bootstrapTestInstance = async (deviceServiceMock?: DeviceService) =
         .overrideProvider(ConfigService)
         .useValue(configService)
         .overrideGuard(AuthGuard('default'))
+        .useValue(authGuard)
+        .overrideGuard(RolesGuard)
         .useValue(authGuard)
         .compile();
 

--- a/packages/exchange/test/orderbook.e2e-spec.ts
+++ b/packages/exchange/test/orderbook.e2e-spec.ts
@@ -127,7 +127,6 @@ describe('orderbook tests', () => {
             } as ProductFilterDTO)
             .expect(200)
             .expect((res) => {
-                console.log(res.body);
                 const { asks, bids } = res.body as {
                     asks: OrderBookOrderDTO[];
                     bids: OrderBookOrderDTO[];
@@ -141,7 +140,6 @@ describe('orderbook tests', () => {
             .post('/orderbook/search')
             .expect(200)
             .expect((res) => {
-                console.log(res.body);
                 const { asks, bids } = res.body as {
                     asks: OrderBookOrderDTO[];
                     bids: OrderBookOrderDTO[];


### PR DESCRIPTION
This PR fixes the issue where every organization member was able to withdraw certificates from organization account.

Note: #1086 make e2e tests hard to implement.