### PR TITLE
fix(issuer): Certificate creation date always shows latest block timestamp

### DIFF
--- a/packages/issuer/src/blockchain-facade/Certificate.ts
+++ b/packages/issuer/src/blockchain-facade/Certificate.ts
@@ -178,7 +178,7 @@ export class Certificate extends PreciseProofEntity implements ICertificate {
             registry.filters.IssuanceSingle(null, null, null)
         );
         const issuanceLog = allIssuanceLogs.filter(
-            (event) => event._id.toString() === this.id.toString()
+            (event) => event.values._id.toString() === this.id.toString()
         )[0];
         const issuanceBlock = await registry.provider.getBlock(issuanceLog.blockHash);
 
@@ -194,7 +194,7 @@ export class Certificate extends PreciseProofEntity implements ICertificate {
             issuer.filters.CertificationRequestApproved(null, null, this.id)
         );
 
-        this.certificationRequestId = certificationRequestApprovedEvents[0]._id;
+        this.certificationRequestId = certificationRequestApprovedEvents[0].values._id;
         this.propertiesDocumentHash = await issuer.getCertificateCommitment(this.id);
 
         if (this.propertiesDocumentHash !== NULL_HASH) {
@@ -422,16 +422,24 @@ export class Certificate extends PreciseProofEntity implements ICertificate {
         );
 
         claimSingleEvents
-            .filter((claimEvent) => claimEvent._id.toNumber() === this.id)
+            .filter((claimEvent) => claimEvent.values._id.toNumber() === this.id)
             .forEach(async (claimEvent) => {
-                const claimData = await decodeClaimData(claimEvent._claimData, this.configuration);
+                const {
+                    _claimData,
+                    _id,
+                    _claimIssuer,
+                    _claimSubject,
+                    _topic,
+                    _value
+                } = claimEvent.values;
+                const claimData = await decodeClaimData(_claimData, this.configuration);
 
                 claims.push({
-                    id: claimEvent._id,
-                    from: claimEvent._claimIssuer,
-                    to: claimEvent._claimSubject,
-                    topic: claimEvent._topic,
-                    value: claimEvent._value,
+                    id: _id,
+                    from: _claimIssuer,
+                    to: _claimSubject,
+                    topic: _topic,
+                    value: _value,
                     claimData
                 });
             });
@@ -443,23 +451,30 @@ export class Certificate extends PreciseProofEntity implements ICertificate {
 
         claimBatchEvents
             .filter((claimBatchEvent) =>
-                claimBatchEvent._ids.map((idAsBN: BigNumber) => idAsBN.toNumber()).includes(this.id)
+                claimBatchEvent.values._ids
+                    .map((idAsBN: BigNumber) => idAsBN.toNumber())
+                    .includes(this.id)
             )
             .forEach(async (claimBatchEvent) => {
-                const claimIds = claimBatchEvent._ids.map((idAsBN: BigNumber) => idAsBN.toNumber());
+                const {
+                    _ids,
+                    _claimData,
+                    _claimIssuer,
+                    _claimSubject,
+                    _topics,
+                    _values
+                } = claimBatchEvent.values;
+                const claimIds = _ids.map((idAsBN: BigNumber) => idAsBN.toNumber());
 
                 const index = claimIds.indexOf(this.id);
-                const claimData = await decodeClaimData(
-                    claimBatchEvent._claimData[index],
-                    this.configuration
-                );
+                const claimData = await decodeClaimData(_claimData[index], this.configuration);
 
                 claims.push({
-                    id: claimBatchEvent._ids[index],
-                    from: claimBatchEvent._claimIssuer,
-                    to: claimBatchEvent._claimSubject,
-                    topic: claimBatchEvent._topics[index],
-                    value: claimBatchEvent._values[index],
+                    id: _ids[index],
+                    from: _claimIssuer,
+                    to: _claimSubject,
+                    topic: _topics[index],
+                    value: _values[index],
                     claimData
                 });
             });

--- a/packages/issuer/src/blockchain-facade/CertificateUtils.ts
+++ b/packages/issuer/src/blockchain-facade/CertificateUtils.ts
@@ -6,15 +6,7 @@ import { EventFilter } from 'ethers';
 import { Certificate, IClaimData } from './Certificate';
 import { Registry } from '../ethers/Registry';
 import { Issuer } from '../ethers/Issuer';
-import { getEventsFromContract } from '../utils/events';
-
-export interface IBlockchainEvent {
-    name: string;
-    transactionHash: string;
-    blockHash: string;
-    values: any;
-    timestamp: number;
-}
+import { getEventsFromContract, IBlockchainEvent } from '../utils/events';
 
 export const encodeClaimData = async (
     claimData: IClaimData,
@@ -164,7 +156,7 @@ export async function getAllCertificates(
         issuer.filters.CertificationRequestApproved(null, null, null)
     );
     const certificatePromises = certificationRequestApprovedEvents.map((event) =>
-        new Certificate(event._certificateId.toNumber(), configuration).sync()
+        new Certificate(event.values._certificateId.toNumber(), configuration).sync()
     );
 
     return Promise.all(certificatePromises);
@@ -184,7 +176,7 @@ export async function getAllOwnedCertificates(
         registry.filters.TransferSingle(null, null, owner, null, null)
     );
     const certificateIds = [
-        ...new Set<number>(transfers.map((transfer) => transfer._id.toNumber()))
+        ...new Set<number>(transfers.map((transfer) => transfer.values._id.toNumber()))
     ];
     const balances = await registry.balanceOfBatch(
         Array(certificateIds.length).fill(owner),

--- a/packages/issuer/src/utils/events.ts
+++ b/packages/issuer/src/utils/events.ts
@@ -1,11 +1,26 @@
 import { Contract, EventFilter } from 'ethers';
 
-export const getEventsFromContract = async (contract: Contract, eventFilter: EventFilter) => {
-    return (
-        await contract.provider.getLogs({
-            ...eventFilter,
-            fromBlock: 0,
-            toBlock: 'latest'
-        })
-    ).map((log) => contract.interface.parseLog(log).values);
+export interface IBlockchainEvent {
+    transactionHash: string;
+    blockHash: string;
+    values: any;
+    name?: string;
+    timestamp?: number;
+}
+
+export const getEventsFromContract = async (
+    contract: Contract,
+    eventFilter: EventFilter
+): Promise<IBlockchainEvent[]> => {
+    const logs = await contract.provider.getLogs({
+        ...eventFilter,
+        fromBlock: 0,
+        toBlock: 'latest'
+    });
+
+    return logs.map((log) => ({
+        values: contract.interface.parseLog(log).values,
+        blockHash: log.blockHash,
+        transactionHash: log.transactionHash
+    }));
 };


### PR DESCRIPTION
Fixes an issue where Certificate creation time would always show the current timestamp instead of the block timestamp.

This happened because `undefined` would be forwarded to the `registry.provider.getBlock()` function and always cause to return the latest block timestamp.