### PR TITLE
chore: move Certification Request validation to the backend

### DIFF
--- a/packages/issuer/package.json
+++ b/packages/issuer/package.json
@@ -50,7 +50,6 @@
         "ethers": "4.0.47",
         "mocha": "7.2.0",
         "moment": "2.24.0",
-        "moment-range": "4.0.2",
         "polly-js": "1.6.5",
         "precise-proofs-js": "1.1.0",
         "winston": "3.2.1"

--- a/packages/issuer/src/blockchain-facade/CertificationRequest.ts
+++ b/packages/issuer/src/blockchain-facade/CertificationRequest.ts
@@ -1,5 +1,3 @@
-import * as Moment from 'moment';
-import { extendMoment } from 'moment-range';
 import { BigNumber, Interface } from 'ethers/utils';
 import { Event as BlockchainEvent } from 'ethers';
 import polly from 'polly-js';
@@ -63,6 +61,8 @@ export class CertificationRequest extends PreciseProofEntity implements ICertifi
             );
         }
 
+        const { certificateClient } = configuration.offChainDataSource;
+
         const request = new CertificationRequest(null, configuration, isVolumePrivate);
 
         const { issuer } = configuration.blockchainProperties as Configuration.BlockchainProperties<
@@ -71,11 +71,15 @@ export class CertificationRequest extends PreciseProofEntity implements ICertifi
         >;
         const issuerWithSigner = issuer.connect(configuration.blockchainProperties.activeUser);
 
-        await this.validateGenerationPeriod(fromTime, toTime, deviceId, configuration);
+        await certificateClient.validateGenerationPeriod({ fromTime, toTime, deviceId });
 
-        const success = await configuration.offChainDataSource.certificateClient.queueCertificationRequestData(
-            { deviceId, fromTime, toTime, energy, files }
-        );
+        const success = await certificateClient.queueCertificationRequestData({
+            deviceId,
+            fromTime,
+            toTime,
+            energy,
+            files
+        });
 
         if (!success) {
             throw new Error('Unable to create CertificationRequest');
@@ -198,44 +202,5 @@ export class CertificationRequest extends PreciseProofEntity implements ICertifi
         );
 
         return Promise.all(certificationRequestPromises);
-    }
-
-    private static async validateGenerationPeriod(
-        fromTime: Timestamp,
-        toTime: Timestamp,
-        deviceId: string,
-        configuration: Configuration.Entity
-    ): Promise<boolean> {
-        const moment = extendMoment(Moment);
-        const unix = (timestamp: Timestamp) => moment.unix(timestamp);
-
-        const allCertificationRequests = await this.getAll(configuration);
-
-        const generationTimeRange = moment.range(unix(fromTime), unix(toTime));
-
-        for (const certificationRequest of allCertificationRequests) {
-            if (certificationRequest.revoked || certificationRequest.deviceId !== deviceId) {
-                continue;
-            }
-
-            const certificationRequestGenerationRange = moment.range(
-                unix(certificationRequest.fromTime),
-                unix(certificationRequest.toTime)
-            );
-
-            if (generationTimeRange.overlaps(certificationRequestGenerationRange)) {
-                throw new Error(
-                    `Generation period ` +
-                        `${unix(fromTime).format()} - ${unix(toTime).format()}` +
-                        ` overlaps with the time period of ` +
-                        `${unix(certificationRequest.fromTime).format()} - ${unix(
-                            certificationRequest.toTime
-                        ).format()}` +
-                        ` of request ${certificationRequest.id}.`
-                );
-            }
-        }
-
-        return true;
     }
 }

