### PR TITLE
fix(exchange): bundles accounting

### DIFF
--- a/packages/exchange/src/pods/account-balance/account-balance.service.spec.ts
+++ b/packages/exchange/src/pods/account-balance/account-balance.service.spec.ts
@@ -213,14 +213,30 @@ describe('AccountBalanceService', () => {
         registerBundles(
             {
                 items: [
-                    { asset: asset1, currentVolume: new BN('1000') } as BundleItem,
-                    { asset: asset2, currentVolume: new BN('500') } as BundleItem
+                    {
+                        asset: asset1,
+                        currentVolume: new BN('1000'),
+                        startVolume: new BN('1000')
+                    } as BundleItem,
+                    {
+                        asset: asset2,
+                        currentVolume: new BN('500'),
+                        startVolume: new BN('500')
+                    } as BundleItem
                 ]
             },
             {
                 items: [
-                    { asset: asset1, currentVolume: new BN('250') } as BundleItem,
-                    { asset: asset2, currentVolume: new BN('500') } as BundleItem
+                    {
+                        asset: asset1,
+                        currentVolume: new BN('250'),
+                        startVolume: new BN('250')
+                    } as BundleItem,
+                    {
+                        asset: asset2,
+                        currentVolume: new BN('500'),
+                        startVolume: new BN('500')
+                    } as BundleItem
                 ]
             }
         );

--- a/packages/exchange/src/pods/bundle/bundle.entity.ts
+++ b/packages/exchange/src/pods/bundle/bundle.entity.ts
@@ -53,4 +53,17 @@ export class Bundle extends ExtendedBaseEntity {
 
         return this.items.every((item) => item.currentVolume.mul(precision).mod(ratio).isZero());
     }
+
+    getUpdatedVolumes(volume: BN) {
+        const currentVolume = this.volume;
+
+        return this.items.map((item) => {
+            const traded = item.startVolume.div(currentVolume.div(volume));
+
+            return {
+                id: item.id,
+                currentVolume: item.currentVolume.sub(traded)
+            };
+        });
+    }
 }


### PR DESCRIPTION
This PR fixes wrong accounting for bundles:

- available was not updated correctly after posting bundle for sale
- locked was not updated correctly for seller after partial buy 