### PR TITLE
fix(origin-backend): only allow certain users to get user information

### DIFF
--- a/packages/origin-backend/src/pods/user/user.controller.ts
+++ b/packages/origin-backend/src/pods/user/user.controller.ts
@@ -19,7 +19,9 @@ import {
     Put,
     UseGuards,
     UseInterceptors,
-    Logger
+    Logger,
+    ParseIntPipe,
+    UnauthorizedException
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
@@ -72,19 +74,32 @@ export class UserController {
     }
 
     @Get(':id')
-    public async get(@Param('id') id: string) {
+    @UseGuards(AuthGuard('jwt'), ActiveUserGuard)
+    public async get(
+        @Param('id', new ParseIntPipe()) id: number,
+        @UserDecorator() loggedUser: ILoggedInUser
+    ) {
+        const canViewUserData = await this.userService.canViewUserData(id, loggedUser);
+
+        if (!canViewUserData) {
+            throw new UnauthorizedException({
+                success: false,
+                message: `Unable to fetch user data. Unauthorized.`
+            });
+        }
+
         return this.userService.findById(id);
     }
 
     @Put('profile')
     @UseGuards(AuthGuard('jwt'), ActiveUserGuard)
-    public async putProfile(@UserDecorator() { id }: ILoggedInUser, @Body() body: IUser) {
+    public async updateOwnProfile(@UserDecorator() { id }: ILoggedInUser, @Body() body: IUser) {
         return this.userService.updateProfile(id, body);
     }
 
     @Put('password')
     @UseGuards(AuthGuard('jwt'), ActiveUserGuard)
-    public async putPassword(
+    public async updateOwnPassword(
         @UserDecorator() { email }: ILoggedInUser,
         @Body() body: UserPasswordUpdate
     ) {
@@ -93,7 +108,10 @@ export class UserController {
 
     @Put('chainAddress')
     @UseGuards(AuthGuard('jwt'), ActiveUserGuard)
-    public async putChainAddress(@UserDecorator() { id }: ILoggedInUser, @Body() body: IUser) {
+    public async updateOwnBlockchainAddress(
+        @UserDecorator() { id }: ILoggedInUser,
+        @Body() body: IUser
+    ) {
         return this.userService.updateBlockChainAddress(id, body);
     }
 }

--- a/packages/origin-backend/src/pods/user/user.service.ts
+++ b/packages/origin-backend/src/pods/user/user.service.ts
@@ -7,7 +7,8 @@ import {
     UserStatus,
     UserPasswordUpdate,
     UserRegistrationData,
-    IUserFilter
+    IUserFilter,
+    ILoggedInUser
 } from '@energyweb/origin-backend-core';
 import { recoverTypedSignatureAddress } from '@energyweb/utils-general';
 import {
@@ -292,5 +293,20 @@ export class UserService {
         });
 
         return this.repository.findOne(id);
+    }
+
+    public async canViewUserData(
+        userId: IUserWithRelationsIds['id'],
+        loggedInUser: ILoggedInUser
+    ): Promise<boolean> {
+        const user = await this.findById(userId);
+
+        const isOwnUser = loggedInUser.id === userId;
+        const isOrgAdmin =
+            loggedInUser.organizationId === user.organization &&
+            loggedInUser.hasRole(Role.OrganizationAdmin);
+        const isAdmin = loggedInUser.hasRole(Role.Issuer, Role.Admin, Role.SupportAgent);
+
+        return isOwnUser || isOrgAdmin || isAdmin;
     }
 }


### PR DESCRIPTION
**Security Bug:** Getting user information for each user was publically available.

**Fix:** 
- **Admin**, **Support Agent** and **Issuer** can get user information for **all users**
- **Organization Admin** can get user information for **all users of the organization**
- **Individual users** can only fetch their own information, and not of other users