### PR TITLE
fix(exchange): correct logged in user id

### DIFF
--- a/packages/exchange/src/pods/order-book/order-book.controller.ts
+++ b/packages/exchange/src/pods/order-book/order-book.controller.ts
@@ -22,7 +22,7 @@ export class OrderBookController {
         @UserDecorator() user: ILoggedInUser,
         @Body() productFilter: ProductFilterDTO
     ) {
-        return this.filterOrderBook(productFilter, user.id.toString());
+        return this.filterOrderBook(productFilter, user.ownerId);
     }
 
     @Post('/public/search')

--- a/packages/exchange/src/pods/order/order.controller.ts
+++ b/packages/exchange/src/pods/order/order.controller.ts
@@ -38,7 +38,7 @@ export class OrderController {
         this.logger.log(`Creating new order ${JSON.stringify(newOrder)}`);
 
         try {
-            const order = await this.orderService.createBid(user.id.toString(), newOrder);
+            const order = await this.orderService.createBid(user.ownerId, newOrder);
             return order;
         } catch (error) {
             this.logger.error(error.message);
@@ -56,7 +56,7 @@ export class OrderController {
         this.logger.log(`Creating new order ${JSON.stringify(newOrder)}`);
 
         try {
-            const order = await this.orderService.createAsk(user.id.toString(), newOrder);
+            const order = await this.orderService.createAsk(user.ownerId, newOrder);
             return order;
         } catch (error) {
             this.logger.error(error.message);
@@ -74,7 +74,7 @@ export class OrderController {
         this.logger.log(`Creating new direct order ${JSON.stringify(directBuy)}`);
 
         try {
-            const order = await this.orderService.createDirectBuy(user.id.toString(), directBuy);
+            const order = await this.orderService.createDirectBuy(user.ownerId, directBuy);
             return order;
         } catch (error) {
             this.logger.error(error.message);
@@ -86,7 +86,7 @@ export class OrderController {
     @Get()
     @UseGuards(AuthGuard())
     public async getOrders(@UserDecorator() user: ILoggedInUser): Promise<Order[]> {
-        const orders = await this.orderService.getAllOrders(user.id.toString());
+        const orders = await this.orderService.getAllOrders(user.ownerId);
         return orders;
     }
 
@@ -96,7 +96,7 @@ export class OrderController {
         @UserDecorator() user: ILoggedInUser,
         @Param('id', new ParseUUIDPipe({ version: '4' })) orderId: string
     ) {
-        const order = await this.orderService.findOne(user.id.toString(), orderId);
+        const order = await this.orderService.findOne(user.ownerId, orderId);
         return order;
     }
 
@@ -107,7 +107,7 @@ export class OrderController {
         @UserDecorator() user: ILoggedInUser,
         @Param('id', new ParseUUIDPipe({ version: '4' })) orderId: string
     ) {
-        const order = await this.orderService.cancelOrder(user.id.toString(), orderId);
+        const order = await this.orderService.cancelOrder(user.ownerId, orderId);
         return order;
     }
 }

--- a/packages/exchange/src/pods/trade/trade.controller.ts
+++ b/packages/exchange/src/pods/trade/trade.controller.ts
@@ -15,11 +15,14 @@ export class TradeController {
     @UseGuards(AuthGuard())
     @Get()
     public async getAll(@UserDecorator() user: ILoggedInUser): Promise<TradeDTO[]> {
-        const userId = user.id.toString();
-        const trades = await this.tradeService.getAllByUser(userId, false);
+        const trades = await this.tradeService.getAllByUser(user.ownerId, false);
 
         return trades.map((trade) =>
-            TradeDTO.fromTrade(trade.withMaskedOrder(userId), trade.ask.assetId, trade.ask.product)
+            TradeDTO.fromTrade(
+                trade.withMaskedOrder(user.ownerId),
+                trade.ask.assetId,
+                trade.ask.product
+            )
         );
     }
 }

--- a/packages/exchange/test/api-deposits.e2e-spec.ts
+++ b/packages/exchange/test/api-deposits.e2e-spec.ts
@@ -5,7 +5,7 @@ import { AccountDTO } from '../src/pods/account/account.dto';
 import { AccountService } from '../src/pods/account/account.service';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
-import { bootstrapTestInstance } from './exchange';
+import { bootstrapTestInstance, authenticatedUser } from './exchange';
 
 describe('account deposit confirmation', () => {
     let app: INestApplication;
@@ -13,7 +13,7 @@ describe('account deposit confirmation', () => {
     let databaseService: DatabaseService;
     let accountService: AccountService;
 
-    const user1Id = '1';
+    const user1Id = authenticatedUser.organization;
 
     const dummyAsset = {
         address: '0x9876',

--- a/packages/exchange/test/api-orders.e2e-spec.ts
+++ b/packages/exchange/test/api-orders.e2e-spec.ts
@@ -12,7 +12,7 @@ import { RequestWithdrawalDTO } from '../src/pods/transfer/create-withdrawal.dto
 import { Transfer } from '../src/pods/transfer/transfer.entity';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
-import { bootstrapTestInstance } from './exchange';
+import { bootstrapTestInstance, authenticatedUser } from './exchange';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -22,7 +22,7 @@ describe('account ask order send', () => {
     let databaseService: DatabaseService;
     let accountService: AccountService;
 
-    const user1Id = '1';
+    const user1Id = authenticatedUser.organization;
     const dummyAsset = {
         address: '0x9876',
         tokenId: '0',

--- a/packages/exchange/test/api-trades.e2e-spec.ts
+++ b/packages/exchange/test/api-trades.e2e-spec.ts
@@ -8,7 +8,7 @@ import { OrderService } from '../src/pods/order/order.service';
 import { TradeDTO } from '../src/pods/trade/trade.dto';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
-import { bootstrapTestInstance } from './exchange';
+import { bootstrapTestInstance, authenticatedUser } from './exchange';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -102,7 +102,7 @@ describe('Trades API', () => {
     });
 
     it('should be able to read the product information from the ask as a buyer', async () => {
-        const buyerId = '1';
+        const buyerId = authenticatedUser.organization;
         const sellerId = '2';
 
         await testTrade(sellerId, buyerId);
@@ -110,7 +110,7 @@ describe('Trades API', () => {
 
     it('should be able to read the product information from the ask as a seller', async () => {
         const buyerId = '2';
-        const sellerId = '1';
+        const sellerId = authenticatedUser.organization;
 
         await testTrade(sellerId, buyerId);
     });

--- a/packages/exchange/test/bundles.e2e-spec.ts
+++ b/packages/exchange/test/bundles.e2e-spec.ts
@@ -7,7 +7,7 @@ import { BundleService } from '../src/pods/bundle/bundle.service';
 import { CreateBundleDTO } from '../src/pods/bundle/create-bundle.dto';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
-import { bootstrapTestInstance } from './exchange';
+import { bootstrapTestInstance, authenticatedUser } from './exchange';
 import { BuyBundleDTO } from '../src/pods/bundle/buy-bundle.dto';
 import { BundleTrade } from '../src/pods/bundle/bundle-trade.entity';
 import { AccountDTO } from '../src/pods/account/account.dto';
@@ -19,7 +19,7 @@ describe('Bundles', () => {
     let accountService: AccountService;
     let bundleService: BundleService;
 
-    const user1Id = '1';
+    const user1Id = authenticatedUser.organization;
     const MWh = 10 ** 6;
 
     const assetOne = {
@@ -191,7 +191,7 @@ describe('Bundles', () => {
                 const trade = res.body as BundleTrade;
 
                 expect(trade).toBeDefined();
-                expect(trade.buyerId).toBe('1');
+                expect(trade.buyerId).toBe(user1Id);
                 expect(trade.volume).toBe(`${10 * MWh}`);
                 expect(trade.items).toHaveLength(2);
 

--- a/packages/exchange/test/demand.e2e-spec.ts
+++ b/packages/exchange/test/demand.e2e-spec.ts
@@ -13,7 +13,7 @@ import { ProductService } from '../src/pods/product/product.service';
 import { TradeDTO } from '../src/pods/trade/trade.dto';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
-import { bootstrapTestInstance } from './exchange';
+import { bootstrapTestInstance, authenticatedUser } from './exchange';
 import { OrderStatus } from '../src/pods/order/order-status.enum';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -77,7 +77,7 @@ describe('Demand orders trading', () => {
         await databaseService.truncate('demand');
     });
 
-    const demandOwner = '1';
+    const demandOwner = authenticatedUser.organization;
     const sellerId = '2';
     const price = 1000;
 

--- a/packages/exchange/test/deposits-auto-post-for-sale.e2e-spec.ts
+++ b/packages/exchange/test/deposits-auto-post-for-sale.e2e-spec.ts
@@ -10,7 +10,7 @@ import { AccountService } from '../src/pods/account/account.service';
 import { OrderStatus } from '../src/pods/order/order-status.enum';
 import { Order } from '../src/pods/order/order.entity';
 import { DatabaseService } from './database.service';
-import { bootstrapTestInstance } from './exchange';
+import { bootstrapTestInstance, authenticatedUser } from './exchange';
 import { depositToken, issueToken, provider } from './utils';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -20,7 +20,7 @@ describe('Deposits automatic posting for sale', () => {
     let databaseService: DatabaseService;
     let accountService: AccountService;
 
-    const user1Id = '1';
+    const user1Id = authenticatedUser.organization;
 
     let registry: Contract;
     let issuer: Contract;

--- a/packages/exchange/test/deposits-withdrawals.e2e-spec.ts
+++ b/packages/exchange/test/deposits-withdrawals.e2e-spec.ts
@@ -11,7 +11,7 @@ import { RequestWithdrawalDTO } from '../src/pods/transfer/create-withdrawal.dto
 import { TransferDirection } from '../src/pods/transfer/transfer-direction';
 import { Transfer } from '../src/pods/transfer/transfer.entity';
 import { DatabaseService } from './database.service';
-import { bootstrapTestInstance } from './exchange';
+import { bootstrapTestInstance, authenticatedUser } from './exchange';
 import { depositToken, issueToken, provider } from './utils';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -21,7 +21,7 @@ describe('Deposits using deployed registry', () => {
     let databaseService: DatabaseService;
     let accountService: AccountService;
 
-    const user1Id = '1';
+    const user1Id = authenticatedUser.organization;
 
     let registry: Contract;
     let issuer: Contract;

--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -52,10 +52,12 @@ const deployIssuer = async (registry: string) => {
     return contract;
 };
 
+export const authenticatedUser = { id: 1, organization: '1000' };
+
 const authGuard: CanActivate = {
     canActivate: (context: ExecutionContext) => {
         const req = context.switchToHttp().getRequest();
-        req.user = { id: 1, organization: 1 };
+        req.user = authenticatedUser;
 
         return true;
     }

--- a/packages/exchange/test/orderbook.e2e-spec.ts
+++ b/packages/exchange/test/orderbook.e2e-spec.ts
@@ -14,7 +14,7 @@ import { OrderService } from '../src/pods/order/order.service';
 import { TradePriceInfoDTO } from '../src/pods/trade/trade-price-info.dto';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { DatabaseService } from './database.service';
-import { bootstrapTestInstance } from './exchange';
+import { bootstrapTestInstance, authenticatedUser } from './exchange';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -31,7 +31,7 @@ describe('orderbook tests', () => {
     let orderService: OrderService;
     let accountService: AccountService;
 
-    const user1Id = '1';
+    const user1Id = authenticatedUser.organization;
     const user2Id = '2';
 
     const solarAsset: CreateAssetDTO = {


### PR DESCRIPTION
This PR fixes the issue where orders were not created for organization id but for logged in user id. 

Additionally test cases were improved so organization id is not the same as user id, causing this bug passing on tests.