### PR TITLE
chore: only pull device.meterStats when explicitly requested

### DIFF
--- a/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
+++ b/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
@@ -146,15 +146,13 @@ export class Entity implements IDevice {
     }
 }
 
-export const getAllDevices = async (withMeterStats: boolean = false, configuration: Configuration.Entity): Promise<Entity[]> => {
+export const getAllDevices = async (
+    configuration: Configuration.Entity,
+    withMeterStats = false
+): Promise<Entity[]> => {
     const allDevices = await configuration.offChainDataSource.deviceClient.getAll(withMeterStats);
 
     return allDevices.map((device) => new Entity(device.id, configuration, device));
-};
-
-export const getDeviceListLength = async (configuration: Configuration.Entity) => {
-    const allDevices = await configuration.offChainDataSource.deviceClient.getAll(false);
-    return allDevices.length;
 };
 
 export const createDevice = async (

--- a/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
+++ b/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
@@ -146,14 +146,14 @@ export class Entity implements IDevice {
     }
 }
 
-export const getAllDevices = async (configuration: Configuration.Entity): Promise<Entity[]> => {
-    const allDevices = await configuration.offChainDataSource.deviceClient.getAll();
+export const getAllDevices = async (withMeterStats: boolean = false, configuration: Configuration.Entity): Promise<Entity[]> => {
+    const allDevices = await configuration.offChainDataSource.deviceClient.getAll(withMeterStats);
 
     return allDevices.map((device) => new Entity(device.id, configuration, device));
 };
 
 export const getDeviceListLength = async (configuration: Configuration.Entity) => {
-    const allDevices = await configuration.offChainDataSource.deviceClient.getAll();
+    const allDevices = await configuration.offChainDataSource.deviceClient.getAll(false);
     return allDevices.length;
 };
 

--- a/packages/device-registry/src/test/DeviceFacade.test.ts
+++ b/packages/device-registry/src/test/DeviceFacade.test.ts
@@ -70,12 +70,10 @@ describe('Device Facade', () => {
                 defaultAskPrice: null
             };
 
-            assert.equal(await ProducingDevice.getDeviceListLength(conf), 0);
-
             const device = await ProducingDevice.createDevice(deviceProps, conf);
             assert.deepOwnInclude(device, deviceProps);
 
-            assert.equal(await ProducingDevice.getDeviceListLength(conf), 1);
+            assert.equal((await ProducingDevice.getAllDevices(conf)).length, 1);
         });
 
         it('should log a new meter reading', async () => {

--- a/packages/origin-backend-client-mocks/src/DeviceClientMock.ts
+++ b/packages/origin-backend-client-mocks/src/DeviceClientMock.ts
@@ -11,8 +11,6 @@ import {
 } from '@energyweb/origin-backend-core';
 
 export class DeviceClientMock implements IDeviceClient {
-    
-    
     private storage = new Map<number, IDeviceWithRelationsIds>();
 
     private idCounter = 0;
@@ -27,7 +25,7 @@ export class DeviceClientMock implements IDeviceClient {
         return this.storage.get(id);
     }
 
-    async getAll(): Promise<IDeviceWithRelationsIds[]> {
+    async getAll(withMeterStats: boolean): Promise<IDeviceWithRelationsIds[]> {
         return [...this.storage.values()];
     }
 
@@ -93,7 +91,7 @@ export class DeviceClientMock implements IDeviceClient {
         throw new Error("Method not implemented.");
     }
 
-    public async getMyDevice(): Promise<IDeviceWithRelationsIds[]> {
+    public async getMyDevices(withMeterStats: boolean): Promise<IDeviceWithRelationsIds[]> {
         throw new Error("Method not implemented.");
     }
 }

--- a/packages/origin-backend/src/pods/device/device.controller.ts
+++ b/packages/origin-backend/src/pods/device/device.controller.ts
@@ -42,15 +42,20 @@ export class DeviceController {
     // TODO: remove sensitive information
 
     @Get()
-    async getAll() {
-        return this.deviceService.getAll();
+    async getAll(@Query('withMeterStats') withMeterStats: boolean) {
+        return this.deviceService.getAll(withMeterStats ?? false);
     }
 
     @Get('/my-devices')
     @UseGuards(AuthGuard(), ActiveUserGuard, RolesGuard)
     @Roles(Role.OrganizationAdmin, Role.OrganizationDeviceManager, Role.OrganizationUser)
-    async getMyDevices(@UserDecorator() { organizationId }: ILoggedInUser) {
-        return this.deviceService.getAll({ where: { organization: { id: organizationId } } });
+    async getMyDevices(
+        @Query('withMeterStats') withMeterStats: boolean,
+        @UserDecorator() { organizationId }: ILoggedInUser
+    ) {
+        return this.deviceService.getAll(withMeterStats ?? false, {
+            where: { organization: { id: organizationId } }
+        });
     }
 
     @Get('supplyBy')
@@ -69,8 +74,11 @@ export class DeviceController {
     }
 
     @Get('/:id')
-    async get(@Param('id') id: string): Promise<IDeviceWithRelationsIds> {
-        const existingEntity = await this.deviceService.findOne(id);
+    async get(
+        @Param('id') id: string,
+        @Query('withMeterStats') withMeterStats: boolean
+    ): Promise<IDeviceWithRelationsIds> {
+        const existingEntity = await this.deviceService.findOne(id, {}, withMeterStats);
 
         if (!existingEntity) {
             throw new NotFoundException(StorageErrors.NON_EXISTENT);

--- a/packages/origin-backend/src/pods/device/device.service.ts
+++ b/packages/origin-backend/src/pods/device/device.service.ts
@@ -59,14 +59,13 @@ export class DeviceService {
             d.externalDeviceIds.find((id) => id.id === externalId.id && id.type === externalId.type)
         );
 
-        device.meterStats = await this.getMeterStats(device.id.toString());
-
         return device;
     }
 
     async findOne(
         id: string,
-        options: FindOneOptions<Device> = {}
+        options: FindOneOptions<Device> = {},
+        withMeterStats = false
     ): Promise<ExtendedBaseEntity & IDeviceWithRelationsIds> {
         const device = ((await this.repository.findOne(id, {
             loadRelationIds: true,
@@ -77,7 +76,9 @@ export class DeviceService {
             device.smartMeterReads = [];
         }
 
-        device.meterStats = await this.getMeterStats(device.id.toString());
+        if (withMeterStats) {
+            device.meterStats = await this.getMeterStats(device.id.toString());
+        }
 
         return device;
     }
@@ -167,6 +168,7 @@ export class DeviceService {
     }
 
     async getAll(
+        withMeterStats = false,
         options: FindOneOptions<Device> = {}
     ): Promise<Array<ExtendedBaseEntity & IDeviceWithRelationsIds>> {
         const devices = ((await this.repository.find({
@@ -179,7 +181,9 @@ export class DeviceService {
                 device.smartMeterReads = [];
             }
 
-            device.meterStats = await this.getMeterStats(device.id.toString());
+            if (withMeterStats) {
+                device.meterStats = await this.getMeterStats(device.id.toString());
+            }
         }
 
         return devices;

--- a/packages/origin-backend/test/device.e2e-spec.ts
+++ b/packages/origin-backend/test/device.e2e-spec.ts
@@ -179,7 +179,7 @@ describe('Device e2e tests', () => {
         );
 
         await request(app.getHttpServer())
-            .get(`/device/${device.id}`)
+            .get(`/device/${device.id}?withMeterStats=true`)
             .set('Authorization', `Bearer ${accessToken}`)
             .expect((res) => {
                 const resultDevice = res.body as IDeviceWithRelationsIds;
@@ -240,7 +240,7 @@ describe('Device e2e tests', () => {
         await certificationRequestService.registerApproved(1);
 
         await request(app.getHttpServer())
-            .get(`/device/${device.id}`)
+            .get(`/device/${device.id}?withMeterStats=true`)
             .set('Authorization', `Bearer ${accessToken}`)
             .expect((res) => {
                 const resultDevice = res.body as IDeviceWithRelationsIds;

--- a/packages/origin-ui-core/src/components/AutoSupplyDeviceTable.tsx
+++ b/packages/origin-ui-core/src/components/AutoSupplyDeviceTable.tsx
@@ -60,7 +60,7 @@ export function AutoSupplyDeviceTable() {
                 parseInt(requestedFilters[1]?.selectedValue, 10) || 0
             );
         } else {
-            entities = await deviceClient.getMyDevice();
+            entities = await deviceClient.getMyDevices(true);
         }
         let newPaginatedData: IRecord[] = entities.map((i) => ({
             device: i

--- a/packages/origin-ui-core/src/components/AutoSupplyDeviceTable.tsx
+++ b/packages/origin-ui-core/src/components/AutoSupplyDeviceTable.tsx
@@ -60,7 +60,7 @@ export function AutoSupplyDeviceTable() {
                 parseInt(requestedFilters[1]?.selectedValue, 10) || 0
             );
         } else {
-            entities = await deviceClient.getMyDevices(true);
+            entities = await deviceClient.getMyDevices(false);
         }
         let newPaginatedData: IRecord[] = entities.map((i) => ({
             device: i

--- a/packages/origin-ui-core/src/features/general/sagas.ts
+++ b/packages/origin-ui-core/src/features/general/sagas.ts
@@ -357,7 +357,7 @@ function* fetchDataAfterConfigurationChange(
     const producingDevices: ProducingDevice.Entity[] = yield apply(
         ProducingDevice,
         ProducingDevice.getAllDevices,
-        [configuration]
+        [true, configuration]
     );
 
     for (const device of producingDevices) {

--- a/packages/origin-ui-core/src/features/general/sagas.ts
+++ b/packages/origin-ui-core/src/features/general/sagas.ts
@@ -357,7 +357,7 @@ function* fetchDataAfterConfigurationChange(
     const producingDevices: ProducingDevice.Entity[] = yield apply(
         ProducingDevice,
         ProducingDevice.getAllDevices,
-        [true, configuration]
+        [configuration, true]
     );
 
     for (const device of producingDevices) {


### PR DESCRIPTION
Every time we would fetch the device from `origin-backend`, the device would be appended with `device.meterStats` regardless on whether we need meterStats or not.

This causes performance issues when `meterStats` are fetched from external APIs.

This PR makes fetching `meterStats` on-demand instead of default.