### PR TITLE
feat(exchange): Bundles possible splits API

### DIFF
--- a/packages/exchange/src/pods/bundle/bundle-split.dto.ts
+++ b/packages/exchange/src/pods/bundle/bundle-split.dto.ts
@@ -1,0 +1,35 @@
+/* eslint-disable max-classes-per-file */
+import BN from 'bn.js';
+import { Transform } from 'class-transformer';
+
+export class BundleSplitItemDTO {
+    constructor(item: Partial<BundleSplitItemDTO>) {
+        Object.assign(this, item);
+    }
+
+    id: string;
+
+    @Transform((v: BN) => v.toString(10))
+    volume: BN;
+}
+
+export class BundleSplitVolumeDTO {
+    constructor(bundleSplitVolume: Partial<BundleSplitVolumeDTO>) {
+        Object.assign(this, bundleSplitVolume);
+    }
+
+    @Transform((v: BN) => v.toString(10))
+    volume: BN;
+
+    items: BundleSplitItemDTO[];
+}
+
+export class BundleSplitDTO {
+    constructor(bundleSplits: Partial<BundleSplitDTO>) {
+        Object.assign(this, bundleSplits);
+    }
+
+    readonly id: string;
+
+    readonly splits: BundleSplitVolumeDTO[];
+}

--- a/packages/exchange/src/pods/bundle/bundle.controller.ts
+++ b/packages/exchange/src/pods/bundle/bundle.controller.ts
@@ -21,6 +21,7 @@ import { CreateBundleDTO } from './create-bundle.dto';
 import { BuyBundleDTO } from './buy-bundle.dto';
 import { BundleTrade } from './bundle-trade.entity';
 import { BundlePublicDTO } from './bundle-public.dto';
+import { BundleSplitDTO } from './bundle-split.dto';
 
 @UseInterceptors(ClassSerializerInterceptor)
 @Controller('bundle')
@@ -118,6 +119,20 @@ export class BundleController {
         try {
             const bundle = await this.bundleService.cancel(user.ownerId.toString(), bundleId);
             return bundle;
+        } catch (error) {
+            this.logger.error(error.message);
+
+            throw error;
+        }
+    }
+
+    @Get('/:id/splits')
+    public async availableBundleSplits(
+        @Param('id', new ParseUUIDPipe({ version: '4' })) bundleId: string
+    ): Promise<BundleSplitDTO> {
+        try {
+            const splits = await this.bundleService.possibleBundleSplits(bundleId);
+            return splits;
         } catch (error) {
             this.logger.error(error.message);
 

--- a/packages/exchange/src/pods/bundle/bundle.entity.spec.ts
+++ b/packages/exchange/src/pods/bundle/bundle.entity.spec.ts
@@ -23,23 +23,10 @@ describe('Bundle canSplit', () => {
         });
 
         expect(bundle.canSplit(new BN(100 * MWh), new BN(MWh))).toBeTruthy();
-    });
-
-    it('should allow split with partial volume', () => {
-        const bundle = new Bundle({
-            items: [
-                {
-                    startVolume: new BN(50 * MWh),
-                    currentVolume: new BN(50 * MWh)
-                } as BundleItem,
-                {
-                    startVolume: new BN(50 * MWh),
-                    currentVolume: new BN(50 * MWh)
-                } as BundleItem
-            ]
-        });
-
+        expect(bundle.canSplit(new BN(60 * MWh), new BN(MWh))).toBeTruthy();
         expect(bundle.canSplit(new BN(50 * MWh), new BN(MWh))).toBeTruthy();
+        expect(bundle.canSplit(new BN(5 * MWh), new BN(MWh))).toBeFalsy();
+        expect(bundle.canSplit(new BN(8 * MWh), new BN(MWh))).toBeTruthy();
     });
 
     it('should not allow split when split results in decimal volumes', () => {
@@ -74,5 +61,29 @@ describe('Bundle canSplit', () => {
         });
 
         expect(bundle.canSplit(new BN(1 * MWh), new BN(MWh))).toBeFalsy();
+    });
+
+    it('should return possible splits for the bundle', () => {
+        const bundle = new Bundle({
+            items: [
+                {
+                    startVolume: new BN(10 * MWh),
+                    currentVolume: new BN(10 * MWh)
+                } as BundleItem,
+                {
+                    startVolume: new BN(10 * MWh),
+                    currentVolume: new BN(10 * MWh)
+                } as BundleItem
+            ]
+        });
+
+        const splits = bundle.possibleSplits(new BN(MWh));
+
+        const expectedSplits = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20].map((i) => new BN(i * MWh));
+
+        const areMatching = splits.every((split, i) => split.volume.eq(expectedSplits[i]));
+
+        expect(splits).toHaveLength(expectedSplits.length);
+        expect(areMatching).toBeTruthy();
     });
 });

