### PR TITLE
feat: Email Confirmation

### DIFF
--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -340,18 +340,28 @@
                 "password": "Password",
                 "status": "Status",
                 "kycStatus": "KYC Status",
-                "blockchainAddress": "Blockchain Address"
+                "blockchainAddress": "Blockchain Address",
+                "emailConfirmed": "Email Confirmed"
             },
             "actions": {
                 "register": "Register",
                 "login": "Login",
-                "save": "Save"
+                "save": "Save",
+                "resendConfirmationEmail": "Re-send confirmation email"
             },
             "feedback": {
                 "userRegistered": "User registered.",
                 "errorWhileRegisteringUser": "Error while registering user.",
                 "userLoggedIn": "User logged in.",
-                "couldNotLogIn": "Could not log in with supplied credentials."
+                "couldNotLogIn": "Could not log in with supplied credentials.",
+                "confirmationEmailResent": "Confirmation email re-sent.",
+                "confirmationEmailResentFailed": "Unable to send the confirmation email.",
+                "emailConfirmation": {
+                    "alreadyConfirmed": "Already confirmed.",
+                    "confirmed": "Email confirmed successfully.",
+                    "expired": "Confirmation link expired.",
+                    "loading:": "Loading..."
+                }
             },
             "profile": {
                 "subtitle": {
@@ -463,10 +473,6 @@
             "feedback": {
                 "removeOrderConfirmation": "Are you sure you want remove?",
                 "orderCanceled": "Order canceled"
-            },
-            "confirmations": {
-                "no": "No",
-                "yes": "Yes"
             }
         }
     }

--- a/packages/origin-backend-client-mocks/src/OffChainDataSourceMock.ts
+++ b/packages/origin-backend-client-mocks/src/OffChainDataSourceMock.ts
@@ -39,10 +39,9 @@ export class OffChainDataSourceMock implements IOffChainDataSource {
     certificateClient: ICertificateClient = new CertificateClientMock();
 
     adminClient: IAdminClient;
-    
+
     constructor() {
         this.deviceClient = new DeviceClientMock();
         this.organizationClient = new OrganizationClientMock();
     }
-
 }

--- a/packages/origin-backend-client-mocks/src/UserClientMock.ts
+++ b/packages/origin-backend-client-mocks/src/UserClientMock.ts
@@ -10,7 +10,8 @@ import {
     UserPasswordUpdate,
     IUserWithRelations,
     IEmailConfirmationToken,
-    EmailConfirmationResponse
+    EmailConfirmationResponse,
+    ISuccessResponse
 } from '@energyweb/origin-backend-core';
 import { recoverTypedSignatureAddress } from '@energyweb/utils-general';
 
@@ -102,6 +103,10 @@ export class UserClientMock implements IUserClient {
     }
 
     confirmEmail(token: IEmailConfirmationToken['token']): Promise<EmailConfirmationResponse> {
+        throw new Error('Method not implemented.');
+    }
+
+    requestConfirmationEmail(): Promise<ISuccessResponse> {
         throw new Error('Method not implemented.');
     }
 }

