### PR TITLE
feature:hide price slider on price length < 2

### DIFF
--- a/packages/origin-ui-core/src/components/bundles/BundleDetails.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundleDetails.tsx
@@ -93,7 +93,7 @@ const BundleDetails = (props: IOwnProps) => {
                 </IconButton>
             </DialogTitle>
             <DialogContent>
-                {maxPrice !== minPrice && (
+                {prices.length > 1 && (
                     <Box mb={2}>
                         <Grid container justify="flex-end">
                             <Grid item xs={7}>


### PR DESCRIPTION
When bundle consists only from one split doesn't show price range slider 