### PR TITLE
fix(exchange): rounding errors due to too low precision

### DIFF
--- a/packages/exchange/src/pods/bundle/bundle.entity.spec.ts
+++ b/packages/exchange/src/pods/bundle/bundle.entity.spec.ts
@@ -81,7 +81,39 @@ describe('Bundle canSplit', () => {
 
         const expectedSplits = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20].map((i) => new BN(i * MWh));
 
-        const areMatching = splits.every((split, i) => split.volume.eq(expectedSplits[i]));
+        const areMatching = splits.every(
+            (split, i) =>
+                split.volume.eq(expectedSplits[i]) &&
+                split.items.reduce((item, s) => s.volume.add(item), new BN(0)).eq(expectedSplits[i])
+        );
+
+        expect(splits).toHaveLength(expectedSplits.length);
+        expect(areMatching).toBeTruthy();
+    });
+
+    it('should return possible splits for the bundle', () => {
+        const bundle = new Bundle({
+            items: [
+                {
+                    startVolume: new BN(45 * MWh),
+                    currentVolume: new BN(45 * MWh)
+                } as BundleItem,
+                {
+                    startVolume: new BN(100 * MWh),
+                    currentVolume: new BN(100 * MWh)
+                } as BundleItem
+            ]
+        });
+
+        const splits = bundle.possibleSplits(new BN(MWh));
+
+        const expectedSplits = [29, 2 * 29, 3 * 29, 4 * 29, 5 * 29].map((i) => new BN(i * MWh));
+
+        const areMatching = splits.every(
+            (split, i) =>
+                split.volume.eq(expectedSplits[i]) &&
+                split.items.reduce((item, s) => s.volume.add(item), new BN(0)).eq(expectedSplits[i])
+        );
 
         expect(splits).toHaveLength(expectedSplits.length);
         expect(areMatching).toBeTruthy();

--- a/packages/exchange/src/pods/bundle/bundle.entity.ts
+++ b/packages/exchange/src/pods/bundle/bundle.entity.ts
@@ -76,7 +76,7 @@ export class Bundle extends ExtendedBaseEntity {
             return new BundleSplitVolumeDTO({ volume: volumeToBuy, items: [] });
         }
 
-        const precision = new BN(100);
+        const precision = new BN(100000);
         const ratio = volumeToBuy.mul(precision).div(this.volume);
         const coefficient = precision.mul(energyPerUnit);
 


### PR DESCRIPTION
This PR fixes the error on calculating possible splits due to too low precision