### PR TITLE
bug(origin-ui-core): undefined device id in Bids Table

### DIFF
--- a/packages/origin-ui-core/src/components/orders/BidsTable.tsx
+++ b/packages/origin-ui-core/src/components/orders/BidsTable.tsx
@@ -52,8 +52,10 @@ export const BidsTable = (props: IOwnProsp) => {
 
     const getFilters = (): ICustomFilterDefinition[] => [
         {
-            property: ({ asset: { deviceId } }: Order) =>
-                deviceId ? deviceById(deviceId, environment, devices).facilityName : undefined,
+            property: (order: Order) =>
+                order.asset?.deviceId
+                    ? deviceById(order.asset.deviceId, environment, devices).facilityName
+                    : undefined,
             label: t('device.properties.facilityName'),
             input: {
                 type: CustomFilterInputType.dropdown,


### PR DESCRIPTION
Fixed issue: When some fields in order are empty Order filter throws error because it expects that each table record has all data

![image](https://user-images.githubusercontent.com/44746858/87304723-ec747500-c51d-11ea-8088-be3319da1bfa.png)
