### PR TITLE
bug(exchange): buying whole bundle volume

### DIFF
--- a/packages/exchange/src/pods/bundle/bundle.entity.ts
+++ b/packages/exchange/src/pods/bundle/bundle.entity.ts
@@ -45,6 +45,9 @@ export class Bundle extends ExtendedBaseEntity {
     }
 
     possibleSplits(energyPerUnit: BN): BundleSplitVolumeDTO[] {
+        if (this.available.lt(energyPerUnit)) {
+            return [];
+        }
         const volume = this.available.div(energyPerUnit).toNumber();
         const splits = [...Array(volume).keys()]
             .map((_, i) => new BN(i + 1).mul(energyPerUnit))
@@ -53,11 +56,9 @@ export class Bundle extends ExtendedBaseEntity {
         return splits;
     }
 
-    getUpdatedVolumes(volume: BN) {
-        const currentVolume = this.volume;
-
+    getUpdatedVolumes(volumeToBuy: BN) {
         return this.items.map((item) => {
-            const traded = item.startVolume.div(currentVolume.div(volume));
+            const traded = item.currentVolume.mul(volumeToBuy).div(this.available);
 
             return {
                 id: item.id,

--- a/packages/origin-ui-core/src/components/bundles/BundleContents.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundleContents.tsx
@@ -72,7 +72,7 @@ const rowStyle = {
 };
 
 export const BundleContents = (props: IOwnProps) => {
-    const { owner, bundle, splits } = props;
+    const { bundle, splits } = props;
     const { price, items, id } = bundle;
     const environment = useSelector(getEnvironment);
     const devices = useSelector(getProducingDevices);

--- a/packages/origin-ui-core/src/components/bundles/BundleContents.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundleContents.tsx
@@ -429,7 +429,7 @@ export const BundleContents = (props: IOwnProps) => {
                                             {formatCurrencyComplete(splitPrice, currency)}
                                         </Typography>
                                     </Box>
-                                    {!owner && (
+                                    {!bundle.own && (
                                         <Button
                                             color="primary"
                                             variant="contained"


### PR DESCRIPTION
Fixed bug: After buying whole volume of bundle either returns 500 from splits endpoint or items volumes turned out to be negative

Reasons:
- The available volume was not checked before determining the volume of split
- On buying the current volume was deducted by the share of the initial volume

Extra: Hide buy bundle button on owned bundle