### PR TITLE
Transition to event driven architecture

### DIFF
--- a/doc/architecture/decisions/0011-transition-to-event-driven-architecture.md
+++ b/doc/architecture/decisions/0011-transition-to-event-driven-architecture.md
@@ -1,0 +1,23 @@
+# 11. transition-to-event-driven-architecture
+
+Date: 2020-06-01
+
+## Status
+
+Accepted
+
+## Context
+
+Origin as an open-source platform should stay open for custom modules. This should not come with a cost of forking core projects but should be allowed from the topmost application layer.
+
+A good example is features like WebSockets, reporting services, or analytics. While this is not a core concern of the Origin domain, it is definitely important from the operations point of view. Additionally, given the number of specialized solutions, it is virtually impossible for Origin to provide solutions for them.
+
+## Decision
+
+We decided to start the transition to event-based architecture for core components. Currently leveraging `@nestjs/cqrs` component of Nest.JS framework for Event emitting and handling parts.
+
+This approach allows developers to create custom event handlers and provide them in the runner projects for e.g @energyweb/origin-backend-app.
+
+## Consequences
+
+As a consequence, the Origin platform becomes open for additional modules that can listen to core events.

--- a/packages/exchange-core/src/MatchingEngine.ts
+++ b/packages/exchange-core/src/MatchingEngine.ts
@@ -10,13 +10,12 @@ import { DirectBuy } from './DirectBuy';
 import { Order, OrderSide } from './Order';
 import { ProductFilter } from './ProductFilter';
 import { Trade } from './Trade';
+import { TradeExecutedEvent } from './TradeExecutedEvent';
 
 export enum ActionResult {
     Cancelled,
     Error
 }
-
-export type TradeExecutedEvent = { trade: Trade; ask: Ask; bid: Bid | DirectBuy };
 
 export type ActionResultEvent = { orderId: string; result: ActionResult; error?: string };
 