--- a/packages/exchange/src/pods/bundle/bundle.entity.ts
+++ b/packages/exchange/src/pods/bundle/bundle.entity.ts
@@ -4,6 +4,7 @@ import { Expose, Transform } from 'class-transformer';
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
 import { BundleItem } from './bundle-item.entity';
+import { BundleSplitItemDTO, BundleSplitVolumeDTO } from './bundle-split.dto';
 
 @Entity()
 export class Bundle extends ExtendedBaseEntity {
@@ -39,18 +40,19 @@ export class Bundle extends ExtendedBaseEntity {
         return this.items.reduce((sum: BN, item) => sum.add(item.startVolume), new BN(0));
     }
 
-    canSplit(volume: BN, energyPerUnit: BN) {
-        if (
-            !volume.mod(energyPerUnit).isZero() ||
-            volume.lt(energyPerUnit.mul(new BN(this.items.length)))
-        ) {
-            return false;
-        }
+    canSplit(volume: BN, energyPerUnit: BN): boolean {
+        return this.split(volume, energyPerUnit).items.length > 0;
+    }
 
-        const precision = new BN(1000);
-        const ratio = this.volume.mul(precision).div(volume);
+    possibleSplits(energyPerUnit: BN): BundleSplitVolumeDTO[] {
+        const volume = this.available.div(energyPerUnit).toNumber();
 
-        return this.items.every((item) => item.currentVolume.mul(precision).mod(ratio).isZero());
+        const splits = [...Array(volume).keys()]
+            .map((_, i) => new BN(i + 1).mul(energyPerUnit))
+            .map((vol) => this.split(vol, energyPerUnit))
+            .filter((split) => split.items.length);
+
+        return splits;
     }
 
     getUpdatedVolumes(volume: BN) {
@@ -64,5 +66,32 @@ export class Bundle extends ExtendedBaseEntity {
                 currentVolume: item.currentVolume.sub(traded)
             };
         });
+    }
+
+    private split(volumeToBuy: BN, energyPerUnit: BN): BundleSplitVolumeDTO {
+        if (
+            !volumeToBuy.mod(energyPerUnit).isZero() ||
+            volumeToBuy.lt(energyPerUnit.mul(new BN(this.items.length)))
+        ) {
+            return new BundleSplitVolumeDTO({ volume: volumeToBuy, items: [] });
+        }
+
+        const precision = new BN(100);
+        const ratio = volumeToBuy.mul(precision).div(this.volume);
+        const coefficient = precision.mul(energyPerUnit);
+
+        const splits = this.items.map(({ id, currentVolume }) => ({
+            id,
+            canSplit: ratio.mul(currentVolume).mod(coefficient).isZero(),
+            volume: ratio.mul(currentVolume).div(precision)
+        }));
+
+        if (!splits.every((split) => split.canSplit)) {
+            return new BundleSplitVolumeDTO({ volume: volumeToBuy, items: [] });
+        }
+
+        const items = splits.map(({ id, volume }) => new BundleSplitItemDTO({ id, volume }));
+
+        return new BundleSplitVolumeDTO({ volume: volumeToBuy, items });
     }
 }

--- a/packages/exchange/src/pods/bundle/bundle.service.ts
+++ b/packages/exchange/src/pods/bundle/bundle.service.ts
@@ -18,6 +18,7 @@ import { BundleTrade } from './bundle-trade.entity';
 import { Bundle } from './bundle.entity';
 import { BuyBundleDTO } from './buy-bundle.dto';
 import { CreateBundleDTO } from './create-bundle.dto';
+import { BundleSplitDTO } from './bundle-split.dto';
 
 @Injectable()
 export class BundleService {
@@ -129,6 +130,15 @@ export class BundleService {
         await this.bundleRepository.update({ userId, id: bundleId }, { isCancelled: true });
 
         return this.get(bundleId);
+    }
+
+    public async possibleBundleSplits(bundleId: string) {
+        const bundle = await this.get(bundleId);
+
+        return new BundleSplitDTO({
+            id: bundle.id,
+            splits: bundle.possibleSplits(this.energyPerUnit)
+        });
     }
 
     private async hasEnoughAssets(userId: string, createBundle: CreateBundleDTO) {


### PR DESCRIPTION
This PR provides:

- `GET /bundle/:id/splits` to get possible volume combinations for given bundle
- fix for cases where `canSplit` return wrong split results due to int division rounding errors