--- a/packages/origin-backend-client-mocks/package.json
+++ b/packages/origin-backend-client-mocks/package.json
@@ -22,7 +22,8 @@
     "dependencies": {
         "@energyweb/origin-backend-client": "6.0.1",
         "@energyweb/origin-backend-core": "3.0.1",
-        "@energyweb/utils-general": "9.1.1"
+        "@energyweb/utils-general": "9.1.1",
+        "moment-range": "4.0.2"
     },
     "files": [
         "dist"

--- a/packages/origin-backend-client-mocks/src/OrganizationClientMock.ts
+++ b/packages/origin-backend-client-mocks/src/OrganizationClientMock.ts
@@ -4,9 +4,8 @@ import {
     IOrganizationWithRelationsIds,
     IUserWithRelationsIds,
     OrganizationInvitationStatus,
-    OrganizationInviteCreateReturnData,
+    ISuccessResponse,
     OrganizationPostData,
-    OrganizationMemberChangedReturnData,
     OrganizationStatus,
     OrganizationUpdateData,
     OrganizationRole,
@@ -65,11 +64,11 @@ export class OrganizationClientMock implements IOrganizationClient {
         return Promise.resolve(organization);
     }
 
-    invite(email: string, role: OrganizationRole): Promise<OrganizationInviteCreateReturnData> {
+    invite(email: string, role: OrganizationRole): Promise<ISuccessResponse> {
         throw new Error('Method not implemented.');
     }
 
-    inviteMocked(email: string, organizationId: number, role: OrganizationRole): OrganizationInviteCreateReturnData {
+    inviteMocked(email: string, organizationId: number, role: OrganizationRole): ISuccessResponse {
         this.invitationCounter++;
 
         const organizationInvitation: IOrganizationInvitation = {
@@ -90,7 +89,7 @@ export class OrganizationClientMock implements IOrganizationClient {
 
         return {
             success: true,
-            error: organizationInvitation.id.toString()
+            message: organizationInvitation.id.toString()
         };
     }
 
@@ -101,16 +100,16 @@ export class OrganizationClientMock implements IOrganizationClient {
     removeMember(
         organizationId: number,
         userId: number
-    ): Promise<OrganizationMemberChangedReturnData> {
+    ): Promise<ISuccessResponse> {
         const organization = this.storage.get(organizationId);
 
         organization.users = organization.users.filter((user) => user !== userId);
 
         this.storage.set(organization.id, organization);
 
-        const returnData: OrganizationMemberChangedReturnData = {
+        const returnData: ISuccessResponse = {
             success: true,
-            error: ''
+            message: ''
         };
 
         return Promise.resolve(returnData);
@@ -121,7 +120,7 @@ export class OrganizationClientMock implements IOrganizationClient {
         organizationId: number,
         userId: number,
         newRole: Role
-    ): Promise<OrganizationMemberChangedReturnData> {
+    ): Promise<ISuccessResponse> {
         throw new Error('Method not implemented.');
     }
 

--- a/packages/origin-backend-client/src/CertificateClient.ts
+++ b/packages/origin-backend-client/src/CertificateClient.ts
@@ -5,7 +5,9 @@ import {
     CertificationRequestUpdateData,
     CommitmentStatus,
     IOwnershipCommitmentProofWithTx,
-    ICertificationRequestBackend
+    ICertificationRequestBackend,
+    CertificationRequestValidationData,
+    ISuccessResponse
 } from '@energyweb/origin-backend-core';
 
 import { IRequestClient, RequestClient } from './RequestClient';
@@ -20,6 +22,7 @@ export class CertificationRequestUpdateDTO {
 
 export interface ICertificateClient {
     queueCertificationRequestData(data: CertificationRequestUpdateData): Promise<boolean>;
+    validateGenerationPeriod(data: CertificationRequestValidationData): Promise<ISuccessResponse>;
     getCertificationRequest(id: number): Promise<ICertificationRequest>;
     getAllCertificationRequests(): Promise<ICertificationRequest[]>;
     getOwnershipCommitment(certificateId: number): Promise<IOwnershipCommitmentProofWithTx>;
@@ -64,6 +67,17 @@ export class CertificateClient implements ICertificateClient {
         }
 
         return success;
+    }
+
+    public async validateGenerationPeriod(
+        data: CertificationRequestValidationData
+    ): Promise<ISuccessResponse> {
+        const response = await this.requestClient.post<CertificationRequestValidationData, ISuccessResponse>(
+            `${this.certificateRequestEndpoint}`,
+            data
+        );
+
+        return response.data;
     }
 
     public async getCertificationRequest(id: number): Promise<ICertificationRequest> {

--- a/packages/origin-backend-client/src/CertificateClient.ts
+++ b/packages/origin-backend-client/src/CertificateClient.ts
@@ -72,9 +72,9 @@ export class CertificateClient implements ICertificateClient {
     public async validateGenerationPeriod(
         data: CertificationRequestValidationData
     ): Promise<ISuccessResponse> {
-        const response = await this.requestClient.post<CertificationRequestValidationData, ISuccessResponse>(
-            `${this.certificateRequestEndpoint}`,
-            data
+        const response = await this.requestClient.get<CertificationRequestValidationData, ISuccessResponse>(
+            `${this.certificateRequestEndpoint}/validate`,
+            { params: data }
         );
 
         return response.data;

--- a/packages/origin-backend-client/src/OrganizationClient.ts
+++ b/packages/origin-backend-client/src/OrganizationClient.ts
@@ -2,13 +2,12 @@ import {
     OrganizationPostData,
     OrganizationUpdateData,
     OrganizationInviteCreateData,
-    OrganizationInviteCreateReturnData,
+    ISuccessResponse,
     IOrganizationInvitation,
     OrganizationInviteUpdateData,
     OrganizationInvitationStatus,
     IOrganizationWithRelationsIds,
     IUserWithRelationsIds,
-    OrganizationMemberChangedReturnData,
     OrganizationRole,
     Role,
     IOrganizationUpdateMemberRole
@@ -22,7 +21,7 @@ export interface IOrganizationClient {
     add(data: OrganizationPostData): Promise<IOrganizationWithRelationsIds>;
     update(id: number, data: OrganizationUpdateData): Promise<IOrganizationWithRelationsIds>;
 
-    invite(email: string, role: OrganizationRole): Promise<OrganizationInviteCreateReturnData>;
+    invite(email: string, role: OrganizationRole): Promise<ISuccessResponse>;
     getInvitations(): Promise<IOrganizationInvitation[]>;
     getInvitationsToOrganization(organizationId: number): Promise<IOrganizationInvitation[]>;
     getInvitationsForEmail(email: string): Promise<IOrganizationInvitation[]>;
@@ -33,12 +32,12 @@ export interface IOrganizationClient {
     removeMember(
         organizationId: number,
         userId: number
-    ): Promise<OrganizationMemberChangedReturnData>;
+    ): Promise<ISuccessResponse>;
     memberChangeRole(
         organizationId: number,
         userId: number,
         newRole: Role
-    ): Promise<OrganizationMemberChangedReturnData>
+    ): Promise<ISuccessResponse>
 }
 
 export class OrganizationClient implements IOrganizationClient {
@@ -103,10 +102,10 @@ export class OrganizationClient implements IOrganizationClient {
         });
     }
 
-    public async invite(email: string, role: OrganizationRole): Promise<OrganizationInviteCreateReturnData> {
+    public async invite(email: string, role: OrganizationRole): Promise<ISuccessResponse> {
         const response = await this.requestClient.post<
             OrganizationInviteCreateData,
-            OrganizationInviteCreateReturnData
+            ISuccessResponse
         >(`${this.endpoint}/invite`, {
             email,
             role
@@ -152,8 +151,8 @@ export class OrganizationClient implements IOrganizationClient {
     public async removeMember(
         organizationId: number,
         userId: number
-    ): Promise<OrganizationMemberChangedReturnData> {
-        const response = await this.requestClient.post<{}, OrganizationMemberChangedReturnData>(
+    ): Promise<ISuccessResponse> {
+        const response = await this.requestClient.post<{}, ISuccessResponse>(
             `${this.endpoint}/${organizationId}/remove-member/${userId}`
         );
 
@@ -173,8 +172,8 @@ export class OrganizationClient implements IOrganizationClient {
         organizationId: number,
         userId: number,
         newRole: Role
-    ): Promise<OrganizationMemberChangedReturnData> {
-        const response = await this.requestClient.put<IOrganizationUpdateMemberRole, OrganizationMemberChangedReturnData>(
+    ): Promise<ISuccessResponse> {
+        const response = await this.requestClient.put<IOrganizationUpdateMemberRole, ISuccessResponse>(
             `${this.endpoint}/${organizationId}/change-role/${userId}`,
             { role: newRole }
         );

--- a/packages/origin-backend-core/src/CertificationRequest.ts
+++ b/packages/origin-backend-core/src/CertificationRequest.ts
@@ -30,6 +30,11 @@ export type CertificationRequestUpdateData = Pick<
     'fromTime' | 'toTime' | 'deviceId' | 'energy' | 'files'
 >;
 
+export type CertificationRequestValidationData = Pick<
+    ICertificationRequest,
+    'fromTime' | 'toTime' | 'deviceId'
+>;
+
 export type CertificationRequestDataMocked = Pick<
     ICertificationRequest,
     'owner' | 'fromTime' | 'toTime' | 'created' | 'approved' | 'revoked' | 'deviceId'

--- a/packages/origin-backend-core/src/General.ts
+++ b/packages/origin-backend-core/src/General.ts
@@ -5,3 +5,8 @@ export const FILE_SUPPORTED_MIMETYPES = [
     'application/msword',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 ];
+
+export interface ISuccessResponse {
+    success: boolean;
+    message?: string;
+}

--- a/packages/origin-backend-core/src/Organization.ts
+++ b/packages/origin-backend-core/src/Organization.ts
@@ -71,8 +71,6 @@ export type OrganizationPostData = Omit<IOrganizationProperties, 'id' | 'status'
 
 export type OrganizationUpdateData = Pick<IOrganization, 'status'>;
 
-export type OrganizationMemberChangedReturnData = { success: boolean; error: string };
-
 export interface IOrganizationUpdateMemberRole {
     role: Role;
 }

--- a/packages/origin-backend-core/src/OrganizationInvitation.ts
+++ b/packages/origin-backend-core/src/OrganizationInvitation.ts
@@ -28,6 +28,5 @@ export interface IOrganizationInvitationWithRelations extends IOrganizationInvit
 }
 
 export type OrganizationInviteCreateData = { email: string; role: OrganizationRole };
-export type OrganizationInviteCreateReturnData = { success: boolean; error: string };
 
 export type OrganizationInviteUpdateData = Pick<IOrganizationInvitation, 'status'>;

--- a/packages/origin-backend/package.json
+++ b/packages/origin-backend/package.json
@@ -61,6 +61,7 @@
         "express": "4.17.1",
         "jsonwebtoken": "8.5.1",
         "moment": "2.24.0",
+        "moment-range": "4.0.2",
         "multer": "1.4.2",
         "nodemailer-mandrill-transport": "1.2.0",
         "passport": "0.4.1",

--- a/packages/origin-backend/src/pods/certificate/certificate.controller.ts
+++ b/packages/origin-backend/src/pods/certificate/certificate.controller.ts
@@ -1,7 +1,8 @@
 import {
     ILoggedInUser,
     IOwnershipCommitmentProofWithTx,
-    Role
+    Role,
+    CertificationRequestValidationData
 } from '@energyweb/origin-backend-core';
 import { Roles, RolesGuard, UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
 import {
@@ -12,7 +13,8 @@ import {
     Param,
     Post,
     UseGuards,
-    Put
+    Put,
+    HttpCode
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
@@ -40,6 +42,22 @@ export class CertificateController {
         @UserDecorator() loggedUser: ILoggedInUser
     ): Promise<CertificationRequestQueueItem> {
         return this.certificationRequestService.queue(dto, loggedUser);
+    }
+
+    @Get(`${CERTIFICATION_REQUEST_ENDPOINT}/validate`)
+    @UseGuards(AuthGuard(), ActiveUserGuard, RolesGuard)
+    @Roles(Role.OrganizationAdmin, Role.OrganizationDeviceManager)
+    @HttpCode(200)
+    async validateGenerationPeriod(
+        @Body() validationData: CertificationRequestValidationData,
+        @UserDecorator() loggedUser: ILoggedInUser
+    ): Promise<{ isValid: boolean }> {
+        const isValid = await this.certificationRequestService.validateGenerationPeriod(
+            validationData,
+            loggedUser
+        );
+
+        return { isValid };
     }
 
     @Get(`${CERTIFICATION_REQUEST_ENDPOINT}/:id`)

--- a/packages/origin-backend/src/pods/certificate/certificate.controller.ts
+++ b/packages/origin-backend/src/pods/certificate/certificate.controller.ts
@@ -2,7 +2,7 @@ import {
     ILoggedInUser,
     IOwnershipCommitmentProofWithTx,
     Role,
-    CertificationRequestValidationData
+    ISuccessResponse
 } from '@energyweb/origin-backend-core';
 import { Roles, RolesGuard, UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
 import {
@@ -14,7 +14,7 @@ import {
     Post,
     UseGuards,
     Put,
-    HttpCode
+    Query
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
@@ -47,17 +47,16 @@ export class CertificateController {
     @Get(`${CERTIFICATION_REQUEST_ENDPOINT}/validate`)
     @UseGuards(AuthGuard(), ActiveUserGuard, RolesGuard)
     @Roles(Role.OrganizationAdmin, Role.OrganizationDeviceManager)
-    @HttpCode(200)
     async validateGenerationPeriod(
-        @Body() validationData: CertificationRequestValidationData,
+        @Query('fromTime') fromTime: number,
+        @Query('toTime') toTime: number,
+        @Query('deviceId') deviceId: string,
         @UserDecorator() loggedUser: ILoggedInUser
-    ): Promise<{ isValid: boolean }> {
-        const isValid = await this.certificationRequestService.validateGenerationPeriod(
-            validationData,
+    ): Promise<ISuccessResponse> {
+        return this.certificationRequestService.validateGenerationPeriod(
+            { fromTime, toTime, deviceId },
             loggedUser
         );
-
-        return { isValid };
     }
 
     @Get(`${CERTIFICATION_REQUEST_ENDPOINT}/:id`)

--- a/packages/origin-backend/src/pods/organization/organization-invitation.service.ts
+++ b/packages/origin-backend/src/pods/organization/organization-invitation.service.ts
@@ -40,7 +40,7 @@ export class OrganizationInvitationService {
         if (typeof organizationId === 'undefined') {
             throw new BadRequestException({
                 success: false,
-                error: `User doesn't belong to any organization.`
+                message: `User doesn't belong to any organization.`
             });
         }
 

--- a/packages/origin-backend/src/pods/organization/organization.controller.ts
+++ b/packages/origin-backend/src/pods/organization/organization.controller.ts
@@ -2,15 +2,14 @@ import {
     ILoggedInUser,
     IOrganizationInvitation,
     isRole,
-    OrganizationInviteCreateReturnData,
     OrganizationPostData,
-    OrganizationMemberChangedReturnData,
     OrganizationStatusChangedEvent,
     OrganizationUpdateData,
     Role,
     SupportedEvents,
     OrganizationRole,
-    IOrganizationUpdateMemberRole
+    IOrganizationUpdateMemberRole,
+    ISuccessResponse
 } from '@energyweb/origin-backend-core';
 import { Roles, RolesGuard, UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
 import {
@@ -240,12 +239,12 @@ export class OrganizationController {
         @Body('email') email: string,
         @Body('role') role: OrganizationRole,
         @UserDecorator() loggedUser: ILoggedInUser
-    ): Promise<OrganizationInviteCreateReturnData> {
+    ): Promise<ISuccessResponse> {
         await this.organizationInvitationService.invite(loggedUser, email, role);
 
         return {
             success: true,
-            error: null
+            message: null
         };
     }
 
@@ -256,12 +255,11 @@ export class OrganizationController {
         @Param('id', new ParseIntPipe()) organizationId: number,
         @Param('userId', new ParseIntPipe()) memberId: number,
         @UserDecorator() loggedUser: ILoggedInUser
-    ): Promise<OrganizationMemberChangedReturnData> {
+    ): Promise<ISuccessResponse> {
         await this.organizationService.removeMember(loggedUser, organizationId, memberId);
 
         return {
-            success: true,
-            error: null
+            success: true
         };
     }
 
@@ -273,12 +271,12 @@ export class OrganizationController {
         @Param('userId', new ParseIntPipe()) memberId: number,
         @Body() { role }: IOrganizationUpdateMemberRole,
         @UserDecorator() loggedUser: ILoggedInUser
-    ): Promise<OrganizationMemberChangedReturnData> {
+    ): Promise<ISuccessResponse> {
         await this.organizationService.changeMemberRole(loggedUser, organizationId, memberId, role);
 
         return {
             success: true,
-            error: null
+            message: null
         };
     }
 }

--- a/packages/origin-backend/src/pods/organization/organization.service.ts
+++ b/packages/origin-backend/src/pods/organization/organization.service.ts
@@ -143,7 +143,7 @@ export class OrganizationService {
         if (organizationId !== user.organizationId) {
             throw new BadRequestException({
                 success: false,
-                error: `You are not in the requested organization.`
+                message: `You are not in the requested organization.`
             });
         }
 
@@ -157,14 +157,14 @@ export class OrganizationService {
         if (isRole(userToBeRemoved, Role.OrganizationAdmin) && admins.length < 2) {
             throw new BadRequestException({
                 success: false,
-                error: `Can't remove admin user from organization. There always has to be at least one admin in the organization.`
+                message: `Can't remove admin user from organization. There always has to be at least one admin in the organization.`
             });
         }
 
         if (!organization.users.find((u) => u.id === memberId)) {
             throw new BadRequestException({
                 success: false,
-                error: `User to be removed is not part of the organization.`
+                message: `User to be removed is not part of the organization.`
             });
         }
 
@@ -190,7 +190,7 @@ export class OrganizationService {
         if (organizationId !== user.organizationId) {
             throw new BadRequestException({
                 success: false,
-                error: `You are not in the requested organization.`
+                message: `You are not in the requested organization.`
             });
         }
 
@@ -204,7 +204,7 @@ export class OrganizationService {
         ) {
             throw new BadRequestException({
                 success: false,
-                error: `Can't change role of admin user from organization. There always has to be at least one admin in the organization.`
+                message: `Can't change role of admin user from organization. There always has to be at least one admin in the organization.`
             });
         }
 
@@ -215,7 +215,7 @@ export class OrganizationService {
         if (!organization.users.find((u) => u.id === memberId)) {
             throw new BadRequestException({
                 success: false,
-                error: `User to be removed is not part of the organization.`
+                message: `User to be removed is not part of the organization.`
             });
         }
 

--- a/packages/origin-backend/test/certification-request.e2e-spec.ts
+++ b/packages/origin-backend/test/certification-request.e2e-spec.ts
@@ -348,14 +348,15 @@ describe('CertificationRequest e2e tests', () => {
         );
 
         await request(app.getHttpServer())
-            .get(`/Certificate/CertificationRequest/validate`)
+            .get(
+                `/Certificate/CertificationRequest/validate?fromTime=${fromTime}&toTime=${toTime}&deviceId=${externalDeviceId}`
+            )
             .set('Authorization', `Bearer ${accessToken}`)
-            .send({ fromTime, toTime, deviceId: externalDeviceId })
             .expect((res) => {
                 expect(res.status).to.equal(200);
 
-                const { isValid } = res.body;
-                expect(isValid).to.be.true;
+                const { success } = res.body;
+                expect(success).to.be.true;
             });
 
         await request(app.getHttpServer())
@@ -377,13 +378,10 @@ describe('CertificationRequest e2e tests', () => {
         });
 
         await request(app.getHttpServer())
-            .get(`/Certificate/CertificationRequest/validate`)
+            .get(
+                `/Certificate/CertificationRequest/validate?fromTime=${fromTime}&toTime=${toTime}&deviceId=${externalDeviceId}`
+            )
             .set('Authorization', `Bearer ${accessToken}`)
-            .send({
-                fromTime,
-                toTime,
-                deviceId: externalDeviceId
-            })
             .expect(409);
     });
 });

--- a/packages/origin-ui-core/src/features/certificates/sagas.ts
+++ b/packages/origin-ui-core/src/features/certificates/sagas.ts
@@ -87,7 +87,15 @@ function* requestCertificatesSaga(): SagaIterator {
             }
         } catch (error) {
             console.warn('Error while requesting certificates', error);
-            showNotification(`Transaction could not be completed.`, NotificationType.Error);
+
+            if (error?.response?.status === 409) {
+                showNotification(
+                    `There is already a certificate requested for that time period.`,
+                    NotificationType.Error
+                );
+            } else {
+                showNotification(`Transaction could not be completed.`, NotificationType.Error);
+            }
         }
 
         yield put(setLoading(false));

--- a/yarn.lock
+++ b/yarn.lock
@@ -15153,7 +15153,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment-range@4.0.2:
+moment-range@4.0.2, moment-range@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/moment-range/-/moment-range-4.0.2.tgz#f7c3863df2a1ed7fd1822ba5a7bcf53a78701be9"
   integrity sha512-n8sceWwSTjmz++nFHzeNEUsYtDqjgXgcOBzsHi+BoXQU2FW+eU92LUaK8gqOiSu5PG57Q9sYj1Fz4LRDj4FtKA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -15153,7 +15153,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment-range@4.0.2, moment-range@^4.0.2:
+moment-range@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/moment-range/-/moment-range-4.0.2.tgz#f7c3863df2a1ed7fd1822ba5a7bcf53a78701be9"
   integrity sha512-n8sceWwSTjmz++nFHzeNEUsYtDqjgXgcOBzsHi+BoXQU2FW+eU92LUaK8gqOiSu5PG57Q9sYj1Fz4LRDj4FtKA==


### PR DESCRIPTION
- [x] Create a generation time validation method on the backend (to verify that a certificate for this device and timeframe doesn't already exist)
- [x] e2e tests
- [x] Replace the old frontend validation with the new backend one

Fixes #1013 