### PR TITLE
chore: not logged in feedback

### DIFF
--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -183,7 +183,8 @@
                 "haveToBeLoggedInUser": "You need to be a logged in user.",
                 "userHasToBePartOfApprovedOrganization": "The user should be a part of an approved organization.",
                 "userHasToHaveBlockchainAccount": "The user has to have a blockchain account attached to the account.",
-                "blockchainAccountMismatch": "Blockchain account mismatch"
+                "blockchainAccountMismatch": "Blockchain account mismatch",
+                "registerOrLoginTryAgain": "Please log in or register to the platform, then try again."
             },
             "info": {
                 "tryingToSignAndBoundIs": "You are trying to sign a transaction with account different than the one that has been linked to your account. Blockchain address bound to your user is:",

--- a/packages/origin-ui-core/src/components/Organization/OrganizationInvitations.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationInvitations.tsx
@@ -4,9 +4,15 @@ import { useSelector } from 'react-redux';
 import { getUserOffchain } from '../../features/users/selectors';
 import { OrganizationInvitationTable } from './OrganizationInvitationTable';
 import { isRole, Role } from '@energyweb/origin-backend-core';
+import { useTranslation } from '../../utils';
 
 export function OrganizationInvitations() {
+    const { t } = useTranslation();
     const userOffchain = useSelector(getUserOffchain);
+
+    if (!userOffchain) {
+        return t('general.feedback.registerOrLoginTryAgain');
+    }
 
     return (
         <>


### PR DESCRIPTION
If a user clicks the organization invitation link while not logged in, an empty page would be shown.
Now it shows a warning to the user to login or register to the platform.