### PR TITLE
chore: show correct energy values in certificate details and table

### DIFF
--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -93,16 +93,24 @@
         },
         "certificate": {
             "properties": {
+                "id": "Certificate ID",
+                "claimed": "Claimed",
+                "creationDate": "Creation Date",
+                "remainingEnergy": "Remaining (unclaimed) Energy",
                 "compliance": "Compliance",
                 "owner": "Owner",
                 "price": "Price",
                 "currency": "Currency",
-                "certifiedEnergy": "Certified energy",
-                "deviceType": "Device type",
-                "certificationDate": "Certification date",
+                "certifiedEnergy": "Certified Energy",
+                "deviceType": "Device Type",
+                "certificationDate": "Certification Date",
                 "from": "From",
                 "to": "To",
-                "source": "Source"
+                "source": "Source",
+                "generationDateStart": "Generation Start Date",
+                "generationDateEnd": "Generation End Date",
+                "claimedEnergy": "Claimed Energy",
+                "claimBeneficiary": "Claim beneficiary"
             },
             "actions": {
                 "requestCertificates": "Request certificates",
@@ -131,7 +139,8 @@
                 "certificatesClaimed": "Certificates have been claimed.",
                 "approved": "Certification request approved.",
                 "withdrawn": "Certificate withdrawn",
-                "certificateDeposited": "Certificate deposited"
+                "certificateDeposited": "Certificate deposited",
+                "certificateNotFound": "Certificate not found"
             },
             "info": {
                 "requestCertificatesFor": "Request certificates for {facilityName}"
@@ -196,6 +205,11 @@
             
         },
         "general": {
+            "responses": {
+                "yes": "Yes",
+                "no": "No",
+                "partially": "Partially"
+            },
             "actions": {
                 "update": "Update",
                 "continue": "Continue",

--- a/packages/origin-ui-core/src/components/CertificateDetailView.tsx
+++ b/packages/origin-ui-core/src/components/CertificateDetailView.tsx
@@ -204,15 +204,19 @@ export function CertificateDetailView(props: IProps) {
         data = [
             [
                 {
-                    label: 'Certificate id',
+                    label: t('certificate.properties.id'),
                     data: selectedCertificate.id.toString()
                 },
                 {
-                    label: 'Claimed',
-                    data: selectedCertificate.isClaimed ? 'yes' : 'no'
+                    label: t('certificate.properties.claimed'),
+                    data: selectedCertificate.isClaimed
+                        ? publicVolume.add(privateVolume).gt(0)
+                            ? t('general.responses.partially')
+                            : t('general.responses.yes')
+                        : t('general.responses.no')
                 },
                 {
-                    label: 'Creation date',
+                    label: t('certificate.properties.creationDate'),
                     data: formatDate(
                         selectedCertificate.creationTime * 1000,
                         false,
@@ -222,15 +226,15 @@ export function CertificateDetailView(props: IProps) {
             ],
             [
                 {
-                    label: `Certified energy (${EnergyFormatter.displayUnit})`,
-                    data: EnergyFormatter.format(
+                    label: `${
                         selectedCertificate.isClaimed
-                            ? claimedVolume
-                            : publicVolume.add(privateVolume)
-                    )
+                            ? t('certificate.properties.remainingEnergy')
+                            : t('certificate.properties.certifiedEnergy')
+                    } (${EnergyFormatter.displayUnit})`,
+                    data: EnergyFormatter.format(publicVolume.add(privateVolume))
                 },
                 {
-                    label: 'Generation start',
+                    label: t('certificate.properties.generationDateStart'),
                     data: formatDate(
                         selectedCertificate.generationStartTime * 1000,
                         true,
@@ -238,7 +242,7 @@ export function CertificateDetailView(props: IProps) {
                     )
                 },
                 {
-                    label: 'Generation end',
+                    label: t('certificate.properties.generationDateEnd'),
                     data: formatDate(
                         selectedCertificate.generationEndTime * 1000,
                         true,
@@ -253,16 +257,25 @@ export function CertificateDetailView(props: IProps) {
                 (claim) => getAddress(claim.to) === getAddress(user.blockchainAccountAddress)
             )?.claimData;
 
+            const claimInfo = [
+                {
+                    label: `${t('certificate.properties.claimedEnergy')} (${
+                        EnergyFormatter.displayUnit
+                    })`,
+                    data: EnergyFormatter.format(claimedVolume)
+                }
+            ];
+
             if (claimData) {
-                data.push([
-                    {
-                        label: 'Claim beneficiary',
-                        data: Object.values(claimData)
-                            .filter((value) => value !== '')
-                            .join(', ')
-                    }
-                ]);
+                claimInfo.push({
+                    label: t('certificate.properties.claimBeneficiary'),
+                    data: Object.values(claimData)
+                        .filter((value) => value !== '')
+                        .join(', ')
+                });
             }
+
+            data.push(claimInfo);
         }
     }
 
@@ -289,7 +302,7 @@ export function CertificateDetailView(props: IProps) {
                         </div>
                     ) : (
                         <div className="text-center">
-                            <strong>Certificate not found</strong>
+                            <strong>{t('certificate.feedback.certificateNotFound')}</strong>
                         </div>
                     )}
                 </div>

--- a/packages/origin-ui-core/src/components/CertificateTable.tsx
+++ b/packages/origin-ui-core/src/components/CertificateTable.tsx
@@ -116,10 +116,10 @@ export function CertificateTable(props: IProps) {
         });
 
         const filteredIEnrichedCertificateData = enrichedData.filter((enrichedCertificateData) => {
-            const ownerOf =
-                enrichedCertificateData.certificate.isOwned ||
-                enrichedCertificateData.certificate.source === CertificateSource.Exchange;
-            const claimed = enrichedCertificateData.certificate.isClaimed;
+            const { source, isOwned, isClaimed } = enrichedCertificateData.certificate;
+
+            const ownerOf = isOwned || source === CertificateSource.Exchange;
+            const claimed = isClaimed && source === CertificateSource.Blockchain;
 
             return (
                 checkRecordPassesFilters(

--- a/packages/origin-ui-core/src/components/Certificates.tsx
+++ b/packages/origin-ui-core/src/components/Certificates.tsx
@@ -22,7 +22,7 @@ function InboxCertificates() {
 }
 
 function ClaimedCertificates() {
-    return <CertificateTable selectedState={SelectedState.Claimed} />;
+    return <CertificateTable selectedState={SelectedState.Claimed} hiddenColumns={['source']} />;
 }
 
 const PendingCertificationRequestsTable = () => <CertificationRequestsTable approved={false} />;


### PR DESCRIPTION
Fixes an issue where a double certificate would be shown after double claiming a single certificate (fix: https://github.com/energywebfoundation/origin/pull/1176/files#diff-67b4d1d064d79cb5c66f123ea02f9eb4R122).

Also:
- Localize Certificate Details view
- Show both claimed and unclaimed energy in Certificate details view

![Screenshot 2020-06-15 at 17 54 34](https://user-images.githubusercontent.com/9353642/84679245-586cb900-af31-11ea-8c0c-209bb2fe50ec.png)
