### PR TITLE
fix(exchange-core): fix work around cast type to number before check …

### DIFF
--- a/packages/exchange-core/src/MatchingEngineFactory.ts
+++ b/packages/exchange-core/src/MatchingEngineFactory.ts
@@ -28,9 +28,8 @@ export class MatchingEngineFactory {
     }
 
     private static getStrategy(pricePickStrategy: PriceStrategy) {
-        const strategy = typeof pricePickStrategy !== 'number'
-            ? Number(pricePickStrategy)
-            : pricePickStrategy;
+        const strategy =
+            typeof pricePickStrategy !== 'number' ? Number(pricePickStrategy) : pricePickStrategy;
 
         switch (strategy) {
             case PriceStrategy.AskPrice:

--- a/packages/exchange-core/src/MatchingEngineFactory.ts
+++ b/packages/exchange-core/src/MatchingEngineFactory.ts
@@ -28,7 +28,11 @@ export class MatchingEngineFactory {
     }
 
     private static getStrategy(pricePickStrategy: PriceStrategy) {
-        switch (pricePickStrategy) {
+        const strategy = typeof pricePickStrategy !== 'number'
+            ? Number(pricePickStrategy)
+            : pricePickStrategy;
+
+        switch (strategy) {
             case PriceStrategy.AskPrice:
                 return new AskPriceStrategy();
             case PriceStrategy.BasedOnOrderCreationTime:


### PR DESCRIPTION
Issue: When user create order bid matching engine can't generateTrades https://github.com/energywebfoundation/origin/issues/1233
 
Reason: MatchingEngineFactory.getStrategy() return null because pricePickStrategy value is string

Fix: cast type pricePickStrategy to number