### PR TITLE
Faster certificates inbox loading

### DIFF
--- a/packages/issuer/src/test/Certificate.test.ts
+++ b/packages/issuer/src/test/Certificate.test.ts
@@ -55,7 +55,7 @@ describe('Certificate tests', () => {
         conf.blockchainProperties.activeUser = wallet;
     };
 
-    const issueCertificate = async (volume: BigNumber, isPrivate = false) => {
+    const issueCertificate = async (volume: BigNumber, address: string, isPrivate = false) => {
         setActiveUser(issuerWallet);
 
         const generationStartTime = timestamp;
@@ -65,7 +65,7 @@ describe('Certificate tests', () => {
         const deviceId = '1';
 
         return Certificate.create(
-            deviceOwnerWallet.address,
+            address,
             volume,
             generationStartTime,
             generationEndTime,
@@ -93,16 +93,32 @@ describe('Certificate tests', () => {
     it('gets all certificates', async () => {
         const totalVolume = new BigNumber(1e9);
 
-        await issueCertificate(totalVolume);
-        await issueCertificate(totalVolume);
+        await issueCertificate(totalVolume, deviceOwnerWallet.address);
+        await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         const allCertificates = await CertificateUtils.getAllCertificates(conf);
         assert.equal(allCertificates.length, 2);
     });
 
+    it('gets all owned certificates', async () => {
+        const totalVolume = new BigNumber(1e9);
+
+        await issueCertificate(totalVolume, deviceOwnerWallet.address);
+        await issueCertificate(totalVolume, traderWallet.address);
+
+        setActiveUser(traderWallet);
+        const [certificate] = await CertificateUtils.getAllOwnedCertificates(conf);
+        assert.isDefined(certificate);
+
+        await certificate.transfer(deviceOwnerWallet.address, totalVolume);
+
+        const myCertificates = await CertificateUtils.getAllOwnedCertificates(conf);
+        assert.lengthOf(myCertificates, 0);
+    });
+
     it('issuer issues a certificate', async () => {
         const volume = new BigNumber(1e9);
-        let certificate = await issueCertificate(volume);
+        let certificate = await issueCertificate(volume, deviceOwnerWallet.address);
 
         assert.isNotNull(certificate.id);
 
@@ -125,7 +141,7 @@ describe('Certificate tests', () => {
 
     it('transfers a certificate', async () => {
         const totalVolume = new BigNumber(1e9);
-        let certificate = await issueCertificate(totalVolume);
+        let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(deviceOwnerWallet);
         certificate = await certificate.sync();
@@ -151,7 +167,7 @@ describe('Certificate tests', () => {
 
     it('transfers a private certificate', async () => {
         const totalVolume = new BigNumber(1e9);
-        let certificate = await issueCertificate(totalVolume, true);
+        let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address, true);
 
         setActiveUser(deviceOwnerWallet);
         certificate = await certificate.sync();
@@ -185,7 +201,7 @@ describe('Certificate tests', () => {
     it('partially transfers a private certificate', async () => {
         const totalVolume = new BigNumber(1e9);
         const partialVolumeToSend = totalVolume.div(4);
-        let certificate = await issueCertificate(totalVolume, true);
+        let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address, true);
 
         setActiveUser(deviceOwnerWallet);
         certificate = await certificate.sync();
@@ -221,7 +237,7 @@ describe('Certificate tests', () => {
 
     it('fails transferring a revoked certificate', async () => {
         const totalVolume = new BigNumber(1e9);
-        let certificate = await issueCertificate(totalVolume);
+        let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(issuerWallet);
 
@@ -243,7 +259,7 @@ describe('Certificate tests', () => {
 
     it('fails claiming a revoked certificate', async () => {
         const totalVolume = new BigNumber(1e9);
-        let certificate = await issueCertificate(totalVolume);
+        let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(issuerWallet);
 
@@ -265,7 +281,7 @@ describe('Certificate tests', () => {
 
     it('claims a certificate', async () => {
         const totalVolume = new BigNumber(1e9);
-        let certificate = await issueCertificate(totalVolume);
+        let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(deviceOwnerWallet);
         certificate = await certificate.sync();
@@ -297,7 +313,7 @@ describe('Certificate tests', () => {
 
     it('claims a certificate with empty beneficiary', async () => {
         const totalVolume = new BigNumber(1e9);
-        let certificate = await issueCertificate(totalVolume);
+        let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(deviceOwnerWallet);
         certificate = await certificate.sync();
@@ -315,7 +331,7 @@ describe('Certificate tests', () => {
 
     it('claims a private certificate', async () => {
         const totalVolume = new BigNumber(1e9);
-        let certificate = await issueCertificate(totalVolume, true);
+        let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address, true);
 
         setActiveUser(deviceOwnerWallet);
         certificate = await certificate.sync();
@@ -349,7 +365,7 @@ describe('Certificate tests', () => {
     it('claims a partial private certificate', async () => {
         const totalVolume = new BigNumber(1e9);
         const partialVolumeToClaim = totalVolume.div(4);
-        let certificate = await issueCertificate(totalVolume, true);
+        let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address, true);
 
         setActiveUser(deviceOwnerWallet);
         certificate = await certificate.sync();
@@ -396,8 +412,8 @@ describe('Certificate tests', () => {
     it('batch transfers certificates', async () => {
         const totalVolume = new BigNumber(1e9);
 
-        let certificate = await issueCertificate(totalVolume);
-        let certificate2 = await issueCertificate(totalVolume);
+        let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
+        let certificate2 = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(deviceOwnerWallet);
         certificate = await certificate.sync();
@@ -436,8 +452,8 @@ describe('Certificate tests', () => {
     it('batch claims certificates', async () => {
         const totalVolume = new BigNumber(1e9);
 
-        let certificate = await issueCertificate(totalVolume);
-        let certificate2 = await issueCertificate(totalVolume);
+        let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
+        let certificate2 = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(deviceOwnerWallet);
         certificate = await certificate.sync();

--- a/packages/origin-ui-core/src/features/certificates/sagas.ts
+++ b/packages/origin-ui-core/src/features/certificates/sagas.ts
@@ -40,7 +40,7 @@ function assertIsContractTransaction(
     }
 }
 
-function* getCertificate(id: number) {
+export function* getCertificate(id: number) {
     const configuration: Configuration.Entity = yield select(getConfiguration);
 
     const certificate = new Certificate(id, configuration);


### PR DESCRIPTION
This PR changes the way certificates inbox is loaded.

Previously process required to all existing certificates to be synced, which over time was not sustainable.

Before:
- sync all existing certificates
- load owned exchange certificates
- filter by ower based on current metamask account

After:
- sync certificates which are currently owned
   - get all SingleTransfer events with "to" set to active address
   - get unique certificate id
   - get balances for certificate ids
   - sync certificates with non-zero balance
- load owned exchange certificates