### PR TITLE
Matching Engine price picking strategies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,8 @@ EXCHANGE_WALLET_PRIV=0xd9066ff9f753a1898709b568119055660a77d9aae4d7a4ad677b8fb3d
 EXCHANGE_MATCHING_INTERVAL=1000
 # Issuer ID type
 ISSUER_ID=Issuer ID
+# Price strategy; check @energyweb/exchange-core/PriceStrategy enum for values
+EXCHANGE_PRICE_STRATEGY=0
 
 # Possible options: GRID_OPERATOR and LOCATION, should be comma separated
 DEVICE_PROPERTIES_ENABLED=GRID_OPERATOR,LOCATION

--- a/packages/exchange-core/src/Ask.ts
+++ b/packages/exchange-core/src/Ask.ts
@@ -14,9 +14,10 @@ export class Ask extends Order {
         product: Product,
         validFrom: Date,
         userId: string,
-        public readonly assetId: string
+        public readonly assetId: string,
+        createdAt: Date
     ) {
-        super(id, OrderSide.Ask, validFrom, product, price, volume, userId);
+        super(id, OrderSide.Ask, validFrom, product, price, volume, userId, createdAt);
 
         if (product.deviceType?.length !== 1) {
             throw new Error('Unable to create ask order. DeviceType has to be specified');
@@ -81,7 +82,7 @@ export class Ask extends Order {
         );
     }
 
-    public clone() {
+    public clone(): Ask {
         return new Ask(
             this.id,
             this.price,
@@ -89,7 +90,8 @@ export class Ask extends Order {
             this.product,
             this.validFrom,
             this.userId,
-            this.assetId
+            this.assetId,
+            this.createdAt
         );
     }
 

--- a/packages/exchange-core/src/Bid.ts
+++ b/packages/exchange-core/src/Bid.ts
@@ -13,9 +13,10 @@ export class Bid extends Order {
         volume: BN,
         product: Product,
         validFrom: Date,
-        userId: string
+        userId: string,
+        createdAt: Date
     ) {
-        super(id, OrderSide.Bid, validFrom, product, price, volume, userId);
+        super(id, OrderSide.Bid, validFrom, product, price, volume, userId, createdAt);
     }
 
     public filterBy(
@@ -60,8 +61,16 @@ export class Bid extends Order {
         );
     }
 
-    public clone() {
-        return new Bid(this.id, this.price, this.volume, this.product, this.validFrom, this.userId);
+    public clone(): Bid {
+        return new Bid(
+            this.id,
+            this.price,
+            this.volume,
+            this.product,
+            this.validFrom,
+            this.userId,
+            this.createdAt
+        );
     }
 
     private hasMatchingDeviceType(product: Product, deviceService: IDeviceTypeService) {

--- a/packages/exchange-core/src/DirectBuy.ts
+++ b/packages/exchange-core/src/DirectBuy.ts
@@ -8,8 +8,20 @@ export class DirectBuy extends Bid {
         userId: string,
         price: number,
         volume: BN,
-        public readonly askId: string
+        public readonly askId: string,
+        createdAt: Date
     ) {
-        super(id, price, volume, null, new Date(), userId);
+        super(id, price, volume, null, new Date(), userId, createdAt);
+    }
+
+    public clone(): DirectBuy {
+        return new DirectBuy(
+            this.id,
+            this.userId,
+            this.price,
+            this.volume,
+            this.askId,
+            this.createdAt
+        );
     }
 }

--- a/packages/exchange-core/src/MatchingEngineFactory.ts
+++ b/packages/exchange-core/src/MatchingEngineFactory.ts
@@ -1,0 +1,40 @@
+import { IDeviceTypeService, ILocationService } from '@energyweb/utils-general';
+
+import { IPriceStrategy } from './strategy/IPriceStrategy';
+import { MatchingEngine } from '.';
+import { OrderCreationTimePickStrategy } from './strategy/OrderCreationTimePickStrategy';
+import { AskPriceStrategy } from './strategy/AskPriceStrategy';
+
+export enum PriceStrategy {
+    AskPrice,
+    BasedOnOrderCreationTime
+}
+
+export class MatchingEngineFactory {
+    public static build(
+        priceStrategy: PriceStrategy | IPriceStrategy,
+        deviceService: IDeviceTypeService,
+        locationService: ILocationService
+    ): MatchingEngine {
+        const strategy = this.isStrategy(priceStrategy)
+            ? (priceStrategy as IPriceStrategy)
+            : this.getStrategy(priceStrategy as PriceStrategy);
+
+        return new MatchingEngine(deviceService, locationService, strategy);
+    }
+
+    private static isStrategy(pricePickStrategy: PriceStrategy | IPriceStrategy) {
+        return (pricePickStrategy as IPriceStrategy).pickPrice !== undefined;
+    }
+
+    private static getStrategy(pricePickStrategy: PriceStrategy) {
+        switch (pricePickStrategy) {
+            case PriceStrategy.AskPrice:
+                return new AskPriceStrategy();
+            case PriceStrategy.BasedOnOrderCreationTime:
+                return new OrderCreationTimePickStrategy();
+            default:
+                return null;
+        }
+    }
+}

--- a/packages/exchange-core/src/Order.ts
+++ b/packages/exchange-core/src/Order.ts
@@ -47,7 +47,8 @@ export abstract class Order implements IOrder {
         public readonly product: Product,
         public readonly price: number,
         volume: BN,
-        public readonly userId: string
+        public readonly userId: string,
+        public readonly createdAt: Date
     ) {
         if (volume.isZero() || volume.isNeg()) {
             throw new Error('Incorrect negative volume');
@@ -56,7 +57,7 @@ export abstract class Order implements IOrder {
             throw new Error('Incorrect negative price');
         }
 
-        this._volume = volume;
+        this._volume = new BN(volume);
     }
 
     public updateWithTradedVolume(tradedVolume: BN) {

--- a/packages/exchange-core/src/Trade.ts
+++ b/packages/exchange-core/src/Trade.ts
@@ -6,11 +6,18 @@ export class Trade {
     constructor(
         public readonly bid: Bid | DirectBuy,
         public readonly ask: Ask,
-        public readonly volume: BN,
+        volume: BN,
         public readonly price: number
     ) {
+        if (volume.isZero() || volume.isNeg()) {
+            throw new Error('Negative or zero trade volume');
+        }
+
         this.created = new Date();
+        this.volume = new BN(volume);
     }
 
     public readonly created: Date;
+
+    public readonly volume: BN;
 }

--- a/packages/exchange-core/src/index.ts
+++ b/packages/exchange-core/src/index.ts
@@ -10,3 +10,4 @@ export { DirectBuy } from './DirectBuy';
 export { TimeRange } from './TimeRange';
 export { Trade } from './Trade';
 export { TradeExecutedEvent } from './TradeExecutedEvent';
+export * from './MatchingEngineFactory';

--- a/packages/exchange-core/src/strategy/AskPriceStrategy.ts
+++ b/packages/exchange-core/src/strategy/AskPriceStrategy.ts
@@ -1,0 +1,9 @@
+import { IPriceStrategy } from './IPriceStrategy';
+import { Ask, Bid } from '..';
+
+export class AskPriceStrategy implements IPriceStrategy {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    pickPrice(ask: Ask, bid: Bid): number {
+        return ask.price;
+    }
+}

--- a/packages/exchange-core/src/strategy/IPriceStrategy.ts
+++ b/packages/exchange-core/src/strategy/IPriceStrategy.ts
@@ -1,0 +1,5 @@
+import { Ask, Bid } from '..';
+
+export interface IPriceStrategy {
+    pickPrice(ask: Ask, bid: Bid): number;
+}

--- a/packages/exchange-core/src/strategy/OrderCreationTimePickStrategy.ts
+++ b/packages/exchange-core/src/strategy/OrderCreationTimePickStrategy.ts
@@ -1,0 +1,8 @@
+import { IPriceStrategy } from './IPriceStrategy';
+import { Ask, Bid } from '..';
+
+export class OrderCreationTimePickStrategy implements IPriceStrategy {
+    pickPrice(ask: Ask, bid: Bid): number {
+        return ask.createdAt > bid.createdAt ? bid.price : ask.price;
+    }
+}

--- a/packages/exchange-core/src/test/Matching.test.ts
+++ b/packages/exchange-core/src/test/Matching.test.ts
@@ -7,7 +7,7 @@ import moment from 'moment';
 import { Ask } from '../Ask';
 import { Bid } from '../Bid';
 import { DeviceVintage } from '../DeviceVintage';
-import { MatchingEngine, ActionResultEvent, ActionResult } from '../MatchingEngine';
+import { ActionResultEvent, ActionResult } from '../MatchingEngine';
 import { Operator } from '../Operator';
 import { Order } from '../Order';
 import { Product } from '../Product';
@@ -15,6 +15,7 @@ import { Trade } from '../Trade';
 import { DirectBuy } from '../DirectBuy';
 import { ProductFilter, Filter } from '../ProductFilter';
 import { TimeRange } from '../TimeRange';
+import { PriceStrategy, MatchingEngineFactory } from '../MatchingEngineFactory';
 
 interface IOrderCreationArgs {
     product?: Product;
@@ -22,6 +23,7 @@ interface IOrderCreationArgs {
     volume?: BN;
     userId?: string;
     validFrom?: Date;
+    createdAt?: Date;
 }
 
 interface ITestCase {
@@ -33,6 +35,8 @@ interface ITestCase {
     bidsAfter?: Bid[];
 
     expectedStatusChanges?: ActionResultEvent[];
+
+    priceStrategies?: PriceStrategy[];
 }
 
 describe('Matching tests', () => {
@@ -108,7 +112,8 @@ describe('Matching tests', () => {
             },
             args?.validFrom || new Date(),
             args?.userId || defaultSeller,
-            'assetId'
+            'assetId',
+            args?.createdAt || new Date()
         );
     };
 
@@ -122,7 +127,8 @@ describe('Matching tests', () => {
                 ...args?.product
             },
             args?.validFrom || new Date(),
-            args?.userId || defaultBuyer
+            args?.userId || defaultBuyer,
+            args?.createdAt || new Date()
         );
     };
 
@@ -132,7 +138,8 @@ describe('Matching tests', () => {
             args?.userId || defaultBuyer,
             args?.price || twoUSD,
             args?.volume || onekWh,
-            askId
+            askId,
+            args?.createdAt || new Date()
         );
     };
 
@@ -153,7 +160,7 @@ describe('Matching tests', () => {
 
         zipped.forEach(([a1, a2]) => {
             assert.equal(a1.id, a2.id, 'Wrong order id');
-            assert.isTrue(a1.volume.eq(a2.volume), 'Wrong volume');
+            assert.equal(a1.volume.toString(10), a2.volume.toString(10), 'Wrong volume');
             assert.equal(a1.price, a2.price, 'Wrong price');
         });
     };
@@ -172,7 +179,7 @@ describe('Matching tests', () => {
         zipped.forEach(([t1, t2]) => {
             assert.equal(t1.ask.id, t2.ask.id, 'Wrong askId');
             assert.equal(t1.bid.id, t2.bid.id, 'Wrong bidId');
-            assert.isTrue(t1.volume.eq(t2.volume), 'Wrong volume');
+            assert.equal(t1.volume.toString(10), t2.volume.toString(10), 'Wrong volume');
             assert.equal(t1.price, t2.price, 'Wrong price');
         });
     };
@@ -192,54 +199,60 @@ describe('Matching tests', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const executeTestCase = (testCase: ITestCase, done: any) => {
-        const matchingEngine = new MatchingEngine(deviceService, locationService);
+        const strategies = testCase?.priceStrategies ?? [
+            PriceStrategy.AskPrice,
+            PriceStrategy.BasedOnOrderCreationTime
+        ];
         let doneTimer: NodeJS.Timeout;
         const signalReady = () => {
-            if (doneTimer) {
-                clearInterval(doneTimer);
-                done();
-            } else {
-                doneTimer = global.setTimeout(() => done(), 50);
-            }
+            clearInterval(doneTimer);
+            doneTimer = global.setTimeout(() => done(), 50);
         };
+        const expectedTrades = List(testCase.expectedTrades);
 
-        testCase.orders.forEach((a) => {
-            if (typeof a === 'string') {
-                matchingEngine.cancelOrder(a);
-            } else if (a instanceof DirectBuy) {
-                matchingEngine.submitDirectBuy(a);
-            } else {
-                matchingEngine.submitOrder(a);
-            }
-        });
-
-        matchingEngine.trades.subscribe((res) => {
-            const expectedTrades = List(testCase.expectedTrades);
-            assertTrades(
-                expectedTrades,
-                res.map((r) => r.trade)
+        strategies.forEach((priceStrategy) => {
+            const matchingEngine = MatchingEngineFactory.build(
+                priceStrategy,
+                deviceService,
+                locationService
             );
 
-            const expectedBidsAfter = List(testCase.bidsAfter);
-            const expectedAsksAfter = List(testCase.asksAfter);
+            testCase.orders.forEach((a) => {
+                if (typeof a === 'string') {
+                    matchingEngine.cancelOrder(a);
+                } else if (a instanceof DirectBuy) {
+                    matchingEngine.submitDirectBuy(a);
+                } else {
+                    matchingEngine.submitOrder(a);
+                }
+            });
 
-            const { asks, bids } = matchingEngine.orderBook();
-            assertOrders(expectedBidsAfter, bids, 'bids');
-            assertOrders(expectedAsksAfter, asks, 'asks');
+            matchingEngine.trades.subscribe((res) => {
+                assertTrades(
+                    expectedTrades,
+                    res.map((r) => r.trade)
+                );
 
-            signalReady();
+                const expectedBidsAfter = List(testCase.bidsAfter);
+                const expectedAsksAfter = List(testCase.asksAfter);
+
+                const { asks, bids } = matchingEngine.orderBook();
+                assertOrders(expectedBidsAfter, bids, 'bids');
+                assertOrders(expectedAsksAfter, asks, 'asks');
+
+                signalReady();
+            });
+
+            matchingEngine.actionResults.subscribe((res) => {
+                const expectedStatusChanges = List(testCase.expectedStatusChanges);
+
+                assertStatusChanges(expectedStatusChanges, res);
+
+                signalReady();
+            });
+
+            matchingEngine.tick();
         });
-
-        matchingEngine.actionResults.subscribe((res) => {
-            const expectedStatusChanges = List(testCase.expectedStatusChanges);
-
-            assertStatusChanges(expectedStatusChanges, res);
-
-            signalReady();
-        });
-
-        matchingEngine.tick();
-
         if (testCase.expectedTrades.length === 0 && !testCase.expectedStatusChanges) {
             setTimeout(() => done(), 50);
         }
@@ -250,19 +263,30 @@ describe('Matching tests', () => {
         bids: Bid[],
         productFilter: ProductFilter,
         expectedAsks: Ask[],
-        expectedBids: Bid[]
+        expectedBids: Bid[],
+        priceStrategies?: PriceStrategy[]
     ) => {
-        const matchingEngine = new MatchingEngine(deviceService, locationService);
+        const strategies = priceStrategies ?? [
+            PriceStrategy.AskPrice,
+            PriceStrategy.BasedOnOrderCreationTime
+        ];
+        strategies.forEach((priceStrategy) => {
+            const matchingEngine = MatchingEngineFactory.build(
+                priceStrategy,
+                deviceService,
+                locationService
+            );
 
-        asks.forEach((b) => matchingEngine.submitOrder(b));
-        bids.forEach((a) => matchingEngine.submitOrder(a));
+            asks.forEach((b) => matchingEngine.submitOrder(b));
+            bids.forEach((a) => matchingEngine.submitOrder(a));
 
-        matchingEngine.tick();
+            matchingEngine.tick();
 
-        const orderBook = matchingEngine.orderBookByProduct(productFilter);
+            const orderBook = matchingEngine.orderBookByProduct(productFilter);
 
-        assertOrders(List<Ask>(expectedAsks), orderBook.asks, 'asks');
-        assertOrders(List<Bid>(expectedBids), orderBook.bids, 'bids');
+            assertOrders(List<Ask>(expectedAsks), orderBook.asks, 'asks');
+            assertOrders(List<Bid>(expectedBids), orderBook.bids, 'bids');
+        });
     };
 
     describe('when asks and bid have to same product', () => {
@@ -301,17 +325,6 @@ describe('Matching tests', () => {
                 },
                 done
             );
-        });
-
-        it('should trade at ask price when bid price is higher than ask', (done) => {
-            const asksBefore = [createAsk()];
-            const bidsBefore = [createBid({ price: twoUSD + 1 })];
-
-            const expectedTrades = [
-                new Trade(bidsBefore[0], asksBefore[0], asksBefore[0].volume, asksBefore[0].price)
-            ];
-
-            executeTestCase({ orders: [...asksBefore, ...bidsBefore], expectedTrades }, done);
         });
 
         it('should return 2 trades and fill all orders when having submitted 2 asks and 1 bid', (done) => {
@@ -395,7 +408,12 @@ describe('Matching tests', () => {
             const bidsAfter: Bid[] = [];
 
             executeTestCase(
-                { orders: [...asksBefore, ...bidsBefore], expectedTrades, asksAfter, bidsAfter },
+                {
+                    orders: [...asksBefore, ...bidsBefore],
+                    expectedTrades,
+                    asksAfter,
+                    bidsAfter
+                },
                 done
             );
         });
@@ -414,9 +432,122 @@ describe('Matching tests', () => {
             const bidsAfter: Bid[] = [bidsBefore[0].clone().updateWithTradedVolume(threeKWh)];
 
             executeTestCase(
-                { orders: [...asksBefore, ...bidsBefore], expectedTrades, asksAfter, bidsAfter },
+                {
+                    orders: [...asksBefore, ...bidsBefore],
+                    expectedTrades,
+                    asksAfter,
+                    bidsAfter
+                },
                 done
             );
+        });
+
+        describe('when price strategy is AskPriceStrategy', () => {
+            it('should trade at ask price when bid has higher price add was added after ask', (done) => {
+                const askCreatedAt = new Date();
+                const bidCreatedAt = moment().add(1, 'minute').toDate();
+
+                const asksBefore = [createAsk({ createdAt: askCreatedAt })];
+                const bidsBefore = [createBid({ price: twoUSD + 1, createdAt: bidCreatedAt })];
+
+                const expectedTrades = [
+                    new Trade(
+                        bidsBefore[0],
+                        asksBefore[0],
+                        asksBefore[0].volume,
+                        asksBefore[0].price
+                    )
+                ];
+
+                executeTestCase(
+                    {
+                        orders: [...asksBefore, ...bidsBefore],
+                        expectedTrades,
+                        priceStrategies: [PriceStrategy.AskPrice]
+                    },
+                    done
+                );
+            });
+
+            it('should trade at ask price when bid has higher price add was added before ask', (done) => {
+                const bidCreatedAt = new Date();
+                const askCreatedAt = moment().add(1, 'minute').toDate();
+
+                const asksBefore = [createAsk({ createdAt: askCreatedAt })];
+                const bidsBefore = [createBid({ price: twoUSD + 1, createdAt: bidCreatedAt })];
+
+                const expectedTrades = [
+                    new Trade(
+                        bidsBefore[0],
+                        asksBefore[0],
+                        asksBefore[0].volume,
+                        asksBefore[0].price
+                    )
+                ];
+
+                executeTestCase(
+                    {
+                        orders: [...asksBefore, ...bidsBefore],
+                        expectedTrades,
+                        priceStrategies: [PriceStrategy.AskPrice]
+                    },
+                    done
+                );
+            });
+        });
+
+        describe('when price strategy is OrderCreationTimePickStrategy', () => {
+            it('should trade at ask price when bid has higher price add was added after ask', (done) => {
+                const askCreatedAt = new Date();
+                const bidCreatedAt = moment().add(1, 'minute').toDate();
+
+                const asksBefore = [createAsk({ createdAt: askCreatedAt })];
+                const bidsBefore = [createBid({ price: twoUSD + 1, createdAt: bidCreatedAt })];
+
+                const expectedTrades = [
+                    new Trade(
+                        bidsBefore[0],
+                        asksBefore[0],
+                        asksBefore[0].volume,
+                        asksBefore[0].price
+                    )
+                ];
+
+                executeTestCase(
+                    {
+                        orders: [...asksBefore, ...bidsBefore],
+                        expectedTrades,
+                        priceStrategies: [PriceStrategy.BasedOnOrderCreationTime]
+                    },
+                    done
+                );
+            });
+
+            it('should trade at bid price when ask has higher price add was added after bid', (done) => {
+                const bidCreatedAt = new Date();
+                const askCreatedAt = moment().add(1, 'minute').toDate();
+
+                const asksBefore = [createAsk({ createdAt: askCreatedAt })];
+                const bidsBefore = [createBid({ price: twoUSD + 1, createdAt: bidCreatedAt })];
+
+                const expectedTrades = [
+                    new Trade(
+                        bidsBefore[0],
+                        asksBefore[0],
+                        asksBefore[0].volume,
+                        bidsBefore[0].price
+                    )
+                ];
+
+                executeTestCase(
+                    {
+                        orders: [...asksBefore, ...bidsBefore],
+                        expectedTrades,
+                        priceStrategies: [PriceStrategy.BasedOnOrderCreationTime]
+                    },
+                    done
+                );
+            });
         });
     });
 
@@ -1234,7 +1365,7 @@ describe('Matching tests', () => {
 
             const expectedTrades = [new Trade(directBuy, ask2, onekWh, ask2.price)];
 
-            const asksAfter = [ask1, ask2];
+            const asksAfter = [ask1, ask2.clone().updateWithTradedVolume(onekWh)];
 
             executeTestCase(
                 {

--- a/packages/exchange/src/pods/matching-engine/order-mapper.ts
+++ b/packages/exchange/src/pods/matching-engine/order-mapper.ts
@@ -12,7 +12,8 @@ export const toMatchingEngineOrder = (order: Order) => {
               ProductDTO.toProduct(order.product),
               order.validFrom,
               order.userId,
-              order.assetId
+              order.assetId,
+              order.createdAt
           )
         : new Bid(
               order.id,
@@ -20,6 +21,7 @@ export const toMatchingEngineOrder = (order: Order) => {
               order.currentVolume,
               ProductDTO.toProduct(order.product),
               order.validFrom,
-              order.userId
+              order.userId,
+              order.createdAt
           );
 };

--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -14,6 +14,7 @@ import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { useContainer } from 'class-validator';
 import { ethers } from 'ethers';
+import { PriceStrategy } from '@energyweb/exchange-core';
 
 import { entities } from '../src';
 import { AppModule } from '../src/app.module';
@@ -98,7 +99,8 @@ export const bootstrapTestInstance = async (deviceServiceMock?: DeviceService) =
         EXCHANGE_WALLET_PUB: '0xd46aC0Bc23dB5e8AfDAAB9Ad35E9A3bA05E092E8',
         EXCHANGE_WALLET_PRIV: '0xd9bc30dc17023fbb68fe3002e0ff9107b241544fd6d60863081c55e383f1b5a3',
         ISSUER_ID: 'Issuer ID',
-        ENERGY_PER_UNIT: 1000000
+        ENERGY_PER_UNIT: 1000000,
+        EXCHANGE_PRICE_STRATEGY: PriceStrategy.AskPrice
     });
 
     const moduleFixture = await Test.createTestingModule({


### PR DESCRIPTION
This PR provides:
- abstraction over price picking strategy in the matching engine
- new price picking strategy `OrderCreationTimePickStrategy` which takes the price of the counter order
- configuration item `EXCHANGE_PRICE_STRATEGY` that allow us to chose which price picking strategy should be used 

### OrderCreationTimePickStrategy  examples
1) Given **bids**

| Time   |      Price      |
|----------|------:|
| 1 | $1600 |
| 2 |  $12 |
| 3 | $1 |

arriving **ask** with price $2000 at time later than 3 results in **trade** based on the **bid** price of $1600

2) Given **asks**

| Time   |      Price      |
|----------|------:|
| 1 | $1 |
| 2 |  $12 |
| 3 | $1600 |

arriving **bid** with price $2000 at time later than 3 results in **trade** based on the **ask** price of $1
