### PR TITLE
bug/owned bundle doesnt show all info

### DIFF
--- a/packages/origin-ui-core/src/components/bundles/BundleContents.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundleContents.tsx
@@ -33,7 +33,7 @@ import {
     ArrowBack,
     ArrowRightAlt
 } from '@material-ui/icons';
-import { buyBundle, cancelBundle } from '../../features/bundles';
+import { buyBundle } from '../../features/bundles';
 
 interface IOwnProps {
     bundle: Bundle;

--- a/packages/origin-ui-core/src/components/bundles/BundleContents.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundleContents.tsx
@@ -90,19 +90,10 @@ export const BundleContents = (props: IOwnProps) => {
         dispatch(buyBundle({ bundleDTO: { bundleId: id, volume: selected.volume.toString() } }));
     };
 
-    const onCancelBundle = async () => {
-        dispatch(cancelBundle(id));
+    const action = {
+        onClick: onBuyBundle,
+        label: 'certificate.actions.buy_bundle'
     };
-
-    const action = owner
-        ? {
-              onClick: onCancelBundle,
-              label: 'certificate.actions.cancel_bundle'
-          }
-        : {
-              onClick: onBuyBundle,
-              label: 'certificate.actions.buy_bundle'
-          };
 
     return (
         <Box
@@ -438,14 +429,16 @@ export const BundleContents = (props: IOwnProps) => {
                                             {formatCurrencyComplete(splitPrice, currency)}
                                         </Typography>
                                     </Box>
-                                    <Button
-                                        color="primary"
-                                        variant="contained"
-                                        onClick={action.onClick}
-                                        disabled={!(selected === split)}
-                                    >
-                                        {t(action.label)}
-                                    </Button>
+                                    {!owner && (
+                                        <Button
+                                            color="primary"
+                                            variant="contained"
+                                            onClick={action.onClick}
+                                            disabled={!(selected === split)}
+                                        >
+                                            {t(action.label)}
+                                        </Button>
+                                    )}
                                 </Box>
                             </Box>
                         );

--- a/packages/origin-ui-core/src/components/bundles/BundleDetails.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundleDetails.tsx
@@ -62,7 +62,6 @@ const BundleDetails = (props: IOwnProps) => {
 
     const [priceRange, setPriceRange] = useState<number[]>([minPrice, maxPrice]);
 
-    splits = owner ? [splits.find((split) => split.volume.eq(bundle.volume))] : bundle.splits;
     splits = splits.filter(
         ({ volume }) =>
             bundlePrice({ volume, price }) >= priceRange[0] &&
@@ -94,7 +93,7 @@ const BundleDetails = (props: IOwnProps) => {
                 </IconButton>
             </DialogTitle>
             <DialogContent>
-                {!owner && maxPrice !== minPrice && (
+                {maxPrice !== minPrice && (
                     <Box mb={2}>
                         <Grid container justify="flex-end">
                             <Grid item xs={7}>


### PR DESCRIPTION
Resolved issue: Owned bundle details doesn't show price slider, bundle splits and show Cancel button