@@ -204,7 +203,7 @@ export class MatchingEngine {
 
         const trade = new Trade(updatedBid, updatedAsk, tradedVolume, bid.price);
 
-        return { trade, ask: updatedAsk, bid: updatedBid };
+        return new TradeExecutedEvent(trade, updatedAsk, updatedBid);
     }
 
     private match() {

--- a/packages/exchange-core/src/TradeExecutedEvent.ts
+++ b/packages/exchange-core/src/TradeExecutedEvent.ts
@@ -1,0 +1,8 @@
+import { Trade } from './Trade';
+import { Ask } from './Ask';
+import { DirectBuy } from './DirectBuy';
+import { Bid } from './Bid';
+
+export class TradeExecutedEvent {
+    constructor(public trade: Trade, public ask: Ask, public bid: Bid | DirectBuy) {}
+}

--- a/packages/exchange-core/src/index.ts
+++ b/packages/exchange-core/src/index.ts
@@ -8,3 +8,4 @@ export { DeviceVintage } from './DeviceVintage';
 export { Operator } from './Operator';
 export { DirectBuy } from './DirectBuy';
 export { TimeRange } from './TimeRange';
+export { TradeExecutedEvent } from './TradeExecutedEvent';

--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -48,6 +48,7 @@
         "@nestjs/common": "7.1.0",
         "@nestjs/config": "0.5.0",
         "@nestjs/core": "7.1.0",
+        "@nestjs/cqrs": "7.0.0",
         "@nestjs/passport": "7.0.0",
         "@nestjs/platform-express": "7.1.0",
         "@nestjs/schedule": "0.4.0",

--- a/packages/exchange/src/index.ts
+++ b/packages/exchange/src/index.ts
@@ -8,6 +8,8 @@ import { Order } from './pods/order/order.entity';
 import { Trade } from './pods/trade/trade.entity';
 import { Transfer } from './pods/transfer/transfer.entity';
 
+export { BulkTradeExecutedEvent } from './pods/matching-engine/bulk-trade-executed.event';
+
 export { AppModule } from './app.module';
 
 export const entities = [

--- a/packages/exchange/src/pods/matching-engine/bulk-trade-executed.event.ts
+++ b/packages/exchange/src/pods/matching-engine/bulk-trade-executed.event.ts
@@ -1,0 +1,6 @@
+import { TradeExecutedEvent } from '@energyweb/exchange-core';
+import { List } from 'immutable';
+
+export class BulkTradeExecutedEvent {
+    constructor(public events: List<TradeExecutedEvent>) {}
+}

--- a/packages/exchange/src/pods/matching-engine/matching-engine.module.ts
+++ b/packages/exchange/src/pods/matching-engine/matching-engine.module.ts
@@ -1,13 +1,13 @@
-import { Module, forwardRef } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
 
-import { TradeModule } from '../trade/trade.module';
-import { MatchingEngineService } from './matching-engine.service';
 import { OrderModule } from '../order/order.module';
 import { RunnerModule } from '../runner/runner.module';
+import { MatchingEngineService } from './matching-engine.service';
 
 @Module({
     providers: [MatchingEngineService],
     exports: [MatchingEngineService],
-    imports: [TradeModule, forwardRef(() => OrderModule), RunnerModule]
+    imports: [forwardRef(() => OrderModule), RunnerModule, CqrsModule]
 })
 export class MatchingEngineModule {}

--- a/packages/exchange/src/pods/trade/trade-executed-event.handler.ts
+++ b/packages/exchange/src/pods/trade/trade-executed-event.handler.ts
@@ -1,0 +1,18 @@
+import { Logger } from '@nestjs/common';
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+
+import { BulkTradeExecutedEvent } from '../matching-engine/bulk-trade-executed.event';
+import { TradeService } from './trade.service';
+
+@EventsHandler(BulkTradeExecutedEvent)
+export class TradeExecutedEventHandler implements IEventHandler<BulkTradeExecutedEvent> {
+    private readonly logger = new Logger(TradeExecutedEventHandler.name);
+
+    constructor(private readonly tradeService: TradeService) {}
+
+    async handle(event: BulkTradeExecutedEvent) {
+        this.logger.debug(`Received trade executed events ${JSON.stringify(event)}`);
+
+        await this.tradeService.persist(event.events);
+    }
+}

--- a/packages/exchange/src/pods/trade/trade.module.ts
+++ b/packages/exchange/src/pods/trade/trade.module.ts
@@ -1,15 +1,17 @@
 import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { RunnerModule } from '../runner/runner.module';
+import { TradeExecutedEventHandler } from './trade-executed-event.handler';
+import { TradeController } from './trade.controller';
 import { Trade } from './trade.entity';
 import { TradeService } from './trade.service';
-import { TradeController } from './trade.controller';
-import { RunnerModule } from '../runner/runner.module';
 
 @Module({
-    providers: [TradeService],
+    providers: [TradeService, TradeExecutedEventHandler],
     exports: [TradeService],
-    imports: [TypeOrmModule.forFeature([Trade]), RunnerModule],
+    imports: [TypeOrmModule.forFeature([Trade]), RunnerModule, CqrsModule],
     controllers: [TradeController]
 })
 export class TradeModule {}

--- a/packages/exchange/src/pods/trade/trade.service.ts
+++ b/packages/exchange/src/pods/trade/trade.service.ts
@@ -1,5 +1,5 @@
 import { Ask, Bid, ProductFilter, TradeExecutedEvent } from '@energyweb/exchange-core';
-import { IDeviceTypeService, LocationService } from '@energyweb/utils-general';
+import { LocationService } from '@energyweb/utils-general';
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import BN from 'bn.js';
@@ -31,8 +31,6 @@ export class TradeService implements OnModuleInit {
 
     private readonly locationService = new LocationService();
 
-    private deviceTypeService: IDeviceTypeService;
-
     private tradeCache: TradeCacheItem[];
 
     constructor(
@@ -44,7 +42,6 @@ export class TradeService implements OnModuleInit {
 
     public async onModuleInit() {
         this.logger.log(`Initializing trade service`);
-        this.deviceTypeService = this.deviceTypeServiceWrapper.deviceTypeService;
 
         await this.loadTradesCache();
     }
@@ -91,8 +88,16 @@ export class TradeService implements OnModuleInit {
 
         const lastTrade = this.tradeCache.find(({ ask, bid }) => {
             return (
-                ask.filterBy(productFilter, this.deviceTypeService, this.locationService) &&
-                bid.filterBy(productFilter, this.deviceTypeService, this.locationService)
+                ask.filterBy(
+                    productFilter,
+                    this.deviceTypeServiceWrapper.deviceTypeService,
+                    this.locationService
+                ) &&
+                bid.filterBy(
+                    productFilter,
+                    this.deviceTypeServiceWrapper.deviceTypeService,
+                    this.locationService
+                )
             );
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2828,6 +2828,11 @@
     tslib "2.0.0"
     uuid "8.0.0"
 
+"@nestjs/cqrs@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/cqrs/-/cqrs-7.0.0.tgz#12b70af5f06ca5ffde5fb1493f17dcfc6eed5e1d"
+  integrity sha512-ZqsQuTdTzgqpizFEgacwHXvfz2+ekGLbMWuPcXk5uDS0+rY1R1rkY8oVkHA7SG700PaV4CccG93THxGfRM9mBQ==
+
 "@nestjs/jwt@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@nestjs/jwt/-/jwt-7.0.0.tgz#977390ea2d5f61cbf49d3da4df740311b98998db"


### PR DESCRIPTION
This PR changes the way trades that occur on the matching engine are communicated outside. This allows 3rd party developers to write custom event handlers on runner application layer for e.g `@energyweb/origin-backend-app`

Closes #1079 