### PR TITLE
chore: improve device endpoints

### DIFF
--- a/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
+++ b/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { Configuration } from '@energyweb/utils-general';
 import {
     IDevice,
@@ -10,7 +9,6 @@ import {
     IDeviceWithRelationsIds,
     ISmartMeterReadStats
 } from '@energyweb/origin-backend-core';
-import { BigNumberish, bigNumberify } from 'ethers/utils';
 
 export class Entity implements IDevice {
     status: DeviceStatus;

--- a/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
+++ b/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
@@ -98,16 +98,11 @@ export class Entity implements IDevice {
         return this;
     }
 
-    async saveSmartMeterRead(
-        meterReading: BigNumberish,
-        timestamp: number = moment().unix()
-    ): Promise<void> {
-        const readingBN = bigNumberify(meterReading);
-
-        return this.configuration.offChainDataSource.deviceClient.addSmartMeterRead(this.id, {
-            meterReading: readingBN,
-            timestamp
-        });
+    async saveSmartMeterReads(smReads: ISmartMeterRead[]): Promise<void> {
+        return this.configuration.offChainDataSource.deviceClient.addSmartMeterReads(
+            this.id,
+            smReads
+        );
     }
 
     async getSmartMeterReads(): Promise<ISmartMeterRead[]> {

--- a/packages/device-registry/src/test/DeviceFacade.test.ts
+++ b/packages/device-registry/src/test/DeviceFacade.test.ts
@@ -108,8 +108,10 @@ describe('Device Facade', () => {
         describe('Smart Meter Readings', () => {
             it('should correctly return reads', async () => {
                 let device = await new ProducingDevice.Entity(1, conf).sync();
-                await device.saveSmartMeterRead(100, SM_READ_TIMESTAMP);
-                await device.saveSmartMeterRead(300, SM_READ_TIMESTAMP + 1);
+                await device.saveSmartMeterReads([
+                    { meterReading: bigNumberify(100), timestamp: SM_READ_TIMESTAMP },
+                    { meterReading: bigNumberify(300), timestamp: SM_READ_TIMESTAMP + 1 }
+                ]);
 
                 device = await device.sync();
 

--- a/packages/origin-backend-client-mocks/src/DeviceClientMock.ts
+++ b/packages/origin-backend-client-mocks/src/DeviceClientMock.ts
@@ -9,7 +9,8 @@ import {
     ISmartMeterRead,
     ISmartMeterReadWithStatus,
     DeviceSettingsUpdateData,
-    ISuccessResponse
+    ISuccessResponse,
+    sortLowestToHighestTimestamp
 } from '@energyweb/origin-backend-core';
 
 export class DeviceClientMock implements IDeviceClient {
@@ -66,20 +67,16 @@ export class DeviceClientMock implements IDeviceClient {
         }));
     }
 
-    public async addSmartMeterRead(id: number, smartMeterRead: ISmartMeterRead): Promise<void> {
+    public async addSmartMeterReads(id: number, smartMeterReads: ISmartMeterRead[]): Promise<void> {
         const device = this.storage.get(id);
 
         if (!device.smartMeterReads) {
             device.smartMeterReads = [];
         }
 
-        device.smartMeterReads.push(smartMeterRead);
-        device.smartMeterReads = device.smartMeterReads.sort((a, b) => {
-            if (a.timestamp > b.timestamp) return 1;
-            if (b.timestamp > a.timestamp) return -1;
-
-            return 0;
-        });
+        device.smartMeterReads = [...device.smartMeterReads, ...smartMeterReads].sort(
+            sortLowestToHighestTimestamp
+        );
 
         this.storage.set(id, device);
     }

--- a/packages/origin-backend-client-mocks/src/DeviceClientMock.ts
+++ b/packages/origin-backend-client-mocks/src/DeviceClientMock.ts
@@ -1,3 +1,4 @@
+/*  eslint-disable @typescript-eslint/no-unused-vars */
 import { IDeviceClient } from '@energyweb/origin-backend-client';
 import {
     DeviceStatus,
@@ -7,7 +8,8 @@ import {
     IExternalDeviceId,
     ISmartMeterRead,
     ISmartMeterReadWithStatus,
-    DeviceSettingsUpdateData
+    DeviceSettingsUpdateData,
+    ISuccessResponse
 } from '@energyweb/origin-backend-core';
 
 export class DeviceClientMock implements IDeviceClient {
@@ -58,7 +60,7 @@ export class DeviceClientMock implements IDeviceClient {
     public async getAllSmartMeterReadings(id: number): Promise<ISmartMeterReadWithStatus[]> {
         const { smartMeterReads } = this.storage.get(id);
 
-        return smartMeterReads.map(smRead => ({
+        return smartMeterReads.map((smRead) => ({
             ...smRead,
             certified: false
         }));
@@ -72,26 +74,35 @@ export class DeviceClientMock implements IDeviceClient {
         }
 
         device.smartMeterReads.push(smartMeterRead);
-        device.smartMeterReads = device.smartMeterReads.sort((a, b) =>
-            a.timestamp > b.timestamp ? 1 : b.timestamp > a.timestamp ? -1 : 0
-        );
+        device.smartMeterReads = device.smartMeterReads.sort((a, b) => {
+            if (a.timestamp > b.timestamp) return 1;
+            if (b.timestamp > a.timestamp) return -1;
+
+            return 0;
+        });
 
         this.storage.set(id, device);
     }
 
-    public async getSupplyBy(facilityName: string, status: number): Promise<IDeviceWithRelationsIds[]> {
+    public async getSupplyBy(
+        facilityName: string,
+        status: number
+    ): Promise<IDeviceWithRelationsIds[]> {
         return [...this.storage.values()];
     }
 
-    public async delete(id: number): Promise<void> {
-        throw new Error("Method not implemented.");
+    public async delete(id: number): Promise<ISuccessResponse> {
+        throw new Error('Method not implemented.');
     }
 
-    public async updateDeviceSettings(id: number, device: DeviceSettingsUpdateData): Promise<void> {
-        throw new Error("Method not implemented.");
+    public async updateDeviceSettings(
+        id: number,
+        device: DeviceSettingsUpdateData
+    ): Promise<ISuccessResponse> {
+        throw new Error('Method not implemented.');
     }
 
     public async getMyDevices(withMeterStats: boolean): Promise<IDeviceWithRelationsIds[]> {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
 }

--- a/packages/origin-backend-client/src/AdminClient.ts
+++ b/packages/origin-backend-client/src/AdminClient.ts
@@ -17,19 +17,18 @@ export class AdminClient implements IAdminClient {
         private readonly requestClient: IRequestClient = new RequestClient()
     ) {}
 
-    async update(formData: IUser) {
-        const response = await this.requestClient.put<UserUpdateData, IUserWithRelations>(
+    async update(formData: IUser): Promise<IUserWithRelations> {
+        const { data } = await this.requestClient.put<UserUpdateData, IUserWithRelations>(
             `${this.endpoint}/users/${formData.id}`,
             formData
         );
-        return response.data;
+        return data;
     }
 
-    public async getUsers(filter?: IUserFilter) {
-        const { data } = await this.requestClient.get<unknown, IUser[]>(
-            `${this.endpoint}/users`,
-            { params: filter }
-        );
+    public async getUsers(filter?: IUserFilter): Promise<IUser[]> {
+        const { data } = await this.requestClient.get<void, IUser[]>(`${this.endpoint}/users`, {
+            params: filter
+        });
 
         return data;
     }

--- a/packages/origin-backend-client/src/DeviceClient.ts
+++ b/packages/origin-backend-client/src/DeviceClient.ts
@@ -1,4 +1,14 @@
-import { DeviceCreateData, DeviceSettingsUpdateData, DeviceUpdateData, IDevice, IDeviceWithRelationsIds, IExternalDeviceId, ISmartMeterRead, ISmartMeterReadWithStatus } from '@energyweb/origin-backend-core';
+import {
+    DeviceCreateData,
+    DeviceSettingsUpdateData,
+    DeviceUpdateData,
+    IDevice,
+    IDeviceWithRelationsIds,
+    IExternalDeviceId,
+    ISmartMeterRead,
+    ISmartMeterReadWithStatus,
+    ISuccessResponse
+} from '@energyweb/origin-backend-core';
 import { bigNumberify } from 'ethers/utils';
 import { IRequestClient, RequestClient } from './RequestClient';
 
@@ -11,8 +21,8 @@ export interface IDeviceClient {
     getAllSmartMeterReadings(id: number): Promise<ISmartMeterReadWithStatus[]>;
     addSmartMeterRead(id: number, smartMeterRead: ISmartMeterRead): Promise<void>;
     getSupplyBy(facilityName: string, status: number): Promise<IDeviceWithRelationsIds[]>;
-    delete(id: number): Promise<void>;
-    updateDeviceSettings(id: number, device: DeviceSettingsUpdateData): Promise<void>;
+    delete(id: number): Promise<ISuccessResponse>;
+    updateDeviceSettings(id: number, device: DeviceSettingsUpdateData): Promise<ISuccessResponse>;
     getMyDevices(withMeterStats: boolean): Promise<IDeviceWithRelationsIds[]>;
 }
 
@@ -21,7 +31,7 @@ export class DeviceClient implements IDeviceClient {
         private readonly dataApiUrl: string,
         private readonly requestClient: IRequestClient = new RequestClient()
     ) {}
-    
+
     private get endpoint() {
         return `${this.dataApiUrl}/Device`;
     }
@@ -40,21 +50,27 @@ export class DeviceClient implements IDeviceClient {
         return this.cleanDeviceData(data);
     }
 
-    public async getAll(withMeterStats: boolean = false): Promise<IDeviceWithRelationsIds[]> {
+    public async getAll(withMeterStats = false): Promise<IDeviceWithRelationsIds[]> {
         const { data } = await this.requestClient.get<void, IDeviceWithRelationsIds[]>(
             `${this.endpoint}?withMeterStats=${withMeterStats}`
         );
 
-        return data.map(device => this.cleanDeviceData(device));
+        return data.map((device) => this.cleanDeviceData(device));
     }
 
     public async add(device: DeviceCreateData): Promise<IDeviceWithRelationsIds> {
-        const { data } = await this.requestClient.post<DeviceCreateData, IDeviceWithRelationsIds>(this.endpoint, device);
+        const { data } = await this.requestClient.post<DeviceCreateData, IDeviceWithRelationsIds>(
+            this.endpoint,
+            device
+        );
 
         return this.cleanDeviceData(data);
     }
 
-    public async update(id: number, updateData: DeviceUpdateData): Promise<IDeviceWithRelationsIds> {
+    public async update(
+        id: number,
+        updateData: DeviceUpdateData
+    ): Promise<IDeviceWithRelationsIds> {
         const { data } = await this.requestClient.put<DeviceUpdateData, IDeviceWithRelationsIds>(
             `${this.endpoint}/${id}`,
             updateData
@@ -64,12 +80,16 @@ export class DeviceClient implements IDeviceClient {
     }
 
     public async getAllSmartMeterReadings(id: number): Promise<ISmartMeterReadWithStatus[]> {
-        const response = await this.requestClient.get<void, ISmartMeterReadWithStatus[]>(`${this.endpoint}/${id}/smartMeterReading`);
+        const response = await this.requestClient.get<void, ISmartMeterReadWithStatus[]>(
+            `${this.endpoint}/${id}/smartMeterReading`
+        );
 
-        const meterReadingsFormatted: ISmartMeterReadWithStatus[] = response.data.map((read: ISmartMeterReadWithStatus) => ({
-            ...read,
-            meterReading: bigNumberify(read.meterReading)    
-        }));
+        const meterReadingsFormatted: ISmartMeterReadWithStatus[] = response.data.map(
+            (read: ISmartMeterReadWithStatus) => ({
+                ...read,
+                meterReading: bigNumberify(read.meterReading)
+            })
+        );
 
         return meterReadingsFormatted;
     }
@@ -91,8 +111,8 @@ export class DeviceClient implements IDeviceClient {
         let cleanDevice = { ...device };
 
         if (device.meterStats) {
-           cleanDevice = { 
-                ...cleanDevice, 
+            cleanDevice = {
+                ...cleanDevice,
                 meterStats: {
                     certified: bigNumberify(device.meterStats.certified),
                     uncertified: bigNumberify(device.meterStats.uncertified)
@@ -101,9 +121,9 @@ export class DeviceClient implements IDeviceClient {
         }
 
         if (device.smartMeterReads) {
-            cleanDevice = { 
-                 ...cleanDevice, 
-                 smartMeterReads: device.smartMeterReads.map(smRead => ({
+            cleanDevice = {
+                ...cleanDevice,
+                smartMeterReads: device.smartMeterReads.map((smRead) => ({
                     ...smRead,
                     meterReading: bigNumberify(smRead.meterReading)
                 }))
@@ -113,34 +133,41 @@ export class DeviceClient implements IDeviceClient {
         return cleanDevice;
     }
 
-    public async getSupplyBy(facilityName: string, status: number):Promise<IDeviceWithRelationsIds[]> {
+    public async getSupplyBy(
+        facilityName: string,
+        status: number
+    ): Promise<IDeviceWithRelationsIds[]> {
         const { data } = await this.requestClient.get<unknown, IDeviceWithRelationsIds[]>(
-            `${this.endpoint}/supplyBy?facility=${
-                facilityName ?? ''
-            }&status=${status}`
+            `${this.endpoint}/supplyBy?facility=${facilityName ?? ''}&status=${status}`
         );
-        return data.map(device => this.cleanDeviceData(device));
+        return data.map((device) => this.cleanDeviceData(device));
     }
 
-    public async delete(id: number) {
-        const { data } = await this.requestClient.delete<void, unknown>(
+    public async delete(id: number): Promise<ISuccessResponse> {
+        const { data } = await this.requestClient.delete<void, ISuccessResponse>(
             `${this.endpoint}/${id}`
         );
+
+        return data;
     }
 
-    public async updateDeviceSettings(id: number, device: DeviceSettingsUpdateData): Promise<void> {
-        const response = await this.requestClient.put<DeviceSettingsUpdateData, void>(
+    public async updateDeviceSettings(
+        id: number,
+        device: DeviceSettingsUpdateData
+    ): Promise<ISuccessResponse> {
+        const { data } = await this.requestClient.put<DeviceSettingsUpdateData, ISuccessResponse>(
             `${this.endpoint}/${id}/settings`,
             device
         );
+
+        return data;
     }
 
-    public async getMyDevices(withMeterStats: boolean = false): Promise<IDeviceWithRelationsIds[]> {
+    public async getMyDevices(withMeterStats = false): Promise<IDeviceWithRelationsIds[]> {
         const { data } = await this.requestClient.get<void, IDeviceWithRelationsIds[]>(
             `${this.endpoint}/my-devices?withMeterStats=${withMeterStats}`
         );
 
-        return data.map(device => this.cleanDeviceData(device));
+        return data.map((device) => this.cleanDeviceData(device));
     }
-    
 }

--- a/packages/origin-backend-client/src/DeviceClient.ts
+++ b/packages/origin-backend-client/src/DeviceClient.ts
@@ -19,7 +19,7 @@ export interface IDeviceClient {
     add(device: DeviceCreateData): Promise<IDeviceWithRelationsIds>;
     update(id: number, data: DeviceUpdateData): Promise<IDevice>;
     getAllSmartMeterReadings(id: number): Promise<ISmartMeterReadWithStatus[]>;
-    addSmartMeterRead(id: number, smartMeterRead: ISmartMeterRead): Promise<void>;
+    addSmartMeterReads(id: number, smartMeterReads: ISmartMeterRead[]): Promise<void>;
     getSupplyBy(facilityName: string, status: number): Promise<IDeviceWithRelationsIds[]>;
     delete(id: number): Promise<ISuccessResponse>;
     updateDeviceSettings(id: number, device: DeviceSettingsUpdateData): Promise<ISuccessResponse>;
@@ -94,8 +94,8 @@ export class DeviceClient implements IDeviceClient {
         return meterReadingsFormatted;
     }
 
-    public async addSmartMeterRead(id: number, smartMeterRead: ISmartMeterRead): Promise<void> {
-        const response = await this.requestClient.put<ISmartMeterRead, void>(
+    public async addSmartMeterReads(id: number, smartMeterRead: ISmartMeterRead[]): Promise<void> {
+        const response = await this.requestClient.put<ISmartMeterRead[], void>(
             `${this.endpoint}/${id}/smartMeterReading`,
             smartMeterRead
         );

--- a/packages/origin-backend-core/src/Device.ts
+++ b/packages/origin-backend-core/src/Device.ts
@@ -42,7 +42,7 @@ export interface ISmartMeterReadStats {
 
 export interface ISmartMeterReadingsAdapter {
     getAll(device: IDevice): Promise<ISmartMeterRead[]>;
-    save(device: IDevice, smRead: ISmartMeterRead): Promise<void>;
+    save(device: IDevice, smReads: ISmartMeterRead[]): Promise<void>;
 }
 
 export interface IDeviceProductInfo {
@@ -92,3 +92,13 @@ export interface IDeviceWithRelations extends IDevice {
 export type DeviceCreateData = Omit<IDeviceProperties, 'id' | 'meterStats'>;
 export type DeviceUpdateData = Pick<IDevice, 'status'>;
 export type DeviceSettingsUpdateData = Pick<IDevice, 'defaultAskPrice' | 'automaticPostForSale'>;
+
+export const sortLowestToHighestTimestamp = (
+    a: ISmartMeterRead | IEnergyGenerated,
+    b: ISmartMeterRead | IEnergyGenerated
+): number => {
+    if (a.timestamp > b.timestamp) return 1;
+    if (b.timestamp > a.timestamp) return -1;
+
+    return 0;
+};

--- a/packages/origin-backend/src/pods/device/device.controller.ts
+++ b/packages/origin-backend/src/pods/device/device.controller.ts
@@ -5,7 +5,8 @@ import {
     IDeviceWithRelationsIds,
     ILoggedInUser,
     ISmartMeterRead,
-    Role
+    Role,
+    ISuccessResponse
 } from '@energyweb/origin-backend-core';
 import { Roles, RolesGuard, UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
 import {
@@ -22,7 +23,8 @@ import {
     Put,
     Query,
     UnprocessableEntityException,
-    UseGuards
+    UseGuards,
+    UnauthorizedException
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { StorageErrors } from '../../enums/StorageErrors';
@@ -100,30 +102,47 @@ export class DeviceController {
 
     @Delete('/:id')
     @UseGuards(AuthGuard(), ActiveUserGuard, RolesGuard)
-    @Roles(Role.OrganizationAdmin, Role.OrganizationDeviceManager)
-    async delete(@Param('id') id: string) {
-        const existingEntity = await this.deviceService.findOne(id);
+    @Roles(Role.Issuer, Role.Admin, Role.OrganizationAdmin)
+    async delete(
+        @Param('id') id: string,
+        @UserDecorator() loggedUser: ILoggedInUser
+    ): Promise<ISuccessResponse> {
+        const device = await this.deviceService.findOne(id);
 
-        if (!existingEntity) {
-            throw new NotFoundException(StorageErrors.NON_EXISTENT);
+        if (!device) {
+            throw new NotFoundException({
+                success: false,
+                message: StorageErrors.NON_EXISTENT
+            });
         }
 
-        await this.deviceService.remove(existingEntity);
+        if (
+            loggedUser.organizationId !== device.organization &&
+            !loggedUser.hasRole(Role.Issuer) &&
+            !loggedUser.hasRole(Role.Admin)
+        ) {
+            throw new UnauthorizedException({
+                success: false,
+                message: 'You are not the organization admin.'
+            });
+        }
+
+        await this.deviceService.remove(device);
 
         return {
+            success: true,
             message: `Entity ${id} deleted`
         };
     }
 
     @Put('/:id')
     @UseGuards(AuthGuard(), ActiveUserGuard, RolesGuard)
-    @Roles(Role.OrganizationAdmin, Role.OrganizationDeviceManager, Role.Issuer)
-    async put(
+    @Roles(Role.Issuer, Role.Admin)
+    async updateDeviceStatus(
         @Param('id') id: string,
         @Body() body: DeviceUpdateData
     ): Promise<ExtendedBaseEntity & IDeviceWithRelationsIds> {
-        const res = await this.deviceService.update(id, body);
-        return res;
+        return this.deviceService.updateStatus(id, body);
     }
 
     @Put('/:id/settings')
@@ -133,7 +152,7 @@ export class DeviceController {
         @Param('id') id: string,
         @Body() body: DeviceSettingsUpdateData,
         @UserDecorator() loggedUser: ILoggedInUser
-    ) {
+    ): Promise<ISuccessResponse> {
         if (!this.organizationService.hasDevice(loggedUser.organizationId, id)) {
             throw new ForbiddenException();
         }
@@ -143,13 +162,18 @@ export class DeviceController {
             (body?.automaticPostForSale &&
                 (!Number.isInteger(body?.defaultAskPrice) || body?.defaultAskPrice === 0))
         ) {
-            throw new UnprocessableEntityException(
-                'Body is missing automaticPostForSale or defaultAskPrice'
-            );
+            throw new UnprocessableEntityException({
+                success: false,
+                message: 'Body is missing automaticPostForSale or defaultAskPrice'
+            });
         }
 
-        const res = await this.deviceService.updateSettings(id, body);
-        return res;
+        await this.deviceService.updateSettings(id, body);
+
+        return {
+            success: true,
+            message: `Device ${id} updated.`
+        };
     }
 
     @Get('/:id/smartMeterReading')
@@ -177,19 +201,21 @@ export class DeviceController {
     // TODO: who can store smart meter readings for device?
 
     @Put('/:id/smartMeterReading')
-    async addSmartMeterRead(@Param('id') id: string, @Body() newSmartMeterRead: ISmartMeterRead) {
-        const existing = await this.deviceService.findOne(id);
+    async addSmartMeterRead(
+        @Param('id') id: string,
+        @Body() newSmartMeterRead: ISmartMeterRead
+    ): Promise<ISuccessResponse> {
+        const device = await this.deviceService.findOne(id);
 
-        if (!existing) {
-            throw new NotFoundException(StorageErrors.NON_EXISTENT);
+        if (!device) {
+            throw new NotFoundException({
+                success: false,
+                message: StorageErrors.NON_EXISTENT
+            });
         }
 
         try {
-            await this.deviceService.addSmartMeterReading(id, newSmartMeterRead);
-
-            return {
-                message: `Smart meter reading successfully added to device ${id}`
-            };
+            return this.deviceService.addSmartMeterReading(id, newSmartMeterRead);
         } catch (error) {
             this.logger.error('Error when saving smart meter read');
             this.logger.error({
@@ -198,6 +224,7 @@ export class DeviceController {
                 newSmartMeterRead
             });
             throw new UnprocessableEntityException({
+                success: false,
                 message: `Smart meter reading could not be added due to an unknown error for device ${id}`
             });
         }

--- a/packages/origin-backend/test/device.e2e-spec.ts
+++ b/packages/origin-backend/test/device.e2e-spec.ts
@@ -3,7 +3,8 @@ import {
     DeviceSettingsUpdateData,
     DeviceStatus,
     IDeviceWithRelationsIds,
-    Role
+    Role,
+    ILoggedInUser
 } from '@energyweb/origin-backend-core';
 import { expect } from 'chai';
 import { bigNumberify } from 'ethers/utils';
@@ -12,30 +13,19 @@ import request from 'supertest';
 import dotenv from 'dotenv';
 
 import { bootstrapTestInstance, registerAndLogin } from './origin-backend';
+import { DeviceService } from '../src/pods/device/device.service';
 
 describe('Device e2e tests', () => {
     dotenv.config({
         path: '.env.test'
     });
 
-    it('should allow to edit settings for organization member with DeviceManager role', async () => {
-        const {
-            app,
-            userService,
-            deviceService,
-            organizationService
-        } = await bootstrapTestInstance();
-
-        await app.init();
-
-        const { accessToken, user } = await registerAndLogin(
-            app,
-            userService,
-            organizationService,
-            [Role.OrganizationUser, Role.OrganizationDeviceManager]
-        );
-
-        const { id: deviceId } = await deviceService.create(
+    const createDevice = (
+        deviceService: DeviceService,
+        user: ILoggedInUser,
+        externalDeviceId = '123'
+    ) =>
+        deviceService.create(
             {
                 address: '',
                 capacityInW: 1000,
@@ -57,12 +47,31 @@ describe('Device e2e tests', () => {
                 typeOfPublicSupport: '',
                 deviceGroup: '',
                 smartMeterReads: [],
-                externalDeviceIds: [],
+                externalDeviceIds: [{ id: externalDeviceId, type: process.env.ISSUER_ID }],
                 automaticPostForSale: false,
                 defaultAskPrice: null
             },
             user
         );
+
+    it('should allow to edit settings for organization member with DeviceManager role', async () => {
+        const {
+            app,
+            userService,
+            deviceService,
+            organizationService
+        } = await bootstrapTestInstance();
+
+        await app.init();
+
+        const { accessToken, user } = await registerAndLogin(
+            app,
+            userService,
+            organizationService,
+            [Role.OrganizationUser, Role.OrganizationDeviceManager]
+        );
+
+        const { id: deviceId } = await createDevice(deviceService, user);
 
         await request(app.getHttpServer())
             .get(`/device/${deviceId}`)
@@ -125,6 +134,39 @@ describe('Device e2e tests', () => {
         await app.close();
     });
 
+    it("should not allow deleting device to another Organization's admins", async () => {
+        const {
+            app,
+            userService,
+            deviceService,
+            organizationService
+        } = await bootstrapTestInstance();
+
+        await app.init();
+
+        const { user: orgAdmin } = await registerAndLogin(app, userService, organizationService, [
+            Role.OrganizationAdmin
+        ]);
+
+        const { accessToken: accessTokenOtherOrgAdmin } = await registerAndLogin(
+            app,
+            userService,
+            organizationService,
+            [Role.OrganizationAdmin],
+            'default2',
+            'default2'
+        );
+
+        const { id: deviceId } = await createDevice(deviceService, orgAdmin);
+
+        await request(app.getHttpServer())
+            .delete(`/device/${deviceId}`)
+            .set('Authorization', `Bearer ${accessTokenOtherOrgAdmin}`)
+            .expect(401);
+
+        await app.close();
+    });
+
     it('should return certified and uncertified readings', async () => {
         const {
             app,
@@ -145,34 +187,7 @@ describe('Device e2e tests', () => {
 
         const externalDeviceId = '123';
 
-        const device = await deviceService.create(
-            {
-                address: '',
-                capacityInW: 1000,
-                complianceRegistry: 'I-REC',
-                country: 'EU',
-                description: '',
-                deviceType: 'Solar',
-                facilityName: 'Test',
-                gpsLatitude: '10',
-                gpsLongitude: '10',
-                gridOperator: 'OP',
-                images: '',
-                operationalSince: 2000,
-                otherGreenAttributes: '',
-                province: '',
-                region: '',
-                status: DeviceStatus.Active,
-                timezone: '',
-                typeOfPublicSupport: '',
-                deviceGroup: '',
-                smartMeterReads: [],
-                externalDeviceIds: [{ id: externalDeviceId, type: process.env.ISSUER_ID }],
-                automaticPostForSale: false,
-                defaultAskPrice: null
-            },
-            user
-        );
+        const device = await createDevice(deviceService, user, externalDeviceId);
 
         await request(app.getHttpServer())
             .get(`/device/${device.id}?withMeterStats=true`)

--- a/packages/solar-simulator/src/consumerService.ts
+++ b/packages/solar-simulator/src/consumerService.ts
@@ -63,22 +63,19 @@ export async function startConsumerService(configFilePath: string) {
         return latestSmRead?.meterReading ?? bigNumberify(0);
     }
 
-    async function saveProducingDeviceSmartMeterRead(
+    async function saveProducingDeviceSmartMeterReads(
         deviceId: string,
-        smartMeterReading: ISmartMeterRead
+        smartMeterReadings: ISmartMeterRead[]
     ) {
         console.log('-----------------------------------------------------------');
 
         try {
             let device = await new ProducingDevice.Entity(parseInt(deviceId, 10), conf).sync();
-            await device.saveSmartMeterRead(
-                smartMeterReading.meterReading,
-                smartMeterReading.timestamp
-            );
+            await device.saveSmartMeterReads(smartMeterReadings);
             device = await device.sync();
             conf.logger.verbose(
                 `Producing device ${deviceId} smart meter reading saved: ${JSON.stringify(
-                    smartMeterReading
+                    smartMeterReadings
                 )}`
             );
         } catch (e) {
@@ -131,7 +128,7 @@ export async function startConsumerService(configFilePath: string) {
                     timestamp: time.unix()
                 };
 
-                await saveProducingDeviceSmartMeterRead(device.id, smartMeterReading);
+                await saveProducingDeviceSmartMeterReads(device.id, [smartMeterReading]);
 
                 console.log(
                     `[Device ID: ${device.id}]::Save Energy Read of: ${roundedEnergy}Wh - [${energyMeasurement.measurementTime}]`

--- a/packages/solar-simulator/src/workers/mockReadingsWorker.ts
+++ b/packages/solar-simulator/src/workers/mockReadingsWorker.ts
@@ -9,6 +9,7 @@ import { Configuration } from '@energyweb/utils-general';
 import { OffChainDataSource } from '@energyweb/origin-backend-client';
 import { ISmartMeterRead } from '@energyweb/origin-backend-core';
 import { bigNumberify, BigNumber } from 'ethers/utils';
+import { Wallet, providers } from 'ethers';
 
 async function getProducingDeviceSmartMeterRead(
     deviceId: string,
@@ -22,9 +23,9 @@ async function getProducingDeviceSmartMeterRead(
     return latestSmRead?.meterReading ?? bigNumberify(0);
 }
 
-async function saveProducingDeviceSmartMeterRead(
+async function saveProducingDeviceSmartMeterReads(
     deviceId: number,
-    smartMeterReading: ISmartMeterRead,
+    smartMeterReadings: ISmartMeterRead[],
     conf: Configuration.Entity
 ) {
     console.log('-----------------------------------------------------------');
@@ -33,23 +34,19 @@ async function saveProducingDeviceSmartMeterRead(
 
     try {
         device = await new ProducingDevice.Entity(deviceId, conf).sync();
-        await device.saveSmartMeterRead(
-            smartMeterReading.meterReading,
-            smartMeterReading.timestamp
-        );
+        await device.saveSmartMeterReads(smartMeterReadings);
         device = await device.sync();
         conf.logger.verbose(
-            `Producing device ${deviceId} smart meter reading saved: ${JSON.stringify(
-                smartMeterReading
+            `Producing device ${deviceId} smart meter readings saved: ${JSON.stringify(
+                smartMeterReadings.length
             )}`
         );
     } catch (e) {
-        conf.logger.error(`Could not save smart meter reading for producing device\n${e}`);
+        conf.logger.error(`Could not save smart meter readings for producing device\n${e}`);
 
         console.error({
             deviceId: device.id,
-            meterReading: smartMeterReading.meterReading,
-            time: moment.unix(smartMeterReading.timestamp).format()
+            smartMeterReadings
         });
     }
 
@@ -66,8 +63,13 @@ const currentTime = moment.tz(device.timezone);
         Number(process.env.BACKEND_PORT)
     );
 
+    const provider = new providers.JsonRpcProvider(process.env.WEB3);
+    const issuerWallet = new Wallet(process.env.DEPLOY_KEY, provider);
+
     const conf = {
-        blockchainProperties: {},
+        blockchainProperties: {
+            activeUser: issuerWallet
+        },
         offChainDataSource,
         logger: Winston.createLogger({
             level: 'verbose',
@@ -76,10 +78,22 @@ const currentTime = moment.tz(device.timezone);
         })
     };
 
+    const loginResponse = await conf.offChainDataSource.userClient.login(
+        'admin@mailinator.com',
+        'test'
+    );
+
+    conf.offChainDataSource.requestClient.authenticationToken = loginResponse.accessToken;
+
     const MOCK_READINGS_MINUTES_INTERVAL =
         parseInt(process.env.SOLAR_SIMULATOR_PAST_READINGS_MINUTES_INTERVAL, 10) || 15;
 
-    let measurementTime = currentTime.clone().subtract(1, 'day').startOf('day');
+    let measurementTime = currentTime.clone().subtract(1, 'week').startOf('week');
+    let currentMeterRead: BigNumber = bigNumberify(
+        await getProducingDeviceSmartMeterRead(device.id, conf)
+    );
+
+    const allSmartMeterReadings: ISmartMeterRead[] = [];
 
     while (measurementTime.isSameOrBefore(currentTime)) {
         const newMeasurementTime = measurementTime
@@ -106,36 +120,34 @@ const currentTime = moment.tz(device.timezone);
         const isValidMeterReading = energyGenerated.gt(0);
 
         if (isValidMeterReading) {
-            try {
-                const previousRead: BigNumber = bigNumberify(
-                    await getProducingDeviceSmartMeterRead(device.id, conf)
-                );
+            const newMeterReading = currentMeterRead.add(energyGenerated);
 
-                const smartMeterReading: ISmartMeterRead = {
-                    meterReading: previousRead.add(energyGenerated),
-                    timestamp: measurementTime.unix()
-                };
+            allSmartMeterReadings.push({
+                meterReading: newMeterReading,
+                timestamp: measurementTime.unix()
+            });
 
-                await saveProducingDeviceSmartMeterRead(device.id, smartMeterReading, conf);
-            } catch (error) {
-                conf.logger.error(`Error while trying to save meter read for device ${device.id}`);
-                if (error?.response?.data) {
-                    conf.logger.error('HTTP Error', {
-                        config: error.config,
-                        response: error?.response?.data
-                    });
-                } else {
-                    conf.logger.error(`ERROR: ${error?.message}`);
-                }
-            }
+            currentMeterRead = newMeterReading;
         }
-
-        parentPort.postMessage(
-            `[Device ID: ${device.id}]:${
-                isValidMeterReading ? 'Saved' : 'Skipped'
-            } Energy Read of: ${energyGenerated} Wh - [${measurementTime.format()}]`
-        );
 
         measurementTime = newMeasurementTime;
     }
+
+    try {
+        await saveProducingDeviceSmartMeterReads(device.id, allSmartMeterReadings, conf);
+    } catch (error) {
+        conf.logger.error(`Error while trying to save meter read for device ${device.id}`);
+        if (error?.response?.data) {
+            conf.logger.error('HTTP Error', {
+                config: error.config,
+                response: error?.response?.data
+            });
+        } else {
+            conf.logger.error(`ERROR: ${error?.message}`);
+        }
+    }
+
+    parentPort.postMessage(
+        `[Device ID: ${device.id}]: Saved ${allSmartMeterReadings.length} smart meter reads`
+    );
 })();


### PR DESCRIPTION
- Adds permissioning to PUT `/api/device/smartMeterReading`
- Improves `/api/device` endpoints with security and type fixes
- More efficient storing smart meter readings for the solar simulator
- Deploying mock smart meter readings changed from "last 1 day" to "last 1 week"

Closes https://github.com/energywebfoundation/origin/pull/1206.