### PR TITLE
bug(origin-ui-core): fetch unnecessary splits

### DIFF
--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -435,7 +435,8 @@
                 "bundleDetails": "BUNDLE DETAILS",
                 "Sell": "Sell",
                 "certificates": "certificates",
-                "price": "Price per MWh"
+                "price": "Price per MWh",
+                "bundleBought": "Bundle was fully purchased"
             },
             "actions": {
                 "sellAsBundle": "Sell as bundle"

--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -225,7 +225,8 @@
             "responses": {
                 "yes": "Yes",
                 "no": "No",
-                "partially": "Partially"
+                "partially": "Partially",
+                "ok": "Ok"
             },
             "actions": {
                 "update": "Update",

--- a/packages/localization/src/languages/pl.json
+++ b/packages/localization/src/languages/pl.json
@@ -141,6 +141,9 @@
             }
         },
         "general": {
+            "responses": {
+                "ok": "Dobrze"
+            },
             "actions": {
                 "update": "Zaktualizuj",
                 "continue": "Kontynuuj",

--- a/packages/localization/src/languages/pl.json
+++ b/packages/localization/src/languages/pl.json
@@ -269,7 +269,8 @@
                 "bundleDetails": "Szczegóły Pakietu",
                 "price": "Cena za MWh",
                 "Sell": "Sprzedać",
-                "certificates": "certyfikaty"
+                "certificates": "certyfikaty",
+                "bundleBought": "Pakiet został w pełni zakupiony."
             },
             "actions": {
                 "sellAsBundle": "Sell as bundle"

--- a/packages/origin-ui-core/src/components/Modal/BundleBought.tsx
+++ b/packages/origin-ui-core/src/components/Modal/BundleBought.tsx
@@ -17,7 +17,7 @@ interface IOwnProps {
     open: boolean;
     setOpen: (boolean) => void;
 }
-export const BundleBougth = (props: IOwnProps) => {
+export const BundleBought = (props: IOwnProps) => {
     const { open, setOpen } = props;
     const { t } = useTranslation();
     const iconStyles = makeStyles((theme: Theme) => ({

--- a/packages/origin-ui-core/src/components/Modal/BundleBougth.tsx
+++ b/packages/origin-ui-core/src/components/Modal/BundleBougth.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {
+    DialogTitle,
+    DialogActions,
+    Button,
+    Dialog,
+    DialogContent,
+    makeStyles,
+    Theme,
+    Box,
+    Grid
+} from '@material-ui/core';
+import { RemoveCircle } from '@material-ui/icons';
+import { useTranslation } from '../..';
+
+interface IOwnProps {
+    open: boolean;
+    setOpen: (boolean) => void;
+}
+export const BundleBougth = (props: IOwnProps) => {
+    const { open, setOpen } = props;
+    const { t } = useTranslation();
+    const iconStyles = makeStyles((theme: Theme) => ({
+        large: {
+            fontSize: theme.spacing(10)
+        }
+    }))();
+
+    return (
+        <Dialog open={open} onClose={() => setOpen(false)}>
+            <DialogTitle></DialogTitle>
+            <DialogContent>
+                <Grid container direction="column" alignItems="center" spacing={2}>
+                    <Grid item>
+                        <RemoveCircle
+                            color="error"
+                            fontSize="large"
+                            classes={{ fontSizeLarge: iconStyles.large }}
+                        />
+                    </Grid>
+                    <Grid item>
+                        <Box>{t('bundle.info.bundleBought')}</Box>
+                    </Grid>
+                </Grid>{' '}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={() => setOpen(false)} color="primary">
+                    Ok
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};

--- a/packages/origin-ui-core/src/components/bundles/BundleDetails.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundleDetails.tsx
@@ -48,14 +48,13 @@ function SliderLabel(props) {
 }
 
 const BundleDetails = (props: IOwnProps) => {
+    const dispatch = useDispatch();
+    const showModal = useSelector(getShowBundleDetails);
+    const { t } = useTranslation();
+    const dialogStyles = useDialogStyles();
     const { bundle, owner } = props;
     let { splits } = bundle;
     const { price } = bundle;
-    const showModal = useSelector(getShowBundleDetails);
-    const dispatch = useDispatch();
-    const { t } = useTranslation();
-    const dialogStyles = useDialogStyles();
-
     const prices = splits.map(({ volume }) => bundlePrice({ volume, price }));
     const maxPrice = Math.ceil(Math.max(...prices) / 10) * 10;
     const minPrice = Math.floor(Math.min(...prices) / 10) * 10;

--- a/packages/origin-ui-core/src/components/bundles/BundlesTable.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundlesTable.tsx
@@ -24,7 +24,7 @@ import { getBundles, getShowBundleDetails } from '../../features/bundles/selecto
 import { Fab, Tooltip } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import { showBundleDetails, cancelBundle, storeBundle } from '../../features/bundles';
-import { BundleBougth } from '../Modal/BundleBougth';
+import { BundleBought } from '../Modal/BundleBought';
 import { BigNumber } from 'ethers/utils';
 
 const BUNDLES_PER_PAGE = 25;
@@ -173,7 +173,7 @@ export const BundlesTable = (props: IOwnProps) => {
                     </Fab>
                 </Tooltip>
             </Link>
-            <BundleBougth open={showBundleBoughtModal} setOpen={setShowBundleBougthModal} />
+            <BundleBought open={showBundleBoughtModal} setOpen={setShowBundleBougthModal} />
         </>
     );
 };

--- a/packages/origin-ui-core/src/components/bundles/BundlesTable.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundlesTable.tsx
@@ -16,14 +16,16 @@ import {
 import { EnergyTypes } from '../../utils';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { Bundle } from '../../utils/exchange';
+import { Bundle, IExchangeClient } from '../../utils/exchange';
 import { Visibility, Add, Cancel as CancelIcon } from '@material-ui/icons';
 import BundleDetails from './BundleDetails';
-import { getCurrencies, getEnvironment } from '../../features';
+import { getCurrencies, getEnvironment, getExchangeClient } from '../../features';
 import { getBundles, getShowBundleDetails } from '../../features/bundles/selectors';
 import { Fab, Tooltip } from '@material-ui/core';
 import { Link } from 'react-router-dom';
-import { showBundleDetails, cancelBundle } from '../../features/bundles';
+import { showBundleDetails, cancelBundle, storeBundle } from '../../features/bundles';
+import { BundleBougth } from '../Modal/BundleBougth';
+import { BigNumber } from 'ethers/utils';
 
 const BUNDLES_PER_PAGE = 25;
 const BUNDLES_TOTAL_ENERGY_COLUMN_ID = 'total';
@@ -40,13 +42,17 @@ const ENERGY_COLUMNS_TO_DISPLAY = [EnergyTypes.SOLAR, EnergyTypes.WIND, EnergyTy
 export const BundlesTable = (props: IOwnProps) => {
     const { owner = false } = props;
     const allBundles = useSelector(getBundles);
-    const bundles = allBundles.filter((b) => (owner ? b.own : true));
+    const exchangeClient: IExchangeClient = useSelector(getExchangeClient);
+    const bundles = allBundles
+        .filter((b) => (owner ? b.own : true))
+        .filter((b) => !(b.splits && b.splits.length === 0));
     const { t } = useTranslation();
     const devices = useSelector(getProducingDevices);
     const [selected, setSelected] = useState<Bundle>(null);
     const environment = useSelector(getEnvironment);
     const dispatch = useDispatch();
     const isBundleDetailsVisible = useSelector(getShowBundleDetails);
+    const [showBundleBoughtModal, setShowBundleBougthModal] = useState<boolean>(false);
 
     const { currentSort, sortAscending, sortData, toggleSort } = usePaginatedLoaderSorting({
         currentSort: {
@@ -91,9 +97,18 @@ export const BundlesTable = (props: IOwnProps) => {
     });
     sortData(rows);
 
-    const viewDetails = (rowIndex: number) => {
+    const viewDetails = async (rowIndex: number) => {
         const { bundleId } = rows[rowIndex];
         const bundle = bundles.find((b) => b.id === bundleId);
+        const { splits } = await exchangeClient.getBundleSplits(bundle);
+        bundle.splits = splits.map((s) => ({
+            volume: new BigNumber(s.volume),
+            items: s.items.map(({ id, volume }) => ({ id, volume: new BigNumber(volume) }))
+        }));
+        dispatch(storeBundle(bundle));
+        if (splits.length === 0) {
+            return setShowBundleBougthModal(true);
+        }
         setSelected(bundle);
         dispatch(showBundleDetails(true));
     };
@@ -116,7 +131,7 @@ export const BundlesTable = (props: IOwnProps) => {
         { id: 'price', label: t('bundle.properties.price') }
     ];
 
-    const actions = [
+    const actions: any[] = [
         {
             icon: <Visibility />,
             name: 'View details',
@@ -158,6 +173,7 @@ export const BundlesTable = (props: IOwnProps) => {
                     </Fab>
                 </Tooltip>
             </Link>
+            <BundleBougth open={showBundleBoughtModal} setOpen={setShowBundleBougthModal} />
         </>
     );
 };

--- a/packages/origin-ui-core/src/components/bundles/BundlesTable.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundlesTable.tsx
@@ -52,7 +52,7 @@ export const BundlesTable = (props: IOwnProps) => {
     const environment = useSelector(getEnvironment);
     const dispatch = useDispatch();
     const isBundleDetailsVisible = useSelector(getShowBundleDetails);
-    const [showBundleBoughtModal, setShowBundleBougthModal] = useState<boolean>(false);
+    const [showBundleBoughtModal, setShowBundleBoughtModal] = useState<boolean>(false);
 
     const { currentSort, sortAscending, sortData, toggleSort } = usePaginatedLoaderSorting({
         currentSort: {
@@ -107,7 +107,7 @@ export const BundlesTable = (props: IOwnProps) => {
         }));
         dispatch(storeBundle(bundle));
         if (splits.length === 0) {
-            return setShowBundleBougthModal(true);
+            return setShowBundleBoughtModal(true);
         }
         setSelected(bundle);
         dispatch(showBundleDetails(true));
@@ -173,7 +173,7 @@ export const BundlesTable = (props: IOwnProps) => {
                     </Fab>
                 </Tooltip>
             </Link>
-            <BundleBought open={showBundleBoughtModal} setOpen={setShowBundleBougthModal} />
+            <BundleBought open={showBundleBoughtModal} setOpen={setShowBundleBoughtModal} />
         </>
     );
 };

--- a/packages/origin-ui-core/src/features/general/sagas.ts
+++ b/packages/origin-ui-core/src/features/general/sagas.ts
@@ -24,8 +24,7 @@ import {
     IExchangeClient,
     ExchangeAccount,
     AccountAsset,
-    Bundle,
-    BundleSplits
+    Bundle
 } from '../../utils/exchange';
 import {
     IOriginConfiguration,
@@ -379,18 +378,6 @@ export function* fetchBundles() {
             continue;
         }
         bundle.volume = new BigNumber(bundle.volume.toString());
-        const bundleSplits: BundleSplits = yield apply(
-            exchangeClient,
-            exchangeClient.getBundleSplits,
-            [bundle]
-        );
-        bundleSplits.splits.forEach((split) => {
-            split.volume = new BigNumber(split.volume);
-            split.items.forEach((item) => {
-                item.volume = new BigNumber(item.volume);
-            });
-        });
-        bundle.splits = bundleSplits.splits;
         yield put(storeBundle(bundle));
     }
 }

--- a/packages/origin-ui-core/src/utils/exchange/ExchangeClient.ts
+++ b/packages/origin-ui-core/src/utils/exchange/ExchangeClient.ts
@@ -17,6 +17,7 @@ import {
     CreateBundleDTO
 } from '.';
 import { Filter, OrderStatus } from '@energyweb/exchange-core';
+import { BundleSplits } from './types';
 
 export interface IExchangeClient {
     search(
@@ -39,7 +40,7 @@ export interface IExchangeClient {
     cancelOrder(order: Order): Promise<Order>;
     getAvailableBundles(): Promise<Bundle[]>;
     getOwnBundles(): Promise<Bundle[]>;
-    getBundleSplits(bundle: Bundle): Promise<Bundle[]>;
+    getBundleSplits(bundle: Bundle): Promise<BundleSplits>;
     createBundle(bundle: CreateBundleDTO): Promise<Bundle>;
     cancelBundle(id: string): Promise<Bundle>;
 }
@@ -194,8 +195,8 @@ export class ExchangeClient implements IExchangeClient {
         return response.data;
     }
 
-    public async getBundleSplits(bundle: Bundle): Promise<Bundle[]> {
-        const response = await this.requestClient.get<unknown, Bundle[]>(
+    public async getBundleSplits(bundle: Bundle): Promise<BundleSplits> {
+        const response = await this.requestClient.get<Bundle, BundleSplits>(
             `${this.bundleEndpoint}/${bundle.id}/splits`
         );
 


### PR DESCRIPTION
Fixed performance issue: On loading application all bundle splits are loaded without need. 
Current behavior: splits loaded on bundle details