--- a/packages/origin-backend-client-mocks/src/UserClientMock.ts
+++ b/packages/origin-backend-client-mocks/src/UserClientMock.ts
@@ -8,14 +8,15 @@ import {
     KYCStatus,
     Role,
     UserPasswordUpdate,
-    IUserWithRelations
+    IUserWithRelations,
+    IEmailConfirmationToken,
+    EmailConfirmationResponse
 } from '@energyweb/origin-backend-core';
 import { recoverTypedSignatureAddress } from '@energyweb/utils-general';
 
 import { IUserClient } from '@energyweb/origin-backend-client';
 
 export class UserClientMock implements IUserClient {
-    
     private storage = new Map<number, IUserWithRelationsIds>();
 
     private userIdCounter = 0;
@@ -89,13 +90,18 @@ export class UserClientMock implements IUserClient {
     }
 
     updateProfile(formData: IUser): Promise<IUserWithRelations> {
-        
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
+
     updatePassword(formData: UserPasswordUpdate): Promise<IUserWithRelations> {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
     }
+
     updateChainAddress(formData: IUser): Promise<IUserWithRelations> {
-        throw new Error("Method not implemented.");
+        throw new Error('Method not implemented.');
+    }
+
+    confirmEmail(token: IEmailConfirmationToken['token']): Promise<EmailConfirmationResponse> {
+        throw new Error('Method not implemented.');
     }
 }

--- a/packages/origin-backend-client/src/UserClient.ts
+++ b/packages/origin-backend-client/src/UserClient.ts
@@ -10,7 +10,8 @@ import {
     IUser,
     UserPasswordUpdate,
     IEmailConfirmationToken,
-    EmailConfirmationResponse
+    EmailConfirmationResponse,
+    ISuccessResponse
 } from '@energyweb/origin-backend-core';
 
 import { IRequestClient, RequestClient } from './RequestClient';
@@ -31,6 +32,7 @@ export interface IUserClient {
     updatePassword(formData: UserPasswordUpdate): Promise<IUserWithRelations>;
     updateChainAddress(formData: IUser): Promise<IUserWithRelations>;
     confirmEmail(token: IEmailConfirmationToken['token']): Promise<EmailConfirmationResponse>;
+    requestConfirmationEmail(): Promise<ISuccessResponse>;
 }
 
 export class UserClient implements IUserClient {
@@ -139,6 +141,14 @@ export class UserClient implements IUserClient {
             IEmailConfirmationToken['token'],
             EmailConfirmationResponse
         >(`${this.userEndpoint}/confirm-email/${token}`);
+
+        return response.data;
+    }
+
+    public async requestConfirmationEmail(): Promise<ISuccessResponse> {
+        const response = await this.requestClient.put<void, ISuccessResponse>(
+            `${this.userEndpoint}/re-send-confirm-email`
+        );
 
         return response.data;
     }

--- a/packages/origin-backend-client/src/UserClient.ts
+++ b/packages/origin-backend-client/src/UserClient.ts
@@ -8,7 +8,9 @@ import {
     IUserProperties,
     IUserWithRelations,
     IUser,
-    UserPasswordUpdate
+    UserPasswordUpdate,
+    IEmailConfirmationToken,
+    EmailConfirmationResponse
 } from '@energyweb/origin-backend-core';
 
 import { IRequestClient, RequestClient } from './RequestClient';
@@ -28,6 +30,7 @@ export interface IUserClient {
     updateProfile(formData: IUser): Promise<IUserWithRelations>;
     updatePassword(formData: UserPasswordUpdate): Promise<IUserWithRelations>;
     updateChainAddress(formData: IUser): Promise<IUserWithRelations>;
+    confirmEmail(token: IEmailConfirmationToken['token']): Promise<EmailConfirmationResponse>;
 }
 
 export class UserClient implements IUserClient {
@@ -112,18 +115,31 @@ export class UserClient implements IUserClient {
         );
         return response.data;
     }
+
     public async updatePassword(formData: UserPasswordUpdate): Promise<IUserWithRelations> {
         const response = await this.requestClient.put<UserPasswordUpdate, IUserWithRelations>(
             `${this.userEndpoint}/password`,
             formData
         );
-        return response.data;   
+        return response.data;
     }
+
     public async updateChainAddress(formData: IUser): Promise<IUserWithRelations> {
         const response = await this.requestClient.put<UserUpdateData, IUserWithRelations>(
             `${this.userEndpoint}/chainAddress`,
             formData
         );
+        return response.data;
+    }
+
+    public async confirmEmail(
+        token: IEmailConfirmationToken['token']
+    ): Promise<EmailConfirmationResponse> {
+        const response = await this.requestClient.put<
+            IEmailConfirmationToken['token'],
+            EmailConfirmationResponse
+        >(`${this.userEndpoint}/confirm-email/${token}`);
+
         return response.data;
     }
 }

--- a/packages/origin-backend-core/src/EmailConfirmation.ts
+++ b/packages/origin-backend-core/src/EmailConfirmation.ts
@@ -7,3 +7,9 @@ export interface IEmailConfirmation extends IEmailConfirmationToken {
     id: number;
     confirmed: boolean;
 }
+
+export enum EmailConfirmationResponse {
+    Success = 'Email confirmed successfully',
+    AlreadyConfirmed = 'Email already confirmed',
+    Expired = 'Email confirmation token expired'
+}

--- a/packages/origin-backend-core/src/EmailConfirmation.ts
+++ b/packages/origin-backend-core/src/EmailConfirmation.ts
@@ -1,0 +1,9 @@
+export interface IEmailConfirmationToken {
+    token: string;
+    expiryTimestamp: number;
+}
+
+export interface IEmailConfirmation extends IEmailConfirmationToken {
+    id: number;
+    confirmed: boolean;
+}

--- a/packages/origin-backend-core/src/Events.ts
+++ b/packages/origin-backend-core/src/Events.ts
@@ -57,7 +57,13 @@ export type OrganizationMemberChangedRoleEvent = {
     email: string;
 };
 
+export type ConfirmEmailEvent = {
+    email: string;
+    token: string;
+};
+
 export enum SupportedEvents {
+    CONFIRM_EMAIL = 'ConfirmEmail',
     DEVICE_STATUS_CHANGED = 'DeviceStatusChanged',
     CREATE_NEW_DEMAND = 'CreatedNewDemand',
     DEMAND_UPDATED = 'DemandUpdated',
@@ -70,6 +76,7 @@ export enum SupportedEvents {
 }
 
 export type SupportedEventData =
+    | ConfirmEmailEvent
     | UserStatusChangedEvent
     | DeviceStatusChangedEvent
     | CreatedNewDemand

--- a/packages/origin-backend-core/src/User.ts
+++ b/packages/origin-backend-core/src/User.ts
@@ -1,4 +1,5 @@
 import { IOrganization } from './Organization';
+import { IEmailConfirmation } from './EmailConfirmation';
 
 export enum Role {
     OrganizationAdmin = 1,
@@ -64,6 +65,7 @@ export interface IUserProperties {
 
 export interface IUser extends IUserProperties {
     organization: IOrganization | IOrganization['id'];
+    emailConfirmed?: IEmailConfirmation['confirmed'];
 }
 
 export interface IUserWithRelationsIds extends IUser {

--- a/packages/origin-backend-core/src/index.ts
+++ b/packages/origin-backend-core/src/index.ts
@@ -10,3 +10,4 @@ export * from './OwnershipCommitment';
 export * from './Certificate';
 export * from './LoggedInUser';
 export * from './UserRegistrationData';
+export * from './EmailConfirmation';

--- a/packages/origin-backend/migrations/1594725219598-EmailConfirmation.ts
+++ b/packages/origin-backend/migrations/1594725219598-EmailConfirmation.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class EmailConfirmation1594725219598 implements MigrationInterface {
+    name = 'EmailConfirmation1594725219598';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE "email_confirmation" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "id" SERIAL NOT NULL, "confirmed" boolean NOT NULL, "token" character varying NOT NULL, "expiryTimestamp" integer NOT NULL, "userId" integer, CONSTRAINT "REL_28d3d3fbd7503f3428b94fd18c" UNIQUE ("userId"), CONSTRAINT "PK_ff2b80a46c3992a0046b07c5456" PRIMARY KEY ("id"))`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "email_confirmation" ADD CONSTRAINT "FK_28d3d3fbd7503f3428b94fd18cc" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "email_confirmation" DROP CONSTRAINT "FK_28d3d3fbd7503f3428b94fd18cc"`
+        );
+        await queryRunner.query(`DROP TABLE "email_confirmation"`);
+    }
+}

--- a/packages/origin-backend/src/app.module.ts
+++ b/packages/origin-backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { DeviceModule } from './pods/device/device.module';
 import { FileModule } from './pods/file/file.module';
 import { OrganizationModule } from './pods/organization/organization.module';
 import { UserModule } from './pods/user/user.module';
+import { EmailConfirmationModule } from './pods/email-confirmation/email-confirmation.module';
 
 const ENV_FILE_PATH = path.resolve(__dirname, '../../../../../.env');
 
@@ -36,7 +37,8 @@ export class AppModule {
                 DeviceModule.register(smartMeterReadingsAdapter),
                 AuthModule,
                 CertificateModule.register(smartMeterReadingsAdapter),
-                AdminModule
+                AdminModule,
+                EmailConfirmationModule
             ],
             controllers: [AppController],
             providers: [{ provide: APP_PIPE, useClass: ValidationPipe }]

--- a/packages/origin-backend/src/index.ts
+++ b/packages/origin-backend/src/index.ts
@@ -7,6 +7,7 @@ import { Organization } from './pods/organization/organization.entity';
 import { OrganizationInvitation } from './pods/organization/organization-invitation.entity';
 import { User } from './pods/user/user.entity';
 import { CertificationRequestQueueItem } from './pods/certificate/certification-request-queue-item.entity';
+import { EmailConfirmation } from './pods/email-confirmation/email-confirmation.entity';
 
 export { AppModule } from './app.module';
 export { ExtendedBaseEntity } from './pods/ExtendedBaseEntity';
@@ -27,5 +28,6 @@ export const entities = [
     OrganizationInvitation,
     CertificationRequest,
     CertificationRequestQueueItem,
-    Certificate
+    Certificate,
+    EmailConfirmation
 ];

--- a/packages/origin-backend/src/pods/email-confirmation/email-confirmation.entity.ts
+++ b/packages/origin-backend/src/pods/email-confirmation/email-confirmation.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToOne, JoinColumn } from 'typeorm';
+
+import { IEmailConfirmation } from '@energyweb/origin-backend-core';
+import { ExtendedBaseEntity } from '../ExtendedBaseEntity';
+import { User } from '../user/user.entity';
+
+@Entity()
+export class EmailConfirmation extends ExtendedBaseEntity implements IEmailConfirmation {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @OneToOne(() => User)
+    @JoinColumn()
+    user: User;
+
+    @Column()
+    confirmed: boolean;
+
+    @Column()
+    token: string;
+
+    @Column()
+    expiryTimestamp: number;
+}

--- a/packages/origin-backend/src/pods/email-confirmation/email-confirmation.module.ts
+++ b/packages/origin-backend/src/pods/email-confirmation/email-confirmation.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EmailConfirmationService } from './email-confirmation.service';
+import { EmailConfirmation } from './email-confirmation.entity';
+import { NotificationModule } from '../notification';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([EmailConfirmation]), NotificationModule],
+    providers: [EmailConfirmationService],
+    controllers: [],
+    exports: [EmailConfirmationService]
+})
+export class EmailConfirmationModule {}

