### PR TITLE
fix(origin-backend): syntax not null and default

### DIFF
--- a/packages/origin-backend/migrations/1591774915665-CertificationRequestEnergyFilesNotNull.ts
+++ b/packages/origin-backend/migrations/1591774915665-CertificationRequestEnergyFilesNotNull.ts
@@ -5,13 +5,13 @@ export class CertificationRequestEnergyFilesNotNull1591774915665 implements Migr
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            `ALTER TABLE "certification_request_queue_item" ALTER COLUMN "files" SET NOT NULL DEFAULT '[]'`
+            `ALTER TABLE "certification_request_queue_item" ALTER COLUMN "files" SET NOT NULL, ALTER COLUMN "files" SET DEFAULT '[]'`
         );
         await queryRunner.query(
             `ALTER TABLE "certification_request" ALTER COLUMN "energy" SET NOT NULL`
         );
         await queryRunner.query(
-            `ALTER TABLE "certification_request" ALTER COLUMN "files" SET NOT NULL DEFAULT '[]'`
+            `ALTER TABLE "certification_request" ALTER COLUMN "files" SET NOT NULL, ALTER COLUMN "files" SET DEFAULT '[]'`
         );
     }
 


### PR DESCRIPTION
Fixes a syntax error when running migrations.