### PR TITLE
fix: Organization Permissions

### DIFF
--- a/packages/origin-ui-core/src/components/Organization/Organization.tsx
+++ b/packages/origin-ui-core/src/components/Organization/Organization.tsx
@@ -28,6 +28,12 @@ export function Organization() {
 
     const Menu = [
         {
+            key: 'my-organization',
+            label: 'My Organization',
+            component: OrganizationView,
+            hide: !isLoggedIn || !userOffchain?.organization
+        },
+        {
             key: 'organization-users',
             label: 'Members',
             component: OrganizationUsersTable,
@@ -58,7 +64,7 @@ export function Organization() {
             key: 'organization-table',
             label: 'All organizations',
             component: OrganizationTable,
-            hide: !isLoggedIn
+            hide: !isLoggedIn || !isRole(userOffchain, Role.Admin, Role.SupportAgent)
         },
         {
             key: 'organization-view',

--- a/packages/origin-ui-core/src/components/Organization/OrganizationView.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationView.tsx
@@ -1,9 +1,11 @@
 import { useParams } from 'react-router-dom';
 import React, { useState, useEffect } from 'react';
-import { OrganizationForm } from './OrganizationForm';
 import { useSelector } from 'react-redux';
-import { getOffChainDataSource } from '../../features/general/selectors';
 import { IOrganization } from '@energyweb/origin-backend-core';
+
+import { OrganizationForm } from './OrganizationForm';
+import { getOffChainDataSource } from '../../features/general/selectors';
+import { getUserOffchain } from '../../features/users/selectors';
 
 interface IMatchParams {
     key?: string;
@@ -11,13 +13,14 @@ interface IMatchParams {
 }
 
 export function OrganizationView() {
+    const userOffchain = useSelector(getUserOffchain);
     const organizationClient = useSelector(getOffChainDataSource)?.organizationClient;
 
     const [entity, setEntity] = useState<IOrganization>(null);
 
     const params: IMatchParams = useParams();
 
-    async function fetchEntity(id: string) {
+    async function fetchEntity(id: string | number) {
         if (!organizationClient) {
             return setEntity(null);
         }
@@ -26,7 +29,7 @@ export function OrganizationView() {
     }
 
     useEffect(() => {
-        fetchEntity(params?.id);
+        fetchEntity(params?.id ?? userOffchain?.organization?.id);
     }, [params, organizationClient]);
 
     return <OrganizationForm entity={entity} readOnly={true} />;


### PR DESCRIPTION
Adjusts the backend and frontend to respect the following rules:

> - Everyone in the organization can see their organization information. 
> - Users of the platform can’t see information about other organizations.
> - Only the admin and support agents can see all information from all organizations.

Also: 
- Fixes an issue where any user would be able to see information about every organization
- Replace the `All Organizations` sub-tab with `My Organization` for non-admin users.


<img width="1038" alt="Screenshot 2020-07-13 at 16 22 52" src="https://user-images.githubusercontent.com/9353642/87316129-a7544100-c525-11ea-90a9-4434da46b6db.png">