--- a/packages/origin-backend/src/pods/email-confirmation/email-confirmation.service.ts
+++ b/packages/origin-backend/src/pods/email-confirmation/email-confirmation.service.ts
@@ -128,7 +128,7 @@ export class EmailConfirmationService {
     generateEmailToken(): IEmailConfirmationToken {
         return {
             token: crypto.randomBytes(64).toString('hex'),
-            expiryTimestamp: moment().add(8, 'day').unix()
+            expiryTimestamp: moment().add(8, 'hour').unix()
         };
     }
 }

--- a/packages/origin-backend/src/pods/email-confirmation/email-confirmation.service.ts
+++ b/packages/origin-backend/src/pods/email-confirmation/email-confirmation.service.ts
@@ -1,0 +1,140 @@
+import crypto from 'crypto';
+import { Logger, Injectable, ConflictException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+    IEmailConfirmationToken,
+    IUser,
+    ISuccessResponse,
+    ConfirmEmailEvent,
+    SupportedEvents
+} from '@energyweb/origin-backend-core';
+import moment from 'moment';
+import { EmailConfirmation } from './email-confirmation.entity';
+import { User } from '../user/user.entity';
+import { NotificationService } from '../notification/notification.service';
+
+@Injectable()
+export class EmailConfirmationService {
+    private readonly logger = new Logger(EmailConfirmationService.name);
+
+    constructor(
+        @InjectRepository(EmailConfirmation)
+        private readonly repository: Repository<EmailConfirmation>,
+        private readonly notificationService: NotificationService
+    ) {}
+
+    public async create(user: User): Promise<EmailConfirmation> {
+        const exists = await this.repository.findOne({ user: { email: user.email } });
+
+        if (exists) {
+            throw new ConflictException({
+                success: false,
+                message: `Email confirmation for user with email ${user.email} already exists`
+            });
+        }
+
+        const { token, expiryTimestamp } = this.generateEmailToken();
+
+        const emailConfirmation = await this.repository.save({
+            user,
+            confirmed: false,
+            token,
+            expiryTimestamp
+        });
+
+        await this.sendConfirmationEmail(user.email);
+
+        return emailConfirmation;
+    }
+
+    async get(userId: IUser['id']): Promise<EmailConfirmation> {
+        const all = await this.repository.find({ relations: ['user'] });
+
+        return all.find((confirmation) => confirmation.user.id === userId);
+    }
+
+    async getByEmail(email: IUser['email']): Promise<EmailConfirmation> {
+        const all = await this.repository.find({ relations: ['user'] });
+
+        return all.find(
+            (confirmation) => confirmation.user.email.toLowerCase() === email.toLowerCase()
+        );
+    }
+
+    async confirmEmail(token: IEmailConfirmationToken['token']): Promise<ISuccessResponse> {
+        const emailConfirmation = await this.repository.findOne({ token });
+
+        if (!emailConfirmation) {
+            throw new BadRequestException({
+                success: false,
+                message: `Email confirmation doesn't exist`
+            });
+        }
+
+        if (emailConfirmation.confirmed === true) {
+            throw new BadRequestException({
+                success: false,
+                message: `Email already confirmed`
+            });
+        }
+
+        if (emailConfirmation.expiryTimestamp < moment().unix()) {
+            throw new BadRequestException({
+                success: false,
+                message: `Token expired`
+            });
+        }
+
+        await this.repository.update(emailConfirmation.id, {
+            confirmed: true
+        });
+
+        return {
+            success: true,
+            message: 'Email successfully confirmed'
+        };
+    }
+
+    public async sendConfirmationEmail(email: IUser['email']): Promise<ISuccessResponse> {
+        const currentToken = await this.getByEmail(email);
+
+        let { token, expiryTimestamp } = currentToken;
+        const { id, confirmed } = currentToken;
+
+        if (confirmed === true) {
+            throw new BadRequestException({
+                success: false,
+                message: `Email already confirmed`
+            });
+        }
+
+        if (expiryTimestamp < moment().unix()) {
+            const newToken = this.generateEmailToken();
+            await this.repository.update(id, newToken);
+
+            ({ token, expiryTimestamp } = newToken);
+        }
+
+        const eventData: ConfirmEmailEvent = {
+            email: email.toLowerCase(),
+            token
+        };
+
+        this.notificationService.handleEvent({
+            type: SupportedEvents.CONFIRM_EMAIL,
+            data: eventData
+        });
+
+        return {
+            success: true
+        };
+    }
+
+    generateEmailToken(): IEmailConfirmationToken {
+        return {
+            token: crypto.randomBytes(64).toString('hex'),
+            expiryTimestamp: moment().add(8, 'day').unix()
+        };
+    }
+}

