### PR TITLE
bug/request account with no account id

### DIFF
--- a/packages/origin-backend-core/src/LoggedInUser.ts
+++ b/packages/origin-backend-core/src/LoggedInUser.ts
@@ -34,7 +34,6 @@ export class LoggedInUser implements ILoggedInUser {
         return isRole(this, ...role);
     }
 
-    // This could be changed to organizationId ?? userId down the road, for now we will require a org for each users
     get ownerId() {
         return (this.organizationId || this.id).toString();
     }

--- a/packages/origin-backend-core/src/LoggedInUser.ts
+++ b/packages/origin-backend-core/src/LoggedInUser.ts
@@ -36,6 +36,6 @@ export class LoggedInUser implements ILoggedInUser {
 
     // This could be changed to organizationId ?? userId down the road, for now we will require a org for each users
     get ownerId() {
-        return this.organizationId.toString();
+        return (this.organizationId || this.id).toString();
     }
 }


### PR DESCRIPTION
Issue: When user which doesn't belong to any organization log in backend return 500 on attempt to get user account

Reason: Application expects that the logged in user has exchange account and this account is bound to user's organization id

Fix: Use userId as its owner id when organization id is not exist