### PR TITLE
bug/Empty Bundle details

### DIFF
--- a/packages/origin-ui-core/src/components/bundles/BundleCard.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundleCard.tsx
@@ -24,7 +24,7 @@ import {
     getCurrencies
 } from '../..';
 import { useSelector, useDispatch } from 'react-redux';
-import { EnergyTypes, formatCurrencyComplete } from '../../utils';
+import { EnergyTypes, formatCurrencyComplete, bundlePrice } from '../../utils';
 import { buyBundle } from '../../features/bundles';
 
 interface IOwnProps {
@@ -126,11 +126,7 @@ export const BundleCard = (props: IOwnProps) => {
                         Total price
                     </Typography>
                     <Typography color="textPrimary" variant="caption">
-                        {formatCurrencyComplete(
-                            (Number(EnergyFormatter.format(bundle.volume, false)) * bundle.price) /
-                                100,
-                            currency
-                        )}
+                        {formatCurrencyComplete(bundlePrice(bundle), currency)}
                     </Typography>
                     {isSelected && (
                         <Button color="primary" variant="contained" onClick={onBuyBundle}>

--- a/packages/origin-ui-core/src/components/bundles/SelectedForSale.tsx
+++ b/packages/origin-ui-core/src/components/bundles/SelectedForSale.tsx
@@ -30,7 +30,7 @@ import { BigNumber } from 'ethers/utils';
 import { formatCurrencyComplete, useTranslation, EnergyFormatter, EnergyTypes } from '../../utils';
 import { createBundle } from '../../features/bundles';
 import { BundleItemDTO } from '../../utils/exchange';
-import { Unit } from '../../../../utils-general/src';
+import { Unit } from '../../../../utils-general';
 
 interface IOwnProps {
     selected: ICertificateViewItem[];

--- a/packages/origin-ui-core/src/components/bundles/SelectedForSale.tsx
+++ b/packages/origin-ui-core/src/components/bundles/SelectedForSale.tsx
@@ -30,7 +30,7 @@ import { BigNumber } from 'ethers/utils';
 import { formatCurrencyComplete, useTranslation, EnergyFormatter, EnergyTypes } from '../../utils';
 import { createBundle } from '../../features/bundles';
 import { BundleItemDTO } from '../../utils/exchange';
-import { Unit } from '../../../../utils-general';
+import { Unit } from '@energyweb/utils-general';
 
 interface IOwnProps {
     selected: ICertificateViewItem[];

--- a/packages/origin-ui-core/src/components/bundles/SelectedForSale.tsx
+++ b/packages/origin-ui-core/src/components/bundles/SelectedForSale.tsx
@@ -30,6 +30,7 @@ import { BigNumber } from 'ethers/utils';
 import { formatCurrencyComplete, useTranslation, EnergyFormatter, EnergyTypes } from '../../utils';
 import { createBundle } from '../../features/bundles';
 import { BundleItemDTO } from '../../utils/exchange';
+import { Unit } from '../../../../utils-general/src';
 
 interface IOwnProps {
     selected: ICertificateViewItem[];
@@ -145,7 +146,7 @@ export const SelectedForSale = (props: IOwnProps) => {
                     <Grid item>Total Price</Grid>
                     <Grid item>
                         {formatCurrencyComplete(
-                            Number(EnergyFormatter.format(totalVolume, false)) * price,
+                            (totalVolume.toNumber() / Unit[EnergyFormatter.displayUnit]) * price,
                             currency
                         )}
                     </Grid>

--- a/packages/origin-ui-core/src/utils/bundles.ts
+++ b/packages/origin-ui-core/src/utils/bundles.ts
@@ -3,7 +3,7 @@ import { Bundle } from './exchange';
 import { deviceById, EnergyFormatter } from '.';
 import { BigNumber } from 'ethers/utils';
 import { EnergyTypes } from './device';
-import { Unit } from '../../../utils-general/src';
+import { Unit } from '@energyweb/utils-general';
 
 export const energyByType = (
     bundle: Bundle,

--- a/packages/origin-ui-core/src/utils/bundles.ts
+++ b/packages/origin-ui-core/src/utils/bundles.ts
@@ -3,6 +3,7 @@ import { Bundle } from './exchange';
 import { deviceById, EnergyFormatter } from '.';
 import { BigNumber } from 'ethers/utils';
 import { EnergyTypes } from './device';
+import { Unit } from '../../../utils-general/src';
 
 export const energyByType = (
     bundle: Bundle,
@@ -45,5 +46,10 @@ export const energyShares = (
     );
 };
 
-export const bundlePrice = (bundle: Bundle) =>
-    (bundle.price * Number(EnergyFormatter.format(bundle.volume, false))) / 100;
+/**
+ * Unformatted price
+ *
+ * @param
+ */
+export const bundlePrice = ({ volume, price }: Bundle) =>
+    (price * volume.toNumber()) / (Unit[EnergyFormatter.displayUnit] * 100);


### PR DESCRIPTION
Empty bundle details when bundle volume at least 1000 MWh

When user clicks on bundle to see its details no Bundle Card is rendered and the price range selector consists only from the NaN value. 
The bug was caused by using formatted price (with comma separated decimal groups) to calculate total bundle price