--- a/packages/origin-backend/src/pods/notification/EmailTypes.ts
+++ b/packages/origin-backend/src/pods/notification/EmailTypes.ts
@@ -6,7 +6,8 @@ enum EmailTypes {
     ORGANIZATION_INVITATION = 'New organization invitation',
     ORGANIZATION_REMOVED_MEMBER = 'You have been removed from an organization',
     ORGANIZATION_MEMBER_CHANGED_ROLE = 'Update to your user role',
-    USER_STATUS_CHANGED = 'User Information Change'
+    USER_STATUS_CHANGED = 'User Information Change',
+    CONFIRM_EMAIL = 'Confirm your email address'
 }
 
 export default EmailTypes;

--- a/packages/origin-backend/src/pods/notification/notification.service.ts
+++ b/packages/origin-backend/src/pods/notification/notification.service.ts
@@ -10,7 +10,8 @@ import {
     DeviceStatus,
     UserStatusChangedEvent,
     OrganizationMemberChangedRoleEvent,
-    Role
+    Role,
+    ConfirmEmailEvent
 } from '@energyweb/origin-backend-core';
 import { MailService } from '../mail';
 import EmailTypes from './EmailTypes';
@@ -54,6 +55,14 @@ export class NotificationService {
     constructor(private readonly mailService: MailService) {}
 
     private handlers = {
+        [SupportedEvents.CONFIRM_EMAIL]: async (data: ConfirmEmailEvent) => {
+            const url = `${process.env.UI_BASE_URL}/account/confirm-email?${data.token}`;
+            await this.sendNotificationEmail(
+                EmailTypes.CONFIRM_EMAIL,
+                data.email,
+                `Please visit <a href="${url}">confirm your email address</a>.`
+            );
+        },
         [SupportedEvents.ORGANIZATION_INVITATION]: async (data: OrganizationInvitationEvent) => {
             const url = `${process.env.UI_BASE_URL}/organization/organization-invitations`;
 

--- a/packages/origin-backend/src/pods/notification/notification.service.ts
+++ b/packages/origin-backend/src/pods/notification/notification.service.ts
@@ -22,7 +22,8 @@ const SUPPORTED_EVENTS = [
     SupportedEvents.ORGANIZATION_REMOVED_MEMBER,
     SupportedEvents.ORGANIZATION_MEMBER_CHANGED_ROLE,
     SupportedEvents.DEVICE_STATUS_CHANGED,
-    SupportedEvents.USER_STATUS_CHANGED
+    SupportedEvents.USER_STATUS_CHANGED,
+    SupportedEvents.CONFIRM_EMAIL
 ];
 
 type TSupportedNotificationEvent = {
@@ -32,14 +33,16 @@ type TSupportedNotificationEvent = {
         | SupportedEvents.ORGANIZATION_STATUS_CHANGED
         | SupportedEvents.ORGANIZATION_REMOVED_MEMBER
         | SupportedEvents.ORGANIZATION_MEMBER_CHANGED_ROLE
-        | SupportedEvents.DEVICE_STATUS_CHANGED;
+        | SupportedEvents.DEVICE_STATUS_CHANGED
+        | SupportedEvents.CONFIRM_EMAIL;
     data:
         | UserStatusChangedEvent
         | OrganizationInvitationEvent
         | OrganizationStatusChangedEvent
         | OrganizationRemovedMemberEvent
         | OrganizationMemberChangedRoleEvent
-        | DeviceStatusChangedEvent;
+        | DeviceStatusChangedEvent
+        | ConfirmEmailEvent;
 };
 
 function assertIsSupportedEvent(event: NewEvent): asserts event is TSupportedNotificationEvent {
@@ -56,11 +59,11 @@ export class NotificationService {
 
     private handlers = {
         [SupportedEvents.CONFIRM_EMAIL]: async (data: ConfirmEmailEvent) => {
-            const url = `${process.env.UI_BASE_URL}/account/confirm-email?${data.token}`;
+            const url = `${process.env.UI_BASE_URL}/account/confirm-email?token=${data.token}`;
             await this.sendNotificationEmail(
                 EmailTypes.CONFIRM_EMAIL,
                 data.email,
-                `Please visit <a href="${url}">confirm your email address</a>.`
+                `Please visit confirm your email address: <a href="${url}">${url}</a>.`
             );
         },
         [SupportedEvents.ORGANIZATION_INVITATION]: async (data: OrganizationInvitationEvent) => {

--- a/packages/origin-backend/src/pods/user/user.controller.ts
+++ b/packages/origin-backend/src/pods/user/user.controller.ts
@@ -5,7 +5,9 @@ import {
     UserRegistrationData,
     UserUpdateData,
     IUser,
-    UserPasswordUpdate
+    UserPasswordUpdate,
+    IEmailConfirmationToken,
+    ISuccessResponse
 } from '@energyweb/origin-backend-core';
 import { UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
 import {
@@ -26,21 +28,23 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 
 import { UserService } from './user.service';
+import { EmailConfirmationService } from '../email-confirmation/email-confirmation.service';
 
 @UseInterceptors(ClassSerializerInterceptor)
 @Controller('user')
 export class UserController {
     private readonly logger = new Logger(UserController.name);
 
-    constructor(private readonly userService: UserService) {}
+    constructor(
+        private readonly userService: UserService,
+        private readonly emailConfirmationService: EmailConfirmationService
+    ) {}
 
     @Post('register')
     public async register(
         @Body() userRegistrationData: UserRegistrationData
     ): Promise<UserRegisterReturnData> {
-        const user = await this.userService.create(userRegistrationData);
-
-        return user;
+        return this.userService.create(userRegistrationData);
     }
 
     @Get('me')
@@ -113,5 +117,20 @@ export class UserController {
         @Body() body: IUser
     ) {
         return this.userService.updateBlockChainAddress(id, body);
+    }
+
+    @Put('confirm-email/:token')
+    public async confirmToken(
+        @Param('token') token: IEmailConfirmationToken['token']
+    ): Promise<ISuccessResponse> {
+        return this.emailConfirmationService.confirmEmail(token);
+    }
+
+    @Put('re-send-confirm-email')
+    @UseGuards(AuthGuard('jwt'))
+    public async reSendEmailConfirmation(
+        @UserDecorator() { email }: ILoggedInUser
+    ): Promise<ISuccessResponse> {
+        return this.emailConfirmationService.sendConfirmationEmail(email);
     }
 }

--- a/packages/origin-backend/src/pods/user/user.controller.ts
+++ b/packages/origin-backend/src/pods/user/user.controller.ts
@@ -7,7 +7,8 @@ import {
     IUser,
     UserPasswordUpdate,
     IEmailConfirmationToken,
-    ISuccessResponse
+    ISuccessResponse,
+    EmailConfirmationResponse
 } from '@energyweb/origin-backend-core';
 import { UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
 import {
@@ -122,7 +123,7 @@ export class UserController {
     @Put('confirm-email/:token')
     public async confirmToken(
         @Param('token') token: IEmailConfirmationToken['token']
-    ): Promise<ISuccessResponse> {
+    ): Promise<EmailConfirmationResponse> {
         return this.emailConfirmationService.confirmEmail(token);
     }
 

--- a/packages/origin-backend/src/pods/user/user.module.ts
+++ b/packages/origin-backend/src/pods/user/user.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { User } from './user.entity';
+import { EmailConfirmationModule } from '../email-confirmation/email-confirmation.module';
 
 @Module({
-    imports: [forwardRef(() => TypeOrmModule.forFeature([User]))],
+    imports: [forwardRef(() => TypeOrmModule.forFeature([User])), EmailConfirmationModule],
     providers: [UserService],
     controllers: [UserController],
     exports: [UserService]

--- a/packages/origin-backend/src/pods/user/user.service.ts
+++ b/packages/origin-backend/src/pods/user/user.service.ts
@@ -178,9 +178,9 @@ export class UserService {
         }) as Promise<IUser>) as Promise<TUserBaseEntity>);
 
         if (user) {
-            const { confirmed } = await this.emailConfirmationService.get(user.id);
+            const emailConfirmation = await this.emailConfirmationService.get(user.id);
 
-            user.emailConfirmed = confirmed;
+            user.emailConfirmed = emailConfirmation?.confirmed || false;
         }
 
         return user;

--- a/packages/origin-backend/test/certification-request.e2e-spec.ts
+++ b/packages/origin-backend/test/certification-request.e2e-spec.ts
@@ -297,8 +297,7 @@ describe('CertificationRequest e2e tests', () => {
     });
 
     it('should properly validate a certification request', async () => {
-        await databaseService.truncate('certification_request');
-        await databaseService.truncate('device');
+        await databaseService.truncate('certification_request', 'device');
 
         const { accessToken, user } = await registerAndLogin(
             app,

--- a/packages/origin-backend/test/database.service.ts
+++ b/packages/origin-backend/test/database.service.ts
@@ -22,7 +22,9 @@ export class DatabaseService {
         }
     }
 
-    public async truncate(table: string) {
-        return this.connection.query(`TRUNCATE "${table}" CASCADE;`);
+    public async truncate(...tables: string[]) {
+        for (const table of tables) {
+            await this.connection.query(`TRUNCATE "${table}" CASCADE;`);
+        }
     }
 }

--- a/packages/origin-backend/test/organization.e2e-spec.ts
+++ b/packages/origin-backend/test/organization.e2e-spec.ts
@@ -40,8 +40,7 @@ describe('Organization e2e tests', () => {
     });
 
     beforeEach(async () => {
-        await databaseService.truncate('user');
-        await databaseService.truncate('organization');
+        await databaseService.truncate('user', 'organization');
     });
 
     after(async () => {

--- a/packages/origin-backend/test/origin-backend.ts
+++ b/packages/origin-backend/test/origin-backend.ts
@@ -24,6 +24,7 @@ import { OrganizationService } from '../src/pods/organization/organization.servi
 import { UserService } from '../src/pods/user';
 import { DatabaseService } from './database.service';
 import { CertificateService } from '../src/pods/certificate/certificate.service';
+import { EmailConfirmationService } from '../src/pods/email-confirmation/email-confirmation.service';
 
 const testLogger = new Logger('e2e');
 
@@ -60,6 +61,9 @@ export const bootstrapTestInstance = async () => {
     const certificationRequestService = await app.resolve<CertificationRequestService>(
         CertificationRequestService
     );
+    const emailConfirmationService = await app.resolve<EmailConfirmationService>(
+        EmailConfirmationService
+    );
 
     app.useLogger(testLogger);
     app.enableCors();
@@ -79,7 +83,8 @@ export const bootstrapTestInstance = async () => {
         deviceService,
         configurationService,
         certificateService,
-        certificationRequestService
+        certificationRequestService,
+        emailConfirmationService
     };
 };
 

--- a/packages/origin-backend/test/user.e2e-spec.ts
+++ b/packages/origin-backend/test/user.e2e-spec.ts
@@ -6,7 +6,8 @@ import {
     KYCStatus,
     Role,
     UserStatus,
-    UserRegistrationData
+    UserRegistrationData,
+    EmailConfirmationResponse
 } from '@energyweb/origin-backend-core';
 import { INestApplication } from '@nestjs/common';
 import { expect } from 'chai';
@@ -242,7 +243,11 @@ describe('User e2e tests', () => {
         await request(app.getHttpServer())
             .put(`/user/confirm-email/${token}`)
             .set('Authorization', `Bearer ${accessToken}`)
-            .expect(200);
+            .expect((res) => {
+                const response = res.text as EmailConfirmationResponse;
+
+                expect(response).equals(EmailConfirmationResponse.Success);
+            });
 
         await request(app.getHttpServer())
             .get(`/user/me`)
@@ -278,32 +283,20 @@ describe('User e2e tests', () => {
         await request(app.getHttpServer())
             .put(`/user/confirm-email/${token}`)
             .set('Authorization', `Bearer ${accessToken}`)
-            .expect(200);
+            .expect((res) => {
+                console.log(res);
+                const response = res.text as EmailConfirmationResponse;
+
+                expect(response).equals(EmailConfirmationResponse.Success);
+            });
 
         await request(app.getHttpServer())
             .put(`/user/confirm-email/${token}`)
             .set('Authorization', `Bearer ${accessToken}`)
-            .expect(400);
-    });
+            .expect((res) => {
+                const response = res.text as EmailConfirmationResponse;
 
-    it('user should not be able to re-confirm confirmed email', async () => {
-        const { user, accessToken } = await registerAndLogin(
-            app,
-            userService,
-            organizationService,
-            [Role.OrganizationUser]
-        );
-
-        const { token } = await emailConfirmationService.get(user.id);
-
-        await request(app.getHttpServer())
-            .put(`/user/confirm-email/${token}`)
-            .set('Authorization', `Bearer ${accessToken}`)
-            .expect(200);
-
-        await request(app.getHttpServer())
-            .put(`/user/confirm-email/${token}`)
-            .set('Authorization', `Bearer ${accessToken}`)
-            .expect(400);
+                expect(response).equals(EmailConfirmationResponse.AlreadyConfirmed);
+            });
     });
 });

--- a/packages/origin-ui-core/src/components/Account/Account.tsx
+++ b/packages/origin-ui-core/src/components/Account/Account.tsx
@@ -9,6 +9,7 @@ import { UserRegister } from './UserRegister';
 import { UserLogin } from './UserLogin';
 import { dataTest, useLinks, useTranslation } from '../../utils';
 import { UserProfile } from './UserProfile';
+import { ConfirmEmail } from './ConfirmEmail';
 
 export function Account() {
     const userOffchain = useSelector(getUserOffchain);
@@ -42,6 +43,12 @@ export function Account() {
             label: 'settings.navigation.userProfile',
             component: UserProfile,
             hide: !isLoggedIn
+        },
+        {
+            key: 'confirm-email',
+            label: 'settings.navigation.confirmEmail',
+            component: ConfirmEmail,
+            hide: true
         }
     ];
 
@@ -74,14 +81,12 @@ export function Account() {
                 path={`${getAccountLink()}/:key/:id?`}
                 render={(props) => {
                     const key = props.match.params.key;
-                    const matches = Menu.filter((item) => {
-                        return item.key === key;
-                    });
 
                     return (
                         <PageContent
-                            menu={matches.length > 0 ? matches[0] : null}
+                            menu={Menu.find((item) => item.key === key)}
                             redirectPath={getAccountLink()}
+                            {...props}
                         />
                     );
                 }}

--- a/packages/origin-ui-core/src/components/Account/ConfirmEmail.tsx
+++ b/packages/origin-ui-core/src/components/Account/ConfirmEmail.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from '../../utils';
+import { useSelector } from 'react-redux';
+
+import * as queryString from 'query-string';
+import { getOffChainDataSource } from '../..';
+import { EmailConfirmationResponse } from '@energyweb/origin-backend-core';
+
+export function ConfirmEmail(props: any) {
+    const { t } = useTranslation();
+
+    const [confirmationState, setConfirmationState] = useState(null);
+    const [clientLoaded, setClientLoaded] = useState(false);
+
+    const userClient = useSelector(getOffChainDataSource)?.userClient;
+
+    if (userClient && !clientLoaded) {
+        setClientLoaded(true);
+    }
+
+    const { token } = queryString.parse(props.location.search);
+
+    useEffect(() => {
+        async function confirm() {
+            if (!token || !clientLoaded) {
+                return false;
+            }
+
+            return userClient.confirmEmail(token as string);
+        }
+
+        confirm().then((result: EmailConfirmationResponse) => setConfirmationState(result));
+    }, [userClient]);
+
+    let message = null;
+
+    switch (confirmationState) {
+        case EmailConfirmationResponse.AlreadyConfirmed:
+            message = 'alreadyConfirmed';
+            break;
+        case EmailConfirmationResponse.Success:
+            message = 'confirmed';
+            break;
+        case EmailConfirmationResponse.Expired:
+            message = 'expired';
+            break;
+        default:
+            message = 'loading';
+    }
+
+    return <div>{t(`user.feedback.emailConfirmation.${message}`)}</div>;
+}

--- a/packages/origin-ui-core/src/components/Account/UserProfile.tsx
+++ b/packages/origin-ui-core/src/components/Account/UserProfile.tsx
@@ -46,7 +46,8 @@ const INITIAL_FORM_VALUES: IFormValues = {
     organization: null,
     rights: 0,
     status: UserStatus.Pending,
-    kycStatus: KYCStatus.Pending
+    kycStatus: KYCStatus.Pending,
+    emailConfirmed: false
 };
 
 export const getUserOffchain = (state: IStoreState) => state.users.userOffchain;
@@ -226,6 +227,26 @@ export function UserProfile() {
                                         />
 
                                         <FormInput
+                                            label={t('user.properties.email')}
+                                            property="email"
+                                            disabled={fieldDisabled}
+                                            className="mt-3"
+                                            required
+                                        />
+
+                                        <Field
+                                            label={t('user.properties.status')}
+                                            type="status"
+                                            name="status"
+                                            component={TextField}
+                                            variant="filled"
+                                            fullWidth
+                                            disabled={true}
+                                            value={UserStatus[values.status]}
+                                            className="mt-3"
+                                        />
+
+                                        <FormInput
                                             label={t('user.properties.telephone')}
                                             property="telephone"
                                             disabled={fieldDisabled}
@@ -241,28 +262,52 @@ export function UserProfile() {
                                             className="mt-3"
                                             required
                                         />
-                                        <FormInput
-                                            label={t('user.properties.email')}
-                                            property="email"
-                                            disabled={fieldDisabled}
-                                            className="mt-3"
-                                            required
-                                        />
-                                    </Grid>
 
-                                    <Grid item xs={6}>
-                                        <Field
-                                            label={t('user.properties.status')}
-                                            type="status"
-                                            name="status"
-                                            component={TextField}
-                                            variant="filled"
-                                            fullWidth
-                                            disabled={true}
-                                            value={UserStatus[values.status]}
-                                        />
-                                    </Grid>
-                                    <Grid item xs={6}>
+                                        {values.emailConfirmed ? (
+                                            <Field
+                                                label={t('user.properties.emailConfirmed')}
+                                                type="emailConfirmed"
+                                                name="emailConfirmed"
+                                                component={TextField}
+                                                variant="filled"
+                                                fullWidth
+                                                disabled={true}
+                                                value={t(
+                                                    values.emailConfirmed
+                                                        ? 'general.responses.yes'
+                                                        : 'general.responses.no'
+                                                )}
+                                                className="mt-3"
+                                            />
+                                        ) : (
+                                            <Button
+                                                type="button"
+                                                variant="contained"
+                                                color="primary"
+                                                className="mt-4 mb-2 right"
+                                                onClick={async () => {
+                                                    const {
+                                                        success
+                                                    } = await userClient.requestConfirmationEmail();
+
+                                                    const message = t(
+                                                        success
+                                                            ? 'user.feedback.confirmationEmailResent'
+                                                            : 'user.feedback.confirmationEmailResentFailed'
+                                                    );
+
+                                                    showNotification(
+                                                        message,
+                                                        success
+                                                            ? NotificationType.Success
+                                                            : NotificationType.Error
+                                                    );
+                                                }}
+                                            >
+                                                {t('user.actions.resendConfirmationEmail')}
+                                            </Button>
+                                        )}
+
                                         <Field
                                             label={t('user.properties.kycStatus')}
                                             type="kycStatus"
@@ -272,6 +317,7 @@ export function UserProfile() {
                                             fullWidth
                                             disabled={true}
                                             value={KYCStatus[values.kycStatus]}
+                                            className="mt-3"
                                         />
                                     </Grid>
                                 </Grid>

--- a/packages/origin-ui-core/src/components/Modal/RemoveOrderConfirmation.tsx
+++ b/packages/origin-ui-core/src/components/Modal/RemoveOrderConfirmation.tsx
@@ -56,10 +56,10 @@ export const RemoveOrderConfirmation = (props: IOwnProps) => {
             </DialogContent>
             <DialogActions style={{ padding: spacing(2), justifyContent: 'center' }}>
                 <Button onClick={close} variant="outlined" color="primary">
-                    {t('order.confirmations.no')}
+                    {t('general.responses.no')}
                 </Button>
                 <Button onClick={onCancelOrder} variant="contained" color="primary" autoFocus>
-                    {t('order.confirmations.yes')}
+                    {t('general.responses.yes')}
                 </Button>
             </DialogActions>
         </Dialog>

--- a/packages/origin-ui-core/src/components/PageContent/PageContent.tsx
+++ b/packages/origin-ui-core/src/components/PageContent/PageContent.tsx
@@ -9,7 +9,11 @@ export class PageContent extends React.Component<any, any> {
         return menu ? (
             <div className="PageContentWrapper">
                 <div className="PageBody">
-                    {menu.component ? <PageComponent {...menu.props} /> : 'Coming Soon...'}
+                    {menu.component ? (
+                        <PageComponent {...menu.props} {...this.props} />
+                    ) : (
+                        'Coming Soon...'
+                    )}
                 </div>
             </div>
         ) : (


### PR DESCRIPTION
![Screenshot 2020-07-15 at 16 21 15](https://user-images.githubusercontent.com/9353642/87556829-6ab84f00-c6b7-11ea-8faf-308e86219786.png)

Adds support for confirming user emails.

### Workflow
1. User registers to the platform
2. Backend sends the confirmation email
3. User clicks on the link in the email
4. Link takes him to Origin with a message "Email confirmed"
5. User profile now says "Email Confirmed: Yes"
6. The User can request re-sending the confirmation email in case it didn't get the email.

### Description
- Email confirmation tokens expire in 8 hours
- After confirmation email expires, the user has to request re-sending the confirmation email, which then generates a new confirmation token
- Confirmation token is a random 128 char hash string
