### PR TITLE
chore: Optimize CertificationRequest syncing

### DIFF
--- a/packages/issuer/src/blockchain-facade/CertificationRequest.ts
+++ b/packages/issuer/src/blockchain-facade/CertificationRequest.ts
@@ -117,11 +117,7 @@ export class CertificationRequest extends PreciseProofEntity implements ICertifi
     ): Promise<CertificationRequest[]> {
         const all = await configuration.offChainDataSource.certificateClient.getAllCertificationRequests();
 
-        const certificationRequestPromises = all.map(
-            (certReq) => new CertificationRequest(certReq, configuration)
-        );
-
-        return Promise.all(certificationRequestPromises);
+        return all.map((certReq) => new CertificationRequest(certReq, configuration));
     }
 
     public static async fetch(

--- a/packages/issuer/src/blockchain-facade/CertificationRequest.ts
+++ b/packages/issuer/src/blockchain-facade/CertificationRequest.ts
@@ -39,14 +39,14 @@ export class CertificationRequest extends PreciseProofEntity implements ICertifi
 
     energy: BigNumber;
 
-    initialized = false;
-
     constructor(
-        id: number,
+        certData: ICertificationRequest,
         configuration: Configuration.Entity,
         public isPrivate: boolean = false
     ) {
-        super(id, configuration);
+        super(certData.id, configuration);
+
+        Object.assign(this, certData);
     }
 
     public static async create(
@@ -57,7 +57,8 @@ export class CertificationRequest extends PreciseProofEntity implements ICertifi
         configuration: Configuration.Entity,
         files: string[],
         isVolumePrivate = false,
-        forAddress?: string
+        forAddress?: string,
+        callback?: (id: CertificationRequest['id']) => void
     ): Promise<CertificationRequest> {
         if (energy.gt(MAX_ENERGY_PER_CERTIFICATE)) {
             throw new Error(
@@ -66,8 +67,6 @@ export class CertificationRequest extends PreciseProofEntity implements ICertifi
         }
 
         const { certificateClient } = configuration.offChainDataSource;
-
-        const request = new CertificationRequest(null, configuration, isVolumePrivate);
 
         const { issuer } = configuration.blockchainProperties as Configuration.BlockchainProperties<
             Registry,
@@ -100,33 +99,50 @@ export class CertificationRequest extends PreciseProofEntity implements ICertifi
         } = await tx.wait();
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        request.id = (certificationRequested.args as any)._id.toNumber();
+        const id = (certificationRequested.args as any)._id.toNumber();
 
         if (configuration.logger) {
-            configuration.logger.info(`CertificationRequest ${request.id} created`);
+            configuration.logger.info(`CertificationRequest ${id} created.`);
         }
 
-        return request.sync();
+        if (callback) {
+            callback(id);
+        }
+
+        return CertificationRequest.fetch(id, configuration);
     }
 
-    async sync(): Promise<CertificationRequest> {
-        const offChainData = await polly()
+    public static async getAll(
+        configuration: Configuration.Entity
+    ): Promise<CertificationRequest[]> {
+        const all = await configuration.offChainDataSource.certificateClient.getAllCertificationRequests();
+
+        const certificationRequestPromises = all.map(
+            (certReq) => new CertificationRequest(certReq, configuration)
+        );
+
+        return Promise.all(certificationRequestPromises);
+    }
+
+    public static async fetch(
+        id: ICertificationRequest['id'],
+        configuration: Configuration.Entity
+    ): Promise<CertificationRequest> {
+        const certData = await polly()
             .waitAndRetry([2000, 4000, 8000, 16000])
             .executeForPromise(() =>
-                this.configuration.offChainDataSource.certificateClient.getCertificationRequest(
-                    this.id
-                )
+                configuration.offChainDataSource.certificateClient.getCertificationRequest(id)
             );
 
-        Object.assign(this, offChainData);
-
-        this.initialized = true;
-
-        if (this.configuration.logger) {
-            this.configuration.logger.verbose(`CertificationRequest ${this.id} synced`);
+        if (configuration.logger) {
+            configuration.logger.verbose(`CertificationRequest ${id} fetched.`);
         }
 
-        return this;
+        return new CertificationRequest(certData, configuration);
+    }
+
+    public async sync(): Promise<CertificationRequest> {
+        return CertificationRequest.fetch(this.id, this.configuration);
     }
 
     async approve(): Promise<number> {
@@ -193,17 +209,5 @@ export class CertificationRequest extends PreciseProofEntity implements ICertifi
         await tx.wait();
 
         return tx;
-    }
-
-    public static async getAll(
-        configuration: Configuration.Entity
-    ): Promise<CertificationRequest[]> {
-        const all = await configuration.offChainDataSource.certificateClient.getAllCertificationRequests();
-
-        const certificationRequestPromises = all.map((certReq) =>
-            new CertificationRequest(certReq.id, configuration).sync()
-        );
-
-        return Promise.all(certificationRequestPromises);
     }
 }

--- a/packages/issuer/src/test/Issuer.test.ts
+++ b/packages/issuer/src/test/Issuer.test.ts
@@ -58,24 +58,22 @@ describe('Issuer', () => {
             conf,
             [],
             isPrivate,
-            forAddress
+            forAddress,
+            (id: CertificationRequest['id']) =>
+                (conf.offChainDataSource.certificateClient as any).mockBlockchainData(id, {
+                    sender: forAddress || deviceOwnerWallet.address,
+                    owner: deviceOwnerWallet.address,
+                    fromTime: generationFromTime,
+                    toTime: generationToTime,
+                    created: moment().unix(),
+                    approved: false,
+                    revoked: false,
+                    deviceId: device,
+                    isPrivate
+                })
         );
 
-        (conf.offChainDataSource.certificateClient as any).mockBlockchainData(
-            certificationRequest.id,
-            {
-                sender: forAddress || deviceOwnerWallet.address,
-                owner: deviceOwnerWallet.address,
-                fromTime: generationFromTime,
-                toTime: generationToTime,
-                created: moment().unix(),
-                approved: false,
-                revoked: false,
-                deviceId: device
-            }
-        );
-
-        return certificationRequest.sync();
+        return certificationRequest;
     };
 
     it('migrates Issuer and Registry', async () => {
@@ -118,7 +116,7 @@ describe('Issuer', () => {
         const toTime = timestamp;
         const device = '1';
 
-        let certificationRequest = await createCertificationRequest(
+        const certificationRequest = await createCertificationRequest(
             energy,
             false,
             fromTime,
@@ -128,23 +126,7 @@ describe('Issuer', () => {
 
         assert.isAbove(certificationRequest.id, -1);
 
-        (conf.offChainDataSource.certificateClient as any).mockBlockchainData(
-            certificationRequest.id,
-            {
-                owner: deviceOwnerWallet.address,
-                fromTime,
-                toTime,
-                created: 123,
-                approved: false,
-                revoked: false,
-                deviceId: device
-            }
-        );
-
-        certificationRequest = await certificationRequest.sync();
-
         assert.deepOwnInclude(certificationRequest, {
-            initialized: true,
             deviceId: device,
             owner: deviceOwnerWallet.address,
             fromTime,
@@ -311,7 +293,6 @@ describe('Issuer', () => {
         assert.isAbove(Number(certificationRequest.id), -1);
 
         assert.deepOwnInclude(certificationRequest, {
-            initialized: true,
             deviceId: '1',
             owner: deviceOwnerWallet.address,
             approved: false,

--- a/packages/origin-backend-client-mocks/src/CertificateClientMock.ts
+++ b/packages/origin-backend-client-mocks/src/CertificateClientMock.ts
@@ -16,16 +16,19 @@ import { ICertificateClient } from '@energyweb/origin-backend-client';
 
 export class CertificateClientMock implements ICertificateClient {
     private requestQueue: CertificationRequestUpdateData[] = [];
+
     private requestStorage = new Map<number, ICertificationRequest>();
+
     private certificateStorage = new Map<number, ICertificateOwnership>();
 
     public async queueCertificationRequestData(
         data: CertificationRequestUpdateData
     ): Promise<boolean> {
-        const exists = this.requestQueue.find(queueItem => 
-            queueItem.deviceId === data.deviceId 
-            && queueItem.fromTime === data.fromTime 
-            && queueItem.toTime === data.toTime
+        const exists = this.requestQueue.find(
+            (queueItem) =>
+                queueItem.deviceId === data.deviceId &&
+                queueItem.fromTime === data.fromTime &&
+                queueItem.toTime === data.toTime
         );
 
         if (!exists) {
@@ -42,7 +45,9 @@ export class CertificateClientMock implements ICertificateClient {
         const unix = (timestamp: number) => moment.unix(timestamp);
         const { deviceId, fromTime, toTime } = data;
 
-        const deviceCertificationRequests = (await this.getAllCertificationRequests()).filter(certReq => certReq.deviceId === deviceId && !certReq.revoked);
+        const deviceCertificationRequests = (await this.getAllCertificationRequests()).filter(
+            (certReq) => certReq.deviceId === deviceId && !certReq.revoked
+        );
 
         const generationTimeRange = moment.range(unix(fromTime), unix(toTime));
 
@@ -53,7 +58,9 @@ export class CertificateClientMock implements ICertificateClient {
             );
 
             if (generationTimeRange.overlaps(certificationRequestGenerationRange)) {
-                throw new Error(`Wanted generation time clashes with an existing certification request: ${certificationRequest.id}`);
+                throw new Error(
+                    `Wanted generation time clashes with an existing certification request: ${certificationRequest.id}`
+                );
             }
         }
 
@@ -62,9 +69,7 @@ export class CertificateClientMock implements ICertificateClient {
         };
     }
 
-    public async getCertificationRequest(
-        id: number
-    ): Promise<ICertificationRequest> {
+    public async getCertificationRequest(id: number): Promise<ICertificationRequest> {
         return this.requestStorage.get(id);
     }
 
@@ -72,16 +77,14 @@ export class CertificateClientMock implements ICertificateClient {
         return [...this.requestStorage.values()];
     }
 
-    public mockBlockchainData(
-        id: number,
-        reqData: Partial<CertificationRequestDataMocked>
-    ) {
+    public mockBlockchainData(id: number, reqData: Partial<CertificationRequestDataMocked>) {
         const certificateRequest = this.requestStorage.get(id);
 
-        const queuedData = this.requestQueue.find(data => 
-            data.deviceId === reqData.deviceId 
-            && data.fromTime === reqData.fromTime 
-            && data.toTime === reqData.toTime
+        const queuedData = this.requestQueue.find(
+            (data) =>
+                data.deviceId === reqData.deviceId &&
+                data.fromTime === reqData.fromTime &&
+                data.toTime === reqData.toTime
         );
 
         if (queuedData) {

--- a/packages/origin-backend-client/src/CertificateClient.ts
+++ b/packages/origin-backend-client/src/CertificateClient.ts
@@ -14,16 +14,20 @@ import { IRequestClient, RequestClient } from './RequestClient';
 
 export class CertificationRequestUpdateDTO {
     deviceId: string;
+
     fromTime: number;
+
     toTime: number;
+
     energy: string;
+
     files: string[];
 }
 
 export interface ICertificateClient {
     queueCertificationRequestData(data: CertificationRequestUpdateData): Promise<boolean>;
     validateGenerationPeriod(data: CertificationRequestValidationData): Promise<ISuccessResponse>;
-    getCertificationRequest(id: number): Promise<ICertificationRequest>;
+    getCertificationRequest(id: ICertificationRequest['id']): Promise<ICertificationRequest>;
     getAllCertificationRequests(): Promise<ICertificationRequest[]>;
     getOwnershipCommitment(certificateId: number): Promise<IOwnershipCommitmentProofWithTx>;
     addOwnershipCommitment(

--- a/packages/origin-ui-core/src/components/CertificateDetailView.tsx
+++ b/packages/origin-ui-core/src/components/CertificateDetailView.tsx
@@ -121,10 +121,10 @@ export function CertificateDetailView(props: IProps) {
 
         const resolvedEvents = await Promise.all(jointEvents);
 
-        const request = await new CertificationRequest(
+        const request = await CertificationRequest.fetch(
             selectedCertificate.certificationRequestId,
             configuration
-        ).sync();
+        );
 
         if (request) {
             resolvedEvents.unshift({

--- a/packages/origin-ui-core/src/components/CertificationRequestsTable.tsx
+++ b/packages/origin-ui-core/src/components/CertificationRequestsTable.tsx
@@ -57,9 +57,7 @@ export function CertificationRequestsTable(props: IProps) {
         let newPaginatedData: IRecord[] = [];
         const isIssuer = isRole(user, Role.Issuer);
         try {
-            const requests = (await CertificationRequest.getAll(configuration)).filter(
-                (cert) => cert.initialized
-            );
+            const requests = await CertificationRequest.getAll(configuration);
 
             for (const request of requests) {
                 const requestDevice = producingDevices.find(


### PR DESCRIPTION
Optimized the way CertificationRequests are synced.

Changes:
- **Fixes** an issue where calling `CertificationRequest.getAll` would **sync each certificate twice**
- `CertificationRequest` is now a wrapper class for certification request data
- Getting a new certification request is now done using a static method `await CertificationRequest.fetch(id, configuration)`
