### PR TITLE
feat(origin-ui-core): Enable defining the amount of MWh when claiming

### DIFF
--- a/packages/issuer/src/blockchain-facade/Certificate.ts
+++ b/packages/issuer/src/blockchain-facade/Certificate.ts
@@ -275,12 +275,6 @@ export class Certificate extends PreciseProofEntity implements ICertificate {
 
         const encodedClaimData = await encodeClaimData(claimData, this.configuration);
 
-        console.log({
-            amount,
-            publicVolume,
-            result: amount || publicVolume
-        });
-
         const claimTx = await registryWithSigner.safeTransferAndClaimFrom(
             activeUserAddress,
             activeUserAddress,

--- a/packages/issuer/src/blockchain-facade/Certificate.ts
+++ b/packages/issuer/src/blockchain-facade/Certificate.ts
@@ -207,9 +207,7 @@ export class Certificate extends PreciseProofEntity implements ICertificate {
         const claimedEnergy = await registry.claimedBalanceOf(owner, this.id);
 
         this.energy = {
-            publicVolume: ownedEnergy.sub(claimedEnergy).lt(0)
-                ? bigNumberify(0)
-                : ownedEnergy.sub(claimedEnergy),
+            publicVolume: ownedEnergy,
             privateVolume: this.privateOwnershipCommitment[owner] ?? bigNumberify(0),
             claimedVolume: claimedEnergy
         };
@@ -276,6 +274,12 @@ export class Certificate extends PreciseProofEntity implements ICertificate {
         const activeUserAddress = await activeUser.getAddress();
 
         const encodedClaimData = await encodeClaimData(claimData, this.configuration);
+
+        console.log({
+            amount,
+            publicVolume,
+            result: amount || publicVolume
+        });
 
         const claimTx = await registryWithSigner.safeTransferAndClaimFrom(
             activeUserAddress,

--- a/packages/issuer/src/test/Certificate.test.ts
+++ b/packages/issuer/src/test/Certificate.test.ts
@@ -311,6 +311,24 @@ describe('Certificate tests', () => {
         );
     });
 
+    it('partially claims a certificate', async () => {
+        const totalVolume = new BigNumber(1e9);
+        let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
+
+        setActiveUser(deviceOwnerWallet);
+        certificate = await certificate.sync();
+
+        await certificate.claim(claimData, totalVolume.div(2));
+
+        certificate = await certificate.sync();
+
+        assert.isTrue(certificate.isOwned);
+        assert.equal(certificate.energy.publicVolume.toString(), totalVolume.div(2).toString());
+
+        assert.isTrue(certificate.isClaimed);
+        assert.equal(certificate.energy.claimedVolume.toString(), totalVolume.div(2).toString());
+    });
+
     it('claims a certificate with empty beneficiary', async () => {
         const totalVolume = new BigNumber(1e9);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);

--- a/packages/origin-ui-core/src/components/Modal/ClaimModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/ClaimModal.tsx
@@ -14,9 +14,9 @@ import {
     TextField
 } from '@material-ui/core';
 import { bigNumberify } from 'ethers/utils';
-import moment from 'moment-timezone';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { Countries } from '@energyweb/utils-general';
 
 import {
     ICertificateViewItem,
@@ -24,7 +24,9 @@ import {
     requestClaimCertificateBulk
 } from '../../features/certificates';
 import { getUserOffchain } from '../../features/users/selectors';
-import { EnergyFormatter } from '../../utils';
+import { EnergyFormatter, countDecimals } from '../../utils';
+import { getEnvironment } from '../../features';
+import { IEnvironment } from '../../features/general';
 
 interface IProps {
     certificates: ICertificateViewItem[];
@@ -35,19 +37,58 @@ interface IProps {
 export function ClaimModal(props: IProps) {
     const { certificates, callback, showModal } = props;
 
+    const environment: IEnvironment = useSelector(getEnvironment);
+    const DEFAULT_ENERGY_IN_BASE_UNIT = bigNumberify(
+        Number(environment?.DEFAULT_ENERGY_IN_BASE_UNIT || 1)
+    );
+
     const isBulkClaim = certificates.length > 1;
     const certificateIds: number[] = certificates.map((cert) => cert.id);
 
+    const getCountryCodeFromId = (id: number) =>
+        Countries.find((country) => country.id === id)?.code;
+
     const user = useSelector(getUserOffchain);
-    const countryCodes = moment.tz.countries();
+    const countryCodes = Countries.map((country) => country.code);
 
     const [beneficiary, setBeneficiary] = useState(user?.organization?.name);
     const [address, setAddress] = useState(user?.organization?.address);
-    const [zipCode, setZipCode] = useState(null);
+    const [zipCode, setZipCode] = useState(user?.organization?.postcode);
     const [region, setRegion] = useState(null);
-    const [countryCode, setCountryCode] = useState(null);
+    const [countryCode, setCountryCode] = useState(
+        getCountryCodeFromId(user?.organization?.country)
+    );
+
+    const [energyInDisplayUnit, setEnergyInDisplayUnit] = useState(
+        EnergyFormatter.getValueInDisplayUnit(DEFAULT_ENERGY_IN_BASE_UNIT)
+    );
+
+    const energyInBaseUnit = EnergyFormatter.getBaseValueFromValueInDisplayUnit(
+        energyInDisplayUnit
+    );
+
+    const [validation, setValidation] = useState({
+        energyInDisplayUnit: true
+    });
 
     const dispatch = useDispatch();
+
+    useEffect(() => {
+        if (certificates.length > 0) {
+            setEnergyInDisplayUnit(
+                EnergyFormatter.getValueInDisplayUnit(certificates[0]?.energy.publicVolume)
+            );
+        }
+    }, [certificates, user]);
+
+    useEffect(() => {
+        if (user?.organization) {
+            setBeneficiary(user.organization.name);
+            setAddress(user.organization.address);
+            setCountryCode(getCountryCodeFromId(user.organization.country));
+            setZipCode(user.organization.postcode);
+        }
+    }, [user]);
 
     useEffect(() => {
         if (countryCode === null && countryCodes && countryCodes[0]) {
@@ -70,11 +111,40 @@ export function ClaimModal(props: IProps) {
 
         const action = isBulkClaim
             ? requestClaimCertificateBulk({ certificateIds, claimData })
-            : requestClaimCertificate({ certificateId: certificateIds[0], claimData });
+            : requestClaimCertificate({
+                  certificateId: certificateIds[0],
+                  claimData,
+                  amount: energyInBaseUnit
+              });
 
         dispatch(action);
 
         handleClose();
+    }
+
+    async function validateInputs(event) {
+        switch (event.target.id) {
+            case 'energyInDisplayUnitInput':
+                const newEnergyInDisplayUnit = Number(event.target.value);
+                const newEnergyInBaseValueUnit = EnergyFormatter.getBaseValueFromValueInDisplayUnit(
+                    newEnergyInDisplayUnit
+                );
+
+                const ownedPublicVolume = certificates[0]?.energy.publicVolume;
+
+                const energyInDisplayUnitValid =
+                    newEnergyInBaseValueUnit.gte(1) &&
+                    newEnergyInBaseValueUnit.lte(ownedPublicVolume) &&
+                    countDecimals(newEnergyInDisplayUnit) <= 6;
+
+                setEnergyInDisplayUnit(newEnergyInDisplayUnit);
+
+                setValidation({
+                    ...validation,
+                    energyInDisplayUnit: energyInDisplayUnitValid
+                });
+                break;
+        }
     }
 
     const title = `Claiming certificate${isBulkClaim ? 's' : ''} ${certificateIds?.join(
@@ -98,6 +168,17 @@ export function ClaimModal(props: IProps) {
                         You selected a total of {totalEnergy} worth of certificates.
                     </DialogContentText>
                 )}
+
+                <TextField
+                    label={EnergyFormatter.displayUnit}
+                    value={energyInDisplayUnit}
+                    type="number"
+                    placeholder="1"
+                    onChange={(e) => validateInputs(e)}
+                    className="mt-4"
+                    id="energyInDisplayUnitInput"
+                    fullWidth
+                />
 
                 <TextField
                     label="Beneficiary"
@@ -144,6 +225,12 @@ export function ClaimModal(props: IProps) {
                         ))}
                     </Select>
                 </FormControl>
+
+                <div className="text-danger">
+                    {!validation.energyInDisplayUnit && (
+                        <div>{EnergyFormatter.displayUnit} value is invalid</div>
+                    )}
+                </div>
             </DialogContent>
             <DialogActions>
                 <Button onClick={handleClose} color="secondary">

--- a/packages/origin-ui-core/src/components/Modal/PublishForSaleModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/PublishForSaleModal.tsx
@@ -22,6 +22,8 @@ import { ICertificateViewItem } from '../../features/certificates/types';
 import { getCurrencies } from '../../features/general/selectors';
 import { getUserOffchain } from '../../features/users/selectors';
 import { countDecimals, EnergyFormatter, formatDate } from '../../utils';
+import { getEnvironment } from '../../features';
+import { IEnvironment } from '../../features/general';
 
 interface IProps {
     certificate: ICertificateViewItem;
@@ -30,13 +32,16 @@ interface IProps {
     callback: () => void;
 }
 
-const DEFAULT_ENERGY_IN_BASE_UNIT = bigNumberify(1);
-
 export function PublishForSaleModal(props: IProps) {
     const { certificate, callback, producingDevice, showModal } = props;
 
     const currencies = useSelector(getCurrencies);
     const user = useSelector(getUserOffchain);
+    const environment: IEnvironment = useSelector(getEnvironment);
+
+    const DEFAULT_ENERGY_IN_BASE_UNIT = bigNumberify(
+        Number(environment?.DEFAULT_ENERGY_IN_BASE_UNIT || 1)
+    );
     const [energyInDisplayUnit, setEnergyInDisplayUnit] = useState(
         EnergyFormatter.getValueInDisplayUnit(DEFAULT_ENERGY_IN_BASE_UNIT)
     );

--- a/packages/origin-ui-core/src/features/certificates/actions.ts
+++ b/packages/origin-ui-core/src/features/certificates/actions.ts
@@ -171,6 +171,7 @@ export interface IRequestClaimCertificateAction {
     type: CertificatesActions.requestClaimCertificate;
     payload: {
         certificateId: Certificate['id'];
+        amount: BigNumber;
         claimData: IClaimData;
     };
 }


### PR DESCRIPTION
Adds a field to the claiming modal that allows defining the energy value to claim.

<img width="718" alt="Screenshot 2020-06-10 at 17 27 47" src="https://user-images.githubusercontent.com/9353642/84287068-bbc8a680-ab3f-11ea-99fd-76605778ea02.png">


Additional:
- [x] Fixes a bug where the Certificate client would show the incorrect Owned energy after partially claiming