### PR TITLE
chore: migrate ethers.js to version 5.x

### DIFF
--- a/packages/device-registry/package.json
+++ b/packages/device-registry/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@energyweb/origin-backend-core": "4.2.0",
         "@energyweb/utils-general": "9.1.5",
-        "ethers": "4.0.47",
+        "ethers": "5.0.7",
         "moment": "2.24.0",
         "winston": "3.3.3"
     },

--- a/packages/device-registry/src/test/DeviceFacade.test.ts
+++ b/packages/device-registry/src/test/DeviceFacade.test.ts
@@ -2,14 +2,13 @@
 import 'mocha';
 import { assert } from 'chai';
 import moment from 'moment';
-import { providers, Wallet } from 'ethers';
+import { providers, Wallet, BigNumber } from 'ethers';
 import dotenv from 'dotenv';
 
 import { Configuration } from '@energyweb/utils-general';
 import { OffChainDataSourceMock } from '@energyweb/origin-backend-client-mocks';
 import { DeviceStatus, IDevice } from '@energyweb/origin-backend-core';
 
-import { bigNumberify } from 'ethers/utils';
 import { ProducingDevice } from '..';
 import { logger } from '../Logger';
 
@@ -109,8 +108,8 @@ describe('Device Facade', () => {
             it('should correctly return reads', async () => {
                 let device = await new ProducingDevice.Entity(1, conf).sync();
                 await device.saveSmartMeterReads([
-                    { meterReading: bigNumberify(100), timestamp: SM_READ_TIMESTAMP },
-                    { meterReading: bigNumberify(300), timestamp: SM_READ_TIMESTAMP + 1 }
+                    { meterReading: BigNumber.from(100), timestamp: SM_READ_TIMESTAMP },
+                    { meterReading: BigNumber.from(300), timestamp: SM_READ_TIMESTAMP + 1 }
                 ]);
 
                 device = await device.sync();
@@ -118,22 +117,22 @@ describe('Device Facade', () => {
                 const reads = await device.getSmartMeterReads();
 
                 assert.deepOwnInclude(reads[0], {
-                    meterReading: bigNumberify(100),
+                    meterReading: BigNumber.from(100),
                     timestamp: SM_READ_TIMESTAMP
                 });
                 assert.deepOwnInclude(reads[1], {
-                    meterReading: bigNumberify(300),
+                    meterReading: BigNumber.from(300),
                     timestamp: SM_READ_TIMESTAMP + 1
                 });
 
                 const energyGenerated = await device.getAmountOfEnergyGenerated();
                 assert.deepOwnInclude(energyGenerated[0], {
-                    energy: bigNumberify(100),
+                    energy: BigNumber.from(100),
                     timestamp: SM_READ_TIMESTAMP
                 });
 
                 assert.deepOwnInclude(energyGenerated[1], {
-                    energy: bigNumberify(200),
+                    energy: BigNumber.from(200),
                     timestamp: SM_READ_TIMESTAMP + 1
                 });
             });

--- a/packages/exchange-token-account/package.json
+++ b/packages/exchange-token-account/package.json
@@ -29,17 +29,17 @@
         "test": "truffle test",
         "test:concurrent": "concurrently --success first --kill-others -n eth,test \"yarn start-ganache\"  \"wait-on tcp:8570 && yarn test\"",
         "clean": "shx rm -rf build dist src/ethers",
-        "typechain:ethers": "typechain --target ethers --outDir src/ethers './build/contracts/TokenAccount.json'"
+        "typechain:ethers": "typechain --target ethers-v5 --outDir src/ethers './build/contracts/TokenAccount.json'"
     },
     "types": "dist/js/src/index.d.ts",
     "dependencies": {
-        "ethers": "4.0.47"
+        "ethers": "5.0.7"
     },
     "devDependencies": {
         "@energyweb/issuer": "2.4.1",
+        "@typechain/ethers-v5": "0.0.3",
         "truffle-typings": "1.0.8",
-        "typechain": "2.0.0",
-        "typechain-target-ethers": "1.0.4"
+        "typechain": "2.0.0"
     },
     "gitHead": "54beaf7fe6686810de74ca290daf99cbde510f9d",
     "publishConfig": {

--- a/packages/exchange-token-account/package.json
+++ b/packages/exchange-token-account/package.json
@@ -33,6 +33,7 @@
     },
     "types": "dist/js/src/index.d.ts",
     "dependencies": {
+        "chai": "4.2.0",
         "ethers": "5.0.7"
     },
     "devDependencies": {

--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -57,7 +57,7 @@
         "bn.js": "^5.1.1",
         "class-transformer": "0.2.3",
         "class-validator": "0.12.2",
-        "ethers": "4.0.47",
+        "ethers": "5.0.7",
         "immutable": "4.0.0-rc.12",
         "moment": "2.24.0",
         "moment-range": "4.0.2",

--- a/packages/exchange/src/pods/deposit-watcher/deposit-watcher.service.ts
+++ b/packages/exchange/src/pods/deposit-watcher/deposit-watcher.service.ts
@@ -73,7 +73,7 @@ export class DepositWatcherService implements OnModuleInit {
 
         this.issuer = new Contract(issuer, Contracts.IssuerJSON.abi, this.provider);
         const topics = [
-            this.tokenInterface.getEventTopic(this.tokenInterface.events.TransferSingle)
+            this.tokenInterface.getEventTopic(this.tokenInterface.getEvent('TransferSingle'))
         ];
         const blockNumber = await this.transferService.getLastConfirmationBlock();
 
@@ -157,9 +157,9 @@ export class DepositWatcherService implements OnModuleInit {
     }
 
     private async decodeDataField(certificateId: string) {
-        const { data } = await this.registry.functions.getCertificate(certificateId);
+        const { data } = await this.registry.getCertificate(certificateId);
 
-        const result = await this.issuer.functions.decodeData(data);
+        const result = await this.issuer.decodeData(data);
 
         return {
             generationFrom: moment.unix(result[0]).toDate(),

--- a/packages/exchange/src/pods/withdrawal-processor/withdrawal-processor.service.ts
+++ b/packages/exchange/src/pods/withdrawal-processor/withdrawal-processor.service.ts
@@ -130,12 +130,12 @@ export class WithdrawalProcessorService implements OnModuleInit {
             );
             return;
         }
-        const transaction = (await this.registry.functions.safeTransferFrom(
+        const transaction = (await this.registry.safeTransferFrom(
             this.wallet.address,
             withdrawal.address,
             withdrawal.asset.tokenId,
             withdrawal.amount,
-            '0x0' // TODO: consider putting withdrawal id for tracking
+            '0x00' // TODO: consider putting withdrawal id for tracking
         )) as ContractTransaction;
 
         await this.transferService.setAsUnconfirmed(id, transaction.hash);
@@ -165,7 +165,9 @@ export class WithdrawalProcessorService implements OnModuleInit {
     private hasMatchingLog(withdrawal: Transfer, log: ethers.utils.Result) {
         const _to = String(log._to).toLowerCase();
         const _from = String(log._from).toLowerCase();
-        const _topic = this.tokenInterface.getEventTopic(this.tokenInterface.events.TransferSingle);
+        const _topic = this.tokenInterface.getEventTopic(
+            this.tokenInterface.getEvent('TransferSingle')
+        );
 
         return (
             log.topic === _topic &&

--- a/packages/exchange/test/deposits-withdrawals.e2e-spec.ts
+++ b/packages/exchange/test/deposits-withdrawals.e2e-spec.ts
@@ -57,9 +57,8 @@ describe('Deposits using deployed registry', () => {
     const generationFrom = moment('2020-01-01').unix();
     const generationTo = moment('2020-01-31').unix();
 
-    const getBalance = async (address: string, id: number) => {
-        return (await registry.functions.balanceOf(address, id)) as ethers.utils.BigNumber;
-    };
+    const getBalance = async (address: string, id: number): Promise<ethers.BigNumber> =>
+        registry.functions.balanceOf(address, id);
 
     it('should be able to discover token deposit and post the ask', async () => {
         const depositAmount = '10';

--- a/packages/exchange/test/deposits-withdrawals.e2e-spec.ts
+++ b/packages/exchange/test/deposits-withdrawals.e2e-spec.ts
@@ -58,7 +58,7 @@ describe('Deposits using deployed registry', () => {
     const generationTo = moment('2020-01-31').unix();
 
     const getBalance = async (address: string, id: number): Promise<ethers.BigNumber> =>
-        registry.functions.balanceOf(address, id);
+        registry.balanceOf(address, id);
 
     it('should be able to discover token deposit and post the ask', async () => {
         const depositAmount = '10';

--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -43,7 +43,6 @@ const deployContract = async ({ abi, bytecode }: { abi: any; bytecode: string })
 
 const deployRegistry = async () => {
     const contract = await deployContract(Contracts.RegistryJSON);
-    await contract.functions.initialize();
 
     return contract;
 };
@@ -52,7 +51,7 @@ const deployIssuer = async (registry: string) => {
     const contract = await deployContract(Contracts.IssuerJSON);
     const wallet = new ethers.Wallet(registryDeployer);
 
-    await contract.functions.initialize(100, registry, wallet.address);
+    await contract.init(100, registry, wallet.address);
 
     return contract;
 };

--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -51,7 +51,7 @@ const deployIssuer = async (registry: string) => {
     const contract = await deployContract(Contracts.IssuerJSON);
     const wallet = new ethers.Wallet(registryDeployer);
 
-    await contract.init(100, registry, wallet.address);
+    await contract['initialize(int256,address,address)'](100, registry, wallet.address);
 
     return contract;
 };

--- a/packages/exchange/test/utils.ts
+++ b/packages/exchange/test/utils.ts
@@ -22,11 +22,14 @@ export const issueToken = async (
         false
     )) as ContractTransaction).wait();
 
-    const {
-        values: { _id: requestId }
-    } = registryInterface.parseLog(requestReceipt.logs[0]);
+    const [log] = requestReceipt.logs;
 
-    const validityData = registryInterface.functions.isRequestValid.encode([requestId.toString()]);
+    const { name } = registryInterface.parseLog(log);
+    const { _id: requestId } = registryInterface.decodeEventLog(name, log.data, log.topics);
+
+    const validityData = registryInterface.encodeFunctionData('isRequestValid', [
+        requestId.toString()
+    ]);
 
     const approvalReceipt = await ((await issuer.approveCertificationRequest(
         requestId,

--- a/packages/exchange/test/utils.ts
+++ b/packages/exchange/test/utils.ts
@@ -51,13 +51,7 @@ export const depositToken = async (
 ) => {
     const registryWithUserAsSigner = registry.connect(sender);
 
-    await registryWithUserAsSigner.functions.safeTransferFrom(
-        sender.address,
-        to,
-        id,
-        amount,
-        '0x0'
-    );
+    await registryWithUserAsSigner.safeTransferFrom(sender.address, to, id, amount, '0x00');
 };
 
 export const provider = new ethers.providers.JsonRpcProvider(web3);

--- a/packages/issuer/contracts/Issuer.sol
+++ b/packages/issuer/contracts/Issuer.sol
@@ -60,9 +60,9 @@ contract Issuer is Initializable, Ownable {
 		bytes32 hash;
 	}
 
-    function init(int _certificateTopic, address _registry, address _owner) public initializer {
-        require(_registry != address(0), "init: Cannot use address 0x0 as registry address.");
-        require(_owner != address(0), "init: Cannot use address 0x0 as the owner.");
+    function initialize(int _certificateTopic, address _registry, address _owner) public initializer {
+        require(_registry != address(0), "initialize: Cannot use address 0x0 as registry address.");
+        require(_owner != address(0), "initialize: Cannot use address 0x0 as the owner.");
 
         certificateTopic = _certificateTopic;
 

--- a/packages/issuer/contracts/Issuer.sol
+++ b/packages/issuer/contracts/Issuer.sol
@@ -60,9 +60,9 @@ contract Issuer is Initializable, Ownable {
 		bytes32 hash;
 	}
 
-    function initialize(int _certificateTopic, address _registry, address _owner) public initializer {
-        require(_registry != address(0), "initialize: Cannot use address 0x0 as registry address.");
-        require(_owner != address(0), "initialize: Cannot use address 0x0 as the owner.");
+    function init(int _certificateTopic, address _registry, address _owner) public initializer {
+        require(_registry != address(0), "init: Cannot use address 0x0 as registry address.");
+        require(_owner != address(0), "init: Cannot use address 0x0 as the owner.");
 
         certificateTopic = _certificateTopic;
 

--- a/packages/issuer/package.json
+++ b/packages/issuer/package.json
@@ -51,7 +51,7 @@
         "mocha": "8.0.1",
         "moment": "2.24.0",
         "polly-js": "1.6.7",
-        "precise-proofs-js": "1.1.0",
+        "precise-proofs-js": "1.2.0",
         "winston": "3.3.3"
     },
     "devDependencies": {

--- a/packages/issuer/package.json
+++ b/packages/issuer/package.json
@@ -26,8 +26,8 @@
         "build:static": "yarn compile && yarn typechain:registry && yarn typechain:issuer",
         "build:ts": "tsc -b tsconfig.json && yarn copy:declarations",
         "copy:declarations": "shx cp src/ethers/*.d.ts dist/js/src/ethers",
-        "typechain:registry": "typechain --target ethers --outDir src/ethers './build/contracts/Registry.json'",
-        "typechain:issuer": "typechain --target ethers --outDir src/ethers './build/contracts/Issuer.json'",
+        "typechain:registry": "typechain --target ethers-v5 --outDir src/ethers './build/contracts/Registry.json'",
+        "typechain:issuer": "typechain --target ethers-v5 --outDir src/ethers './build/contracts/Issuer.json'",
         "clean": "shx rm -rf dist dist-shakeable build src/ethers",
         "compile": "truffle compile",
         "deploy-contracts": "truffle migrate",
@@ -47,7 +47,7 @@
         "@energyweb/utils-general": "9.1.5",
         "chai": "4.2.0",
         "dotenv": "8.2.0",
-        "ethers": "4.0.47",
+        "ethers": "5.0.7",
         "mocha": "8.0.1",
         "moment": "2.24.0",
         "polly-js": "1.6.7",
@@ -55,11 +55,11 @@
         "winston": "3.3.3"
     },
     "devDependencies": {
+        "@typechain/ethers-v5": "0.0.3",
         "ethlint": "1.2.5",
         "ganache-cli": "6.5.1",
         "truffle-typings": "1.0.8",
-        "typechain": "2.0.0",
-        "typechain-target-ethers": "1.0.4"
+        "typechain": "2.0.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/issuer/src/blockchain-facade/CertificationRequest.ts
+++ b/packages/issuer/src/blockchain-facade/CertificationRequest.ts
@@ -96,8 +96,13 @@ export class CertificationRequest extends PreciseProofEntity implements ICertifi
             events: [certificationRequested]
         } = await tx.wait();
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const id = (certificationRequested.args as any)._id.toNumber();
+        const log = issuer.interface.decodeEventLog(
+            certificationRequested.event,
+            certificationRequested.data,
+            certificationRequested.topics
+        );
+
+        const id = log._id.toNumber();
 
         if (configuration.logger) {
             configuration.logger.info(`CertificationRequest ${id} created.`);

--- a/packages/issuer/src/blockchain-facade/CertificationRequest.ts
+++ b/packages/issuer/src/blockchain-facade/CertificationRequest.ts
@@ -1,5 +1,4 @@
-import { BigNumber, Interface } from 'ethers/utils';
-import { Event as BlockchainEvent } from 'ethers';
+import { ethers, Event as BlockchainEvent, BigNumber } from 'ethers';
 import polly from 'polly-js';
 
 import { Configuration, Timestamp } from '@energyweb/utils-general';
@@ -14,7 +13,6 @@ import { PreciseProofEntity } from './PreciseProofEntity';
 import { Issuer } from '../ethers/Issuer';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Registry } from '../ethers/Registry';
-import { IssuerJSON } from '../contracts';
 
 export class CertificationRequest extends PreciseProofEntity implements ICertificationRequest {
     owner: string;
@@ -142,13 +140,16 @@ export class CertificationRequest extends PreciseProofEntity implements ICertifi
     }
 
     async approve(): Promise<number> {
-        const issuerInterface = new Interface(IssuerJSON.abi);
-        const validityData = issuerInterface.functions.isRequestValid.encode([this.id.toString()]);
-
         let approveTx;
         const { issuer } = this.configuration
             .blockchainProperties as Configuration.BlockchainProperties<Registry, Issuer>;
+
+        const validityData = issuer.interface.encodeFunctionData('isRequestValid', [
+            this.id.toString()
+        ]);
+
         const issuerWithSigner = issuer.connect(this.configuration.blockchainProperties.activeUser);
+
         if (this.isPrivate) {
             const commitment: IOwnershipCommitment = {
                 [this.owner]: this.energy
@@ -178,15 +179,17 @@ export class CertificationRequest extends PreciseProofEntity implements ICertifi
         return certificateId;
     }
 
-    async revoke() {
+    async revoke(): Promise<ethers.ContractTransaction> {
         const { issuer } = this.configuration
             .blockchainProperties as Configuration.BlockchainProperties<Registry, Issuer>;
         const issuerWithSigner = issuer.connect(this.configuration.blockchainProperties.activeUser);
         const revokeTx = await issuerWithSigner.revokeRequest(this.id);
         await revokeTx.wait();
+
+        return revokeTx;
     }
 
-    async requestMigrateToPublic(value: BigNumber) {
+    async requestMigrateToPublic(value: BigNumber): Promise<ethers.ContractTransaction> {
         if (!this.isPrivate) {
             throw new Error('Certificate is already public.');
         }

--- a/packages/issuer/src/migrate.ts
+++ b/packages/issuer/src/migrate.ts
@@ -19,11 +19,7 @@ export async function migrateIssuer(
     const issuerContract = await new factories.IssuerFactory(wallet).deploy();
     await issuerContract.deployed();
 
-    const tx = await issuerContract.initialize(
-        CertificateTopic.IREC,
-        registryAddress,
-        wallet.address
-    );
+    const tx = await issuerContract.init(CertificateTopic.IREC, registryAddress, wallet.address);
     await tx.wait();
 
     const version = await issuerContract.version();
@@ -43,9 +39,6 @@ export async function migrateRegistry(
 
     const registryContract = await new factories.RegistryFactory(wallet).deploy();
     await registryContract.deployed();
-
-    const tx = await registryContract.initialize();
-    await tx.wait();
 
     console.log(`Registry created at ${registryContract.address}`);
 

--- a/packages/issuer/src/migrate.ts
+++ b/packages/issuer/src/migrate.ts
@@ -19,7 +19,11 @@ export async function migrateIssuer(
     const issuerContract = await new factories.IssuerFactory(wallet).deploy();
     await issuerContract.deployed();
 
-    const tx = await issuerContract.init(CertificateTopic.IREC, registryAddress, wallet.address);
+    const tx = await issuerContract['initialize(int256,address,address)'](
+        CertificateTopic.IREC,
+        registryAddress,
+        wallet.address
+    );
     await tx.wait();
 
     const version = await issuerContract.version();

--- a/packages/issuer/src/test/Certificate.test.ts
+++ b/packages/issuer/src/test/Certificate.test.ts
@@ -2,8 +2,7 @@ import { assert } from 'chai';
 import dotenv from 'dotenv';
 import 'mocha';
 import moment from 'moment';
-import { providers, Wallet } from 'ethers';
-import { BigNumber } from 'ethers/utils';
+import { providers, Wallet, BigNumber } from 'ethers';
 
 import { Configuration } from '@energyweb/utils-general';
 import { OffChainDataSourceMock } from '@energyweb/origin-backend-client-mocks';
@@ -91,7 +90,7 @@ describe('Certificate tests', () => {
     });
 
     it('gets all certificates', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
 
         await issueCertificate(totalVolume, deviceOwnerWallet.address);
         await issueCertificate(totalVolume, deviceOwnerWallet.address);
@@ -101,7 +100,7 @@ describe('Certificate tests', () => {
     });
 
     it('gets all owned certificates', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
 
         await issueCertificate(totalVolume, deviceOwnerWallet.address);
         await issueCertificate(totalVolume, traderWallet.address);
@@ -117,7 +116,7 @@ describe('Certificate tests', () => {
     });
 
     it('issuer issues a certificate', async () => {
-        const volume = new BigNumber(1e9);
+        const volume = BigNumber.from(1e9);
         let certificate = await issueCertificate(volume, deviceOwnerWallet.address);
 
         assert.isNotNull(certificate.id);
@@ -140,7 +139,7 @@ describe('Certificate tests', () => {
     });
 
     it('transfers a certificate', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(deviceOwnerWallet);
@@ -166,7 +165,7 @@ describe('Certificate tests', () => {
     });
 
     it('transfers a private certificate', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address, true);
 
         setActiveUser(deviceOwnerWallet);
@@ -199,7 +198,7 @@ describe('Certificate tests', () => {
     });
 
     it('partially transfers a private certificate', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
         const partialVolumeToSend = totalVolume.div(4);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address, true);
 
@@ -236,7 +235,7 @@ describe('Certificate tests', () => {
     });
 
     it('fails transferring a revoked certificate', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(issuerWallet);
@@ -258,7 +257,7 @@ describe('Certificate tests', () => {
     });
 
     it('fails claiming a revoked certificate', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(issuerWallet);
@@ -280,7 +279,7 @@ describe('Certificate tests', () => {
     });
 
     it('claims a certificate', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(deviceOwnerWallet);
@@ -312,7 +311,7 @@ describe('Certificate tests', () => {
     });
 
     it('partially claims a certificate', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(deviceOwnerWallet);
@@ -330,7 +329,7 @@ describe('Certificate tests', () => {
     });
 
     it('claims a certificate with empty beneficiary', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
 
         setActiveUser(deviceOwnerWallet);
@@ -348,7 +347,7 @@ describe('Certificate tests', () => {
     });
 
     it('claims a private certificate', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address, true);
 
         setActiveUser(deviceOwnerWallet);
@@ -381,7 +380,7 @@ describe('Certificate tests', () => {
     });
 
     it('claims a partial private certificate', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
         const partialVolumeToClaim = totalVolume.div(4);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address, true);
 
@@ -428,7 +427,7 @@ describe('Certificate tests', () => {
     });
 
     it('batch transfers certificates', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
 
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
         let certificate2 = await issueCertificate(totalVolume, deviceOwnerWallet.address);
@@ -468,7 +467,7 @@ describe('Certificate tests', () => {
     });
 
     it('batch claims certificates', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
 
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address);
         let certificate2 = await issueCertificate(totalVolume, deviceOwnerWallet.address);

--- a/packages/issuer/src/test/Certificate.test.ts
+++ b/packages/issuer/src/test/Certificate.test.ts
@@ -346,7 +346,7 @@ describe('Certificate tests', () => {
         );
     });
 
-    it('claims a private certificate', async () => {
+    xit('claims a private certificate', async () => {
         const totalVolume = BigNumber.from(1e9);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address, true);
 
@@ -379,7 +379,7 @@ describe('Certificate tests', () => {
         );
     });
 
-    it('claims a partial private certificate', async () => {
+    xit('claims a partial private certificate', async () => {
         const totalVolume = BigNumber.from(1e9);
         const partialVolumeToClaim = totalVolume.div(4);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address, true);

--- a/packages/issuer/src/test/Certificate.test.ts
+++ b/packages/issuer/src/test/Certificate.test.ts
@@ -346,7 +346,7 @@ describe('Certificate tests', () => {
         );
     });
 
-    xit('claims a private certificate', async () => {
+    it('claims a private certificate', async () => {
         const totalVolume = BigNumber.from(1e9);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address, true);
 
@@ -379,7 +379,7 @@ describe('Certificate tests', () => {
         );
     });
 
-    xit('claims a partial private certificate', async () => {
+    it('claims a partial private certificate', async () => {
         const totalVolume = BigNumber.from(1e9);
         const partialVolumeToClaim = totalVolume.div(4);
         let certificate = await issueCertificate(totalVolume, deviceOwnerWallet.address, true);

--- a/packages/issuer/src/test/Issuer.test.ts
+++ b/packages/issuer/src/test/Issuer.test.ts
@@ -2,12 +2,11 @@ import { assert } from 'chai';
 import dotenv from 'dotenv';
 import 'mocha';
 import moment from 'moment';
-import { BigNumber } from 'ethers/utils';
 
 import { Configuration } from '@energyweb/utils-general';
 import { OffChainDataSourceMock } from '@energyweb/origin-backend-client-mocks';
 
-import { providers, Wallet } from 'ethers';
+import { providers, Wallet, BigNumber } from 'ethers';
 import { migrateIssuer, migrateRegistry } from '../migrate';
 import { CertificationRequest } from '..';
 
@@ -97,7 +96,7 @@ describe('Issuer', () => {
     });
 
     it('gets all certification requests', async () => {
-        const totalVolume = new BigNumber(1e9);
+        const totalVolume = BigNumber.from(1e9);
 
         await createCertificationRequest(totalVolume);
         await createCertificationRequest(totalVolume);
@@ -109,7 +108,7 @@ describe('Issuer', () => {
     it('user correctly requests issuance', async () => {
         setActiveUser(deviceOwnerWallet);
 
-        const energy = new BigNumber(1e9);
+        const energy = BigNumber.from(1e9);
         const fromTime = timestamp;
         // Simulate time moving forward 1 month
         timestamp += 30 * 24 * 3600;
@@ -138,7 +137,7 @@ describe('Issuer', () => {
     });
 
     it('issuer correctly approves issuance', async () => {
-        const volume = new BigNumber(1e9);
+        const volume = BigNumber.from(1e9);
         let certificationRequest = await createCertificationRequest(volume);
 
         setActiveUser(issuerWallet);
@@ -166,7 +165,7 @@ describe('Issuer', () => {
     it('user revokes a certificationRequest', async () => {
         setActiveUser(deviceOwnerWallet);
 
-        const volume = new BigNumber(1e9);
+        const volume = BigNumber.from(1e9);
         let certificationRequest = await createCertificationRequest(volume);
 
         certificationRequest = await certificationRequest.sync();
@@ -190,7 +189,7 @@ describe('Issuer', () => {
     it('user shouldnt be able to revoke an approved certificationRequest', async () => {
         setActiveUser(deviceOwnerWallet);
 
-        const volume = new BigNumber(1e9);
+        const volume = BigNumber.from(1e9);
         let certificationRequest = await createCertificationRequest(volume);
 
         setActiveUser(issuerWallet);
@@ -231,12 +230,12 @@ describe('Issuer', () => {
         const toTime = timestamp;
         const device = '1';
 
-        await createCertificationRequest(new BigNumber(1e9), false, fromTime, toTime, device);
+        await createCertificationRequest(BigNumber.from(1e9), false, fromTime, toTime, device);
 
         let failed = false;
 
         try {
-            await createCertificationRequest(new BigNumber(1e9), false, fromTime, toTime, device);
+            await createCertificationRequest(BigNumber.from(1e9), false, fromTime, toTime, device);
         } catch (e) {
             failed = true;
         }
@@ -252,7 +251,7 @@ describe('Issuer', () => {
         timestamp += 30 * 24 * 3600;
         const toTime = timestamp;
         const device = '1';
-        const volume = new BigNumber(1e9);
+        const volume = BigNumber.from(1e9);
 
         let certificationRequest = await createCertificationRequest(
             volume,
@@ -287,7 +286,7 @@ describe('Issuer', () => {
     });
 
     it('user correctly requests private issuance', async () => {
-        const volume = new BigNumber(1e9);
+        const volume = BigNumber.from(1e9);
         const certificationRequest = await createCertificationRequest(volume, true);
 
         assert.isAbove(Number(certificationRequest.id), -1);
@@ -302,7 +301,7 @@ describe('Issuer', () => {
     });
 
     it('issuer correctly approves private issuance', async () => {
-        const volume = new BigNumber(1e9);
+        const volume = BigNumber.from(1e9);
         let certificationRequest = await createCertificationRequest(volume, true);
 
         setActiveUser(issuerWallet);
@@ -335,7 +334,7 @@ describe('Issuer', () => {
         timestamp += 30 * 24 * 3600;
         const toTime = timestamp;
         const device = '1';
-        const volume = new BigNumber(1e9);
+        const volume = BigNumber.from(1e9);
 
         const certificationRequest = await createCertificationRequest(
             volume,

--- a/packages/issuer/src/utils/events.ts
+++ b/packages/issuer/src/utils/events.ts
@@ -3,9 +3,9 @@ import { Contract, EventFilter } from 'ethers';
 export interface IBlockchainEvent {
     transactionHash: string;
     blockHash: string;
-    values: any;
     name?: string;
     timestamp?: number;
+    [key: string]: any;
 }
 
 export const getEventsFromContract = async (
@@ -18,9 +18,15 @@ export const getEventsFromContract = async (
         toBlock: 'latest'
     });
 
-    return logs.map((log) => ({
-        values: contract.interface.parseLog(log).values,
-        blockHash: log.blockHash,
-        transactionHash: log.transactionHash
-    }));
+    const parsedLogs = logs.map((log) => {
+        const { name } = contract.interface.parseLog(log);
+
+        return {
+            ...contract.interface.decodeEventLog(name, log.data, log.topics),
+            blockHash: log.blockHash,
+            transactionHash: log.transactionHash
+        };
+    });
+
+    return parsedLogs;
 };

--- a/packages/origin-backend-client/package.json
+++ b/packages/origin-backend-client/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@energyweb/origin-backend-core": "4.2.0",
         "axios": "0.19.2",
-        "ethers": "4.0.47",
+        "ethers": "5.0.7",
         "moment": "2.24.0"
     },
     "files": [

--- a/packages/origin-backend-client/src/CertificateClient.ts
+++ b/packages/origin-backend-client/src/CertificateClient.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-classes-per-file */
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import {
     ICertificationRequest,
     CertificationRequestUpdateData,
@@ -94,7 +94,7 @@ export class CertificateClient implements ICertificateClient {
         return {
             id,
             ...data,
-            energy: bigNumberify(data.energy),
+            energy: BigNumber.from(data.energy),
             deviceId: data.device.id.toString(),
             approvedDate: data.approvedDate ? new Date(data.approvedDate) : null,
             revokedDate: data.revokedDate ? new Date(data.revokedDate) : null
@@ -109,7 +109,7 @@ export class CertificateClient implements ICertificateClient {
         return data.map((certReq) => {
             return {
                 ...certReq,
-                energy: bigNumberify(certReq.energy),
+                energy: BigNumber.from(certReq.energy),
                 deviceId: certReq.device.id.toString(),
                 approvedDate: certReq.approvedDate ? new Date(certReq.approvedDate) : null,
                 revokedDate: certReq.revokedDate ? new Date(certReq.revokedDate) : null

--- a/packages/origin-backend-client/src/DeviceClient.ts
+++ b/packages/origin-backend-client/src/DeviceClient.ts
@@ -9,7 +9,7 @@ import {
     ISmartMeterReadWithStatus,
     ISuccessResponse
 } from '@energyweb/origin-backend-core';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import { IRequestClient, RequestClient } from './RequestClient';
 
 export interface IDeviceClient {
@@ -87,7 +87,7 @@ export class DeviceClient implements IDeviceClient {
         const meterReadingsFormatted: ISmartMeterReadWithStatus[] = response.data.map(
             (read: ISmartMeterReadWithStatus) => ({
                 ...read,
-                meterReading: bigNumberify(read.meterReading)
+                meterReading: BigNumber.from(read.meterReading)
             })
         );
 
@@ -114,8 +114,8 @@ export class DeviceClient implements IDeviceClient {
             cleanDevice = {
                 ...cleanDevice,
                 meterStats: {
-                    certified: bigNumberify(device.meterStats.certified),
-                    uncertified: bigNumberify(device.meterStats.uncertified)
+                    certified: BigNumber.from(device.meterStats.certified),
+                    uncertified: BigNumber.from(device.meterStats.uncertified)
                 }
             };
         }
@@ -125,7 +125,7 @@ export class DeviceClient implements IDeviceClient {
                 ...cleanDevice,
                 smartMeterReads: device.smartMeterReads.map((smRead) => ({
                     ...smRead,
-                    meterReading: bigNumberify(smRead.meterReading)
+                    meterReading: BigNumber.from(smRead.meterReading)
                 }))
             };
         }

--- a/packages/origin-backend-core/package.json
+++ b/packages/origin-backend-core/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "class-transformer": "0.2.3",
         "class-validator": "0.12.2",
-        "ethers": "4.0.47",
+        "ethers": "5.0.7",
         "precise-proofs-js": "1.1.0"
     }
 }

--- a/packages/origin-backend-core/package.json
+++ b/packages/origin-backend-core/package.json
@@ -31,6 +31,6 @@
         "class-transformer": "0.2.3",
         "class-validator": "0.12.2",
         "ethers": "5.0.7",
-        "precise-proofs-js": "1.1.0"
+        "precise-proofs-js": "1.2.0"
     }
 }

--- a/packages/origin-backend-core/src/CertificationRequest.ts
+++ b/packages/origin-backend-core/src/CertificationRequest.ts
@@ -1,8 +1,8 @@
-import { BigNumber, bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import { IDevice } from '.';
 
 // Maximum number Solidity can handle is (2^256)-1
-export const MAX_ENERGY_PER_CERTIFICATE = bigNumberify(2).pow(256).sub(1);
+export const MAX_ENERGY_PER_CERTIFICATE = BigNumber.from(2).pow(256).sub(1);
 
 export interface ICertificationRequestMinimal {
     id: number;

--- a/packages/origin-backend-core/src/Device.ts
+++ b/packages/origin-backend-core/src/Device.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import { IOrganization } from '.';
 
 export enum DeviceStatus {

--- a/packages/origin-backend-core/src/OwnershipCommitment.ts
+++ b/packages/origin-backend-core/src/OwnershipCommitment.ts
@@ -1,5 +1,5 @@
 import { PreciseProofs } from 'precise-proofs-js';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 
 export interface IOwnershipCommitment {
     [address: string]: BigNumber;

--- a/packages/origin-backend/package.json
+++ b/packages/origin-backend/package.json
@@ -58,7 +58,7 @@
         "class-validator": "0.12.2",
         "cors": "2.8.5",
         "dotenv": "8.2.0",
-        "ethers": "4.0.47",
+        "ethers": "5.0.7",
         "express": "4.17.1",
         "jsonwebtoken": "8.5.1",
         "moment": "2.24.0",

--- a/packages/origin-backend/package.json
+++ b/packages/origin-backend/package.json
@@ -68,7 +68,7 @@
         "passport": "0.4.1",
         "passport-jwt": "4.0.0",
         "passport-local": "1.0.0",
-        "precise-proofs-js": "^1.0.2",
+        "precise-proofs-js": "1.2.0",
         "reflect-metadata": "0.1.13",
         "rxjs": "6.6.0",
         "typeorm": "0.2.25",

--- a/packages/origin-backend/src/pods/certificate/certificate-watcher.service.ts
+++ b/packages/origin-backend/src/pods/certificate/certificate-watcher.service.ts
@@ -2,30 +2,23 @@ import { Contracts } from '@energyweb/issuer';
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ModuleRef } from '@nestjs/core';
-import { ethers } from 'ethers';
-import { Log } from 'ethers/providers';
+import { ethers, providers, Contract } from 'ethers';
 
 import { ConfigurationService } from '../configuration';
-import { DeviceService } from '../device/device.service';
 import { CertificateService } from './certificate.service';
-import { UserService } from '../user';
 
 @Injectable()
 export class CertificationWatcherService implements OnModuleInit {
     private readonly logger = new Logger(CertificationWatcherService.name);
 
-    private issuerInterface: ethers.utils.Interface;
+    private provider: providers.JsonRpcProvider;
 
-    private provider: ethers.providers.JsonRpcProvider;
-
-    private issuer: ethers.Contract;
+    private issuer: Contract;
 
     public constructor(
         private readonly configService: ConfigService,
         private readonly moduleRef: ModuleRef,
-        private readonly certificateService: CertificateService,
-        private readonly deviceService: DeviceService,
-        private readonly userService: UserService
+        private readonly certificateService: CertificateService
     ) {}
 
     public async onModuleInit() {
@@ -48,42 +41,44 @@ export class CertificationWatcherService implements OnModuleInit {
             return;
         }
 
-        this.issuerInterface = new ethers.utils.Interface(Contracts.IssuerJSON.abi);
-
         const web3ProviderUrl = this.configService.get<string>('WEB3');
-        this.provider = new ethers.providers.JsonRpcProvider(web3ProviderUrl);
+        this.provider = new providers.JsonRpcProvider(web3ProviderUrl);
 
         this.issuer = new ethers.Contract(issuer, Contracts.IssuerJSON.abi, this.provider);
 
-        this.provider.on(this.issuer.filters.PrivateTransferRequested(null, null), (event: Log) =>
-            this.registerPrivateTransferRequest(event)
+        this.provider.on(
+            this.issuer.filters.PrivateTransferRequested(null, null),
+            (event: providers.Log) => this.registerPrivateTransferRequest(event)
         );
 
-        this.provider.on(this.issuer.filters.MigrateToPublicRequested(null, null), (event: Log) =>
-            this.registerMigrationRequest(event)
+        this.provider.on(
+            this.issuer.filters.MigrateToPublicRequested(null, null),
+            (event: providers.Log) => this.registerMigrationRequest(event)
         );
     }
 
-    private async registerPrivateTransferRequest(event: Log): Promise<void> {
+    private async registerPrivateTransferRequest(event: providers.Log): Promise<void> {
         this.logger.debug(`Discovered new event ${JSON.stringify(event)}`);
 
-        const log = this.issuerInterface.parseLog(event);
+        const { name } = this.issuer.interface.parseLog(event);
+        const log = this.issuer.interface.decodeEventLog(name, event.data, event.topics);
 
         this.logger.debug(`Parsed to ${JSON.stringify(log)}`);
 
-        const { _certificateId } = log.values;
+        const { _certificateId } = log;
 
         await this.certificateService.approvePrivateTransfer(_certificateId.toNumber());
     }
 
-    private async registerMigrationRequest(event: Log): Promise<void> {
+    private async registerMigrationRequest(event: providers.Log): Promise<void> {
         this.logger.debug(`Discovered new event ${JSON.stringify(event)}`);
 
-        const log = this.issuerInterface.parseLog(event);
+        const { name } = this.issuer.interface.parseLog(event);
+        const log = this.issuer.interface.decodeEventLog(name, event.data, event.topics);
 
         this.logger.debug(`Parsed to ${JSON.stringify(log)}`);
 
-        const { _id } = log.values;
+        const { _id } = log;
 
         await this.certificateService.migrateToPublic(_id.toNumber());
     }

--- a/packages/origin-backend/src/pods/certificate/certificate.service.ts
+++ b/packages/origin-backend/src/pods/certificate/certificate.service.ts
@@ -1,6 +1,4 @@
-import { ContractTransaction, Contract, Wallet } from 'ethers';
-import { JsonRpcProvider } from 'ethers/providers';
-import { getAddress } from 'ethers/utils';
+import { ethers } from 'ethers';
 import {
     Injectable,
     NotFoundException,
@@ -143,7 +141,7 @@ export class CertificateService {
         });
     }
 
-    async migrateToPublic(certificateId: number): Promise<ContractTransaction> {
+    async migrateToPublic(certificateId: number): Promise<ethers.Transaction> {
         const certificate = await this.get(certificateId);
 
         const {
@@ -151,7 +149,7 @@ export class CertificateService {
         } = await this.configurationService.get();
 
         try {
-            getAddress(issuerContractAddress);
+            ethers.utils.getAddress(issuerContractAddress);
         } catch (e) {
             this.logger.error(
                 `Issuer address "${issuerContractAddress}" is not a contract address. Unable to initialize.`
@@ -160,11 +158,15 @@ export class CertificateService {
         }
 
         const web3ProviderUrl = this.configService.get<string>('WEB3');
-        const provider = new JsonRpcProvider(web3ProviderUrl);
+        const provider = new ethers.providers.JsonRpcProvider(web3ProviderUrl);
 
-        const backendWallet = new Wallet(this.configService.get<string>('DEPLOY_KEY'));
+        const backendWallet = new ethers.Wallet(this.configService.get<string>('DEPLOY_KEY'));
 
-        const issuer = new Contract(issuerContractAddress, Contracts.IssuerJSON.abi, provider);
+        const issuer = new ethers.Contract(
+            issuerContractAddress,
+            Contracts.IssuerJSON.abi,
+            provider
+        );
         const issuerWithSigner = issuer.connect(backendWallet);
 
         const migrationRequestId = await issuerWithSigner.getMigrationRequestId(certificateId);
@@ -205,7 +207,7 @@ export class CertificateService {
         await tx.wait();
     }
 
-    async approvePrivateTransfer(certificateId: number): Promise<ContractTransaction> {
+    async approvePrivateTransfer(certificateId: number): Promise<ethers.Transaction> {
         const certificate = await this.get(certificateId);
 
         const {
@@ -213,7 +215,7 @@ export class CertificateService {
         } = await this.configurationService.get();
 
         try {
-            getAddress(issuerContractAddress);
+            ethers.utils.getAddress(issuerContractAddress);
         } catch (e) {
             this.logger.error(
                 `Issuer address "${issuerContractAddress}" is not a contract address. Unable to initialize.`
@@ -222,11 +224,15 @@ export class CertificateService {
         }
 
         const web3ProviderUrl = this.configService.get<string>('WEB3');
-        const provider = new JsonRpcProvider(web3ProviderUrl);
+        const provider = new ethers.providers.JsonRpcProvider(web3ProviderUrl);
 
-        const backendWallet = new Wallet(this.configService.get<string>('DEPLOY_KEY'));
+        const backendWallet = new ethers.Wallet(this.configService.get<string>('DEPLOY_KEY'));
 
-        const issuer = new Contract(issuerContractAddress, Contracts.IssuerJSON.abi, provider);
+        const issuer = new ethers.Contract(
+            issuerContractAddress,
+            Contracts.IssuerJSON.abi,
+            provider
+        );
         const issuerWithSigner = issuer.connect(backendWallet);
 
         const { commitment: previousCommitment } = certificate.currentOwnershipCommitment;

--- a/packages/origin-backend/src/pods/device/device.service.ts
+++ b/packages/origin-backend/src/pods/device/device.service.ts
@@ -27,7 +27,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { validate } from 'class-validator';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import moment from 'moment';
 import { FindOneOptions, Repository } from 'typeorm';
 import { v4 as uuid } from 'uuid';
@@ -341,8 +341,8 @@ export class DeviceService {
             const { meterReading, timestamp, certified } = smReads[i];
 
             energiesGenerated.push({
-                energy: bigNumberify(meterReading).sub(
-                    isFirstReading ? 0 : bigNumberify(smReads[i - 1].meterReading)
+                energy: BigNumber.from(meterReading).sub(
+                    isFirstReading ? 0 : BigNumber.from(smReads[i - 1].meterReading)
                 ),
                 timestamp,
                 certified
@@ -350,7 +350,7 @@ export class DeviceService {
         }
 
         const sumEnergy = (energyGens: IEnergyGeneratedWithStatus[]) =>
-            energyGens.reduce((sum, energyGen) => sum.add(energyGen.energy), bigNumberify(0));
+            energyGens.reduce((sum, energyGen) => sum.add(energyGen.energy), BigNumber.from(0));
 
         return {
             certified: sumEnergy(energiesGenerated.filter((energyGen) => energyGen.certified)),

--- a/packages/origin-backend/src/utils/positiveBNStringValidator.ts
+++ b/packages/origin-backend/src/utils/positiveBNStringValidator.ts
@@ -1,12 +1,12 @@
 import { ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
-import { bigNumberify, BigNumber } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 
 @ValidatorConstraint()
 export class PositiveBNStringValidator implements ValidatorConstraintInterface {
     validate(text: string) {
         try {
-            const bn = new BigNumber(text);
-            return bn.gt(bigNumberify(0));
+            const bn = BigNumber.from(text);
+            return bn.gt(0);
         } catch (e) {
             return false;
         }

--- a/packages/origin-backend/test/certificate.e2e-spec.ts
+++ b/packages/origin-backend/test/certificate.e2e-spec.ts
@@ -2,7 +2,7 @@
 import { CommitmentStatus, Role } from '@energyweb/origin-backend-core';
 import { INestApplication } from '@nestjs/common';
 import { expect } from 'chai';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import request from 'supertest';
 
 import { CertificateService } from '../src/pods/certificate/certificate.service';
@@ -18,7 +18,7 @@ describe('Certificate e2e tests', () => {
 
     const generateCommitment = (requestor: string) => ({
         commitment: {
-            [requestor]: bigNumberify(1000)
+            [requestor]: BigNumber.from(1000)
         },
         rootHash: '0x4d66a6a59ac48f27a549982a5db8a7292bc0ed64d40e12f8b83db32d54c4137f',
         leafs: [

--- a/packages/origin-backend/test/device.e2e-spec.ts
+++ b/packages/origin-backend/test/device.e2e-spec.ts
@@ -7,7 +7,7 @@ import {
     ILoggedInUser
 } from '@energyweb/origin-backend-core';
 import { expect } from 'chai';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import moment from 'moment';
 import request from 'supertest';
 import dotenv from 'dotenv';
@@ -192,8 +192,8 @@ describe('Device e2e tests', () => {
             .expect((res) => {
                 const resultDevice = res.body as IDeviceWithRelationsIds;
 
-                expect(bigNumberify(resultDevice.meterStats.certified).toNumber()).equals(0);
-                expect(bigNumberify(resultDevice.meterStats.uncertified).toNumber()).equals(0);
+                expect(BigNumber.from(resultDevice.meterStats.certified).toNumber()).equals(0);
+                expect(BigNumber.from(resultDevice.meterStats.uncertified).toNumber()).equals(0);
             });
 
         const now = moment();
@@ -254,7 +254,7 @@ describe('Device e2e tests', () => {
                 const resultDevice = res.body as IDeviceWithRelationsIds;
 
                 expect(
-                    bigNumberify(resultDevice.meterStats.certified).toNumber()
+                    BigNumber.from(resultDevice.meterStats.certified).toNumber()
                 ).to.be.greaterThan(0);
             });
     });

--- a/packages/origin-ui-core/package.json
+++ b/packages/origin-ui-core/package.json
@@ -46,7 +46,7 @@
         "chart.js": "2.9.3",
         "clsx": "1.1.1",
         "connected-react-router": "6.8.0",
-        "ethers": "4.0.47",
+        "ethers": "5.0.7",
         "extract-text-webpack-plugin": "4.0.0-beta.0",
         "file-loader": "6.0.0",
         "formik": "2.1.5",

--- a/packages/origin-ui-core/src/__tests__/unit/ProducingDeviceTable.test.tsx
+++ b/packages/origin-ui-core/src/__tests__/unit/ProducingDeviceTable.test.tsx
@@ -13,7 +13,7 @@ import { IOffChainDataSource } from '@energyweb/origin-backend-client';
 import { configurationUpdated } from '../../features';
 import { Configuration, DeviceTypeService } from '@energyweb/utils-general';
 import { OffChainDataSourceMock } from '@energyweb/origin-backend-client-mocks';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 
 describe('ProducingDeviceTable', () => {
     it('correctly renders and search works', async () => {
@@ -33,8 +33,8 @@ describe('ProducingDeviceTable', () => {
             id: 0,
             status: DeviceStatus.Active,
             meterStats: {
-                uncertified: bigNumberify(7777),
-                certified: bigNumberify(0)
+                uncertified: BigNumber.from(7777),
+                certified: BigNumber.from(0)
             }
         });
 

--- a/packages/origin-ui-core/src/__tests__/unit/SmartMeterReadingsChart.test.tsx
+++ b/packages/origin-ui-core/src/__tests__/unit/SmartMeterReadingsChart.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import { SmartMeterReadingsChart } from '../../components/SmartMeterReadingsChart';
 import { ProducingDevice } from '@energyweb/device-registry';
 import { Bar } from 'react-chartjs-2';
@@ -26,7 +26,7 @@ describe('SmartMeterReadingsChart', () => {
 
         const reads: IEnergyGenerated[] = [
             {
-                energy: bigNumberify(1000),
+                energy: BigNumber.from(1000),
                 timestamp: currentTime.unix()
             }
         ];

--- a/packages/origin-ui-core/src/__tests__/utils/helpers.tsx
+++ b/packages/origin-ui-core/src/__tests__/utils/helpers.tsx
@@ -23,9 +23,8 @@ import {
     initializeI18N
 } from '../../components';
 import { IDevice, DeviceStatus, ISmartMeterReadStats } from '@energyweb/origin-backend-core';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber, Signer } from 'ethers';
 import { ICertificate, Certificate } from '@energyweb/issuer';
-import { Signer } from 'ethers';
 
 export const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -269,8 +268,8 @@ export const createProducingDevice = (
 ): ProducingDevice.Entity => {
     const owner = properties.owner || '0x0';
     const meterStats = properties.meterStats ?? {
-        certified: bigNumberify(0),
-        uncertified: bigNumberify(0)
+        certified: BigNumber.from(0),
+        uncertified: BigNumber.from(0)
     };
 
     const offChainProperties = {

--- a/packages/origin-ui-core/src/components/CertificateDetailView.tsx
+++ b/packages/origin-ui-core/src/components/CertificateDetailView.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { CertificationRequest, CertificateUtils } from '@energyweb/issuer';
 import { ProducingDeviceDetailView } from './ProducingDeviceDetailView';
 import { useSelector } from 'react-redux';
-import { getAddress } from 'ethers/utils';
+import { utils } from 'ethers';
 import { getConfiguration, getProducingDevices } from '../features/selectors';
 import { getCertificates } from '../features/certificates/selectors';
 import { deduplicate } from '../utils/helper';
@@ -62,7 +62,7 @@ export function CertificateDetailView(props: IProps) {
         const { issuer, registry } = configuration.blockchainProperties;
 
         const transformAddress = (address: string) => {
-            switch (getAddress(address)) {
+            switch (utils.getAddress(address)) {
                 case environment.EXCHANGE_WALLET_PUB:
                     return t('certificate.event.participants.exchange.wallet');
                 case exchangeDepositAddress:
@@ -254,7 +254,8 @@ export function CertificateDetailView(props: IProps) {
 
         if (selectedCertificate.isClaimed) {
             const claimData = selectedCertificate.claims.find(
-                (claim) => getAddress(claim.to) === getAddress(user.blockchainAccountAddress)
+                (claim) =>
+                    utils.getAddress(claim.to) === utils.getAddress(user.blockchainAccountAddress)
             )?.claimData;
 
             const claimInfo = [

--- a/packages/origin-ui-core/src/components/CertificateTable.tsx
+++ b/packages/origin-ui-core/src/components/CertificateTable.tsx
@@ -3,7 +3,7 @@ import { AssignmentTurnedIn, Publish, Undo, BusinessCenter } from '@material-ui/
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Redirect } from 'react-router-dom';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import { getConfiguration, getProducingDevices } from '../features/selectors';
 import {
     EnergyFormatter,
@@ -354,7 +354,7 @@ export function CertificateTable(props: IProps) {
                 const { publicVolume, privateVolume } = b.energy;
                 const totalOwned = publicVolume.add(privateVolume);
                 return a.add(totalOwned);
-            }, bigNumberify(0));
+            }, BigNumber.from(0));
 
             return `${t('certificate.feedback.amountSelected', {
                 amount: selectedIndexes.length

--- a/packages/origin-ui-core/src/components/Modal/ClaimModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/ClaimModal.tsx
@@ -13,7 +13,7 @@ import {
     Select,
     TextField
 } from '@material-ui/core';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Countries } from '@energyweb/utils-general';
@@ -38,7 +38,7 @@ export function ClaimModal(props: IProps) {
     const { certificates, callback, showModal } = props;
 
     const environment: IEnvironment = useSelector(getEnvironment);
-    const DEFAULT_ENERGY_IN_BASE_UNIT = bigNumberify(
+    const DEFAULT_ENERGY_IN_BASE_UNIT = BigNumber.from(
         Number(environment?.DEFAULT_ENERGY_IN_BASE_UNIT || 1)
     );
 
@@ -155,7 +155,7 @@ export function ClaimModal(props: IProps) {
         props.certificates.reduce((a, b) => {
             const energy = b.energy.publicVolume.add(b.energy.privateVolume);
             return a.add(energy);
-        }, bigNumberify(0)),
+        }, BigNumber.from(0)),
         true
     );
 

--- a/packages/origin-ui-core/src/components/Modal/DepositModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/DepositModal.tsx
@@ -7,7 +7,7 @@ import {
     DialogTitle,
     TextField
 } from '@material-ui/core';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import moment from 'moment';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -30,7 +30,7 @@ export function DepositModal(props: IProps) {
     const { certificate, callback, producingDevice, showModal } = props;
     const user = useSelector(getUserOffchain);
     const environment: IEnvironment = useSelector(getEnvironment);
-    const DEFAULT_ENERGY_IN_BASE_UNIT = bigNumberify(
+    const DEFAULT_ENERGY_IN_BASE_UNIT = BigNumber.from(
         Number(environment?.DEFAULT_ENERGY_IN_BASE_UNIT || 1)
     );
     const [energyInDisplayUnit, setEnergyInDisplayUnit] = useState(

--- a/packages/origin-ui-core/src/components/Modal/PublishForSaleModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/PublishForSaleModal.tsx
@@ -12,7 +12,7 @@ import {
     Select,
     TextField
 } from '@material-ui/core';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import moment from 'moment';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -39,7 +39,7 @@ export function PublishForSaleModal(props: IProps) {
     const user = useSelector(getUserOffchain);
     const environment: IEnvironment = useSelector(getEnvironment);
 
-    const DEFAULT_ENERGY_IN_BASE_UNIT = bigNumberify(
+    const DEFAULT_ENERGY_IN_BASE_UNIT = BigNumber.from(
         Number(environment?.DEFAULT_ENERGY_IN_BASE_UNIT || 1)
     );
     const [energyInDisplayUnit, setEnergyInDisplayUnit] = useState(

--- a/packages/origin-ui-core/src/components/Modal/WithdrawModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/WithdrawModal.tsx
@@ -7,7 +7,7 @@ import {
     DialogTitle,
     TextField
 } from '@material-ui/core';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import moment from 'moment';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -30,7 +30,7 @@ export function WithdrawModal(props: IProps) {
     const { certificate, callback, producingDevice, showModal } = props;
     const user = useSelector(getUserOffchain);
     const environment: IEnvironment = useSelector(getEnvironment);
-    const DEFAULT_ENERGY_IN_BASE_UNIT = bigNumberify(
+    const DEFAULT_ENERGY_IN_BASE_UNIT = BigNumber.from(
         Number(environment?.DEFAULT_ENERGY_IN_BASE_UNIT || 1)
     );
     const [energyInDisplayUnit, setEnergyInDisplayUnit] = useState(

--- a/packages/origin-ui-core/src/components/SmartMeterReadingsChart.tsx
+++ b/packages/origin-ui-core/src/components/SmartMeterReadingsChart.tsx
@@ -7,7 +7,7 @@ import { reverse } from '../utils/helper';
 import { EnergyFormatter } from '../utils/EnergyFormatter';
 import { useOriginConfiguration } from '../utils/configuration';
 import { useTranslation } from 'react-i18next';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 
 enum TIMEFRAME {
     DAY = 'Day',
@@ -139,7 +139,7 @@ export function SmartMeterReadingsChart(props: ISmartMeterReadingsChartProps) {
                 .subtract(currentIndex, measurementUnit)
                 .tz(producingDevice.timezone);
 
-            let totalEnergy = bigNumberify(0);
+            let totalEnergy = BigNumber.from(0);
 
             for (const reading of readings) {
                 const readingDate = moment.unix(reading.timestamp).tz(producingDevice.timezone);

--- a/packages/origin-ui-core/src/components/SmartMeterReadingsTable.tsx
+++ b/packages/origin-ui-core/src/components/SmartMeterReadingsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import moment from 'moment-timezone';
 import { ProducingDevice } from '@energyweb/device-registry';
 import { TableMaterial } from './Table/TableMaterial';
@@ -29,7 +29,7 @@ export function SmartMeterReadingsTable(props: IProps) {
         const deviceTimezone = producingDevice.timezone;
 
         const data = [];
-        let currentSmartMeterState = bigNumberify(0);
+        let currentSmartMeterState = BigNumber.from(0);
 
         for (let i = 0; i < readings.length; i++) {
             currentSmartMeterState = currentSmartMeterState.add(readings[i].energy);
@@ -78,7 +78,7 @@ export function SmartMeterReadingsTable(props: IProps) {
 
     const rows = paginatedData.map((data) => ({
         time: data[0],
-        value: EnergyFormatter.format(bigNumberify(data[1]))
+        value: EnergyFormatter.format(BigNumber.from(data[1]))
     }));
 
     return (

--- a/packages/origin-ui-core/src/components/bundles/BundlesTable.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundlesTable.tsx
@@ -25,7 +25,7 @@ import { Fab, Tooltip } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import { showBundleDetails, cancelBundle, storeBundle } from '../../features/bundles';
 import { BundleBought } from '../Modal/BundleBought';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 
 const BUNDLES_PER_PAGE = 25;
 const BUNDLES_TOTAL_ENERGY_COLUMN_ID = 'total';
@@ -102,8 +102,8 @@ export const BundlesTable = (props: IOwnProps) => {
         const bundle = bundles.find((b) => b.id === bundleId);
         const { splits } = await exchangeClient.getBundleSplits(bundle);
         bundle.splits = splits.map((s) => ({
-            volume: new BigNumber(s.volume),
-            items: s.items.map(({ id, volume }) => ({ id, volume: new BigNumber(volume) }))
+            volume: BigNumber.from(s.volume),
+            items: s.items.map(({ id, volume }) => ({ id, volume: BigNumber.from(volume) }))
         }));
         dispatch(storeBundle(bundle));
         if (splits.length === 0) {

--- a/packages/origin-ui-core/src/components/bundles/CreateBundleForm.tsx
+++ b/packages/origin-ui-core/src/components/bundles/CreateBundleForm.tsx
@@ -3,7 +3,7 @@ import { Box } from '@material-ui/core';
 import { Certificates } from './Certificates';
 import { SelectedForSale } from './SelectedForSale';
 import { ICertificateViewItem } from '../../features/certificates';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import { useHistory } from 'react-router-dom';
 import { useLinks } from '../../utils';
 
@@ -16,7 +16,7 @@ export const CreateBundleForm = () => {
         return selected.reduce(
             (total, { energy: { publicVolume, privateVolume } }) =>
                 total.add(publicVolume).add(privateVolume),
-            new BigNumber(0)
+            BigNumber.from(0)
         );
     };
 

--- a/packages/origin-ui-core/src/components/bundles/SelectedForSale.tsx
+++ b/packages/origin-ui-core/src/components/bundles/SelectedForSale.tsx
@@ -22,7 +22,7 @@ import {
     getCurrencies
 } from '../..';
 import { useSelector, useDispatch } from 'react-redux';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import { formatCurrencyComplete, useTranslation, EnergyFormatter, EnergyTypes } from '../../utils';
 import { createBundle } from '../../features/bundles';
 import { BundleItemDTO } from '../../utils/exchange';

--- a/packages/origin-ui-core/src/features/certificates/actions.ts
+++ b/packages/origin-ui-core/src/features/certificates/actions.ts
@@ -1,6 +1,6 @@
 import { ProducingDevice } from '@energyweb/device-registry';
 import { Certificate, CertificationRequest, IClaimData } from '@energyweb/issuer';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 
 import { ICertificateViewItem, CertificateSource } from '.';
 import { IStoreState } from '../../types';

--- a/packages/origin-ui-core/src/features/general/sagas.ts
+++ b/packages/origin-ui-core/src/features/general/sagas.ts
@@ -32,7 +32,7 @@ import {
     UsersActions,
     ISetActiveBlockchainAccountAddressAction
 } from '../users/actions';
-import { ethers } from 'ethers';
+import { ethers, BigNumber } from 'ethers';
 import { getSearch, push } from 'connected-react-router';
 import { getConfiguration, getBaseURL } from '../selectors';
 import * as queryString from 'query-string';
@@ -48,7 +48,6 @@ import {
     updateCertificate
 } from '../certificates/actions';
 import { IStoreState } from '../../types';
-import { BigNumber } from 'ethers/utils';
 import { getI18n } from 'react-i18next';
 import { showNotification, NotificationType, getDevicesOwnedLink } from '../../utils';
 import { ICertificateViewItem, CertificateSource } from '../certificates';
@@ -332,9 +331,9 @@ export function enhanceCertificate(
     return {
         ...onChainCertificate,
         energy: {
-            publicVolume: new BigNumber(amount),
-            privateVolume: new BigNumber(0),
-            claimedVolume: new BigNumber(0)
+            publicVolume: BigNumber.from(amount),
+            privateVolume: BigNumber.from(0),
+            claimedVolume: BigNumber.from(0)
         },
         source: CertificateSource.Exchange,
         assetId: asset.id
@@ -363,17 +362,17 @@ export function* fetchBundles() {
     for (const bundle of bundles) {
         bundle.own = ownBundles.find((b) => b.id === bundle.id) !== undefined;
         bundle.items.forEach((item) => {
-            item.currentVolume = new BigNumber(item.currentVolume.toString());
-            item.startVolume = new BigNumber(item.startVolume.toString());
+            item.currentVolume = BigNumber.from(item.currentVolume.toString());
+            item.startVolume = BigNumber.from(item.startVolume.toString());
         });
         if (
             bundle.items
-                .reduce((total, item) => total.add(item.currentVolume), new BigNumber(0))
+                .reduce((total, item) => total.add(item.currentVolume), BigNumber.from(0))
                 .isZero()
         ) {
             continue;
         }
-        bundle.volume = new BigNumber(bundle.volume.toString());
+        bundle.volume = BigNumber.from(bundle.volume.toString());
         yield put(storeBundle(bundle));
     }
 }

--- a/packages/origin-ui-core/src/features/orders/sagas.ts
+++ b/packages/origin-ui-core/src/features/orders/sagas.ts
@@ -3,7 +3,7 @@ import { IExchangeClient, Order } from '../../utils/exchange';
 import { getExchangeClient } from '..';
 import { SagaIterator } from 'redux-saga';
 import { clearOrders, storeOrder, OrdersActionsType } from './actions';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import { showNotification, NotificationType } from '../..';
 import { getI18n } from 'react-i18next';
 import { reloadCertificates } from '../certificates';
@@ -15,8 +15,8 @@ export function* fetchOrders(): SagaIterator {
     for (const order of orders) {
         const { startVolume, currentVolume } = order;
         const filled =
-            new BigNumber(startVolume)
-                .sub(new BigNumber(currentVolume))
+            BigNumber.from(startVolume)
+                .sub(BigNumber.from(currentVolume))
                 .mul(100)
                 .div(startVolume)
                 .toNumber() / 100;

--- a/packages/origin-ui-core/src/utils/EnergyFormatter.ts
+++ b/packages/origin-ui-core/src/utils/EnergyFormatter.ts
@@ -1,5 +1,5 @@
 import { Unit } from '@energyweb/utils-general';
-import { commify, BigNumber, BigNumberish, bigNumberify } from 'ethers/utils';
+import { utils, BigNumber, BigNumberish } from 'ethers';
 
 export class EnergyFormatter {
     public static readonly displayUnit: string = 'MWh';
@@ -7,7 +7,7 @@ export class EnergyFormatter {
     public static readonly decimalPlaces: number = 3;
 
     static getValueInDisplayUnit(baseValue: BigNumberish): number {
-        const bnValue = bigNumberify(baseValue);
+        const bnValue = BigNumber.from(baseValue);
 
         const whole = bnValue.div(Unit[EnergyFormatter.displayUnit]);
         const mod = bnValue.mod(Unit[EnergyFormatter.displayUnit]);
@@ -15,12 +15,12 @@ export class EnergyFormatter {
     }
 
     static getBaseValueFromValueInDisplayUnit(valueInDisplayUnit: number): BigNumber {
-        return bigNumberify(valueInDisplayUnit * Unit[EnergyFormatter.displayUnit]);
+        return BigNumber.from(valueInDisplayUnit * Unit[EnergyFormatter.displayUnit]);
     }
 
     static format(baseValue: BigNumberish, includeDisplayUnit?: boolean): string {
-        const returnValue = bigNumberify(baseValue);
-        return `${commify(EnergyFormatter.getValueInDisplayUnit(returnValue).toString())}${
+        const returnValue = BigNumber.from(baseValue);
+        return `${utils.commify(EnergyFormatter.getValueInDisplayUnit(returnValue).toString())}${
             includeDisplayUnit ? EnergyFormatter.displayUnit : ''
         }`;
     }

--- a/packages/origin-ui-core/src/utils/bundles.ts
+++ b/packages/origin-ui-core/src/utils/bundles.ts
@@ -1,7 +1,7 @@
 import { IEnvironment } from '../features/general';
 import { Bundle } from './exchange';
 import { deviceById, EnergyFormatter } from '.';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import { EnergyTypes } from './device';
 import { Unit } from '@energyweb/utils-general';
 
@@ -21,9 +21,9 @@ export const energyByType = (
             grouped.total = grouped.total.add(item.currentVolume);
             return grouped;
         },
-        types.reduce((acc, type) => ({ ...acc, [type]: new BigNumber(0) }), {
-            total: new BigNumber(0),
-            other: new BigNumber(0)
+        types.reduce((acc, type) => ({ ...acc, [type]: BigNumber.from(0) }), {
+            total: BigNumber.from(0),
+            other: BigNumber.from(0)
         })
     );
 };
@@ -38,7 +38,7 @@ export const energyShares = (
     return Object.fromEntries(
         Object.keys(energy)
             .filter((p) => p !== 'total')
-            .map((p) => [p, energy[p].mul(new BigNumber(10000)).div(energy.total)])
+            .map((p) => [p, energy[p].mul(BigNumber.from(10000)).div(energy.total)])
             .map(([p, v]) => {
                 return [p, `${(v.toNumber() / 100).toFixed(2)}%`];
             })

--- a/packages/origin-ui-core/src/utils/exchange/types.ts
+++ b/packages/origin-ui-core/src/utils/exchange/types.ts
@@ -1,5 +1,5 @@
 import { Filter, Operator, OrderSide, Product, OrderStatus } from '@energyweb/exchange-core';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 
 export type DeviceVintageDTO = {
     year: number;

--- a/packages/solar-simulator/package.json
+++ b/packages/solar-simulator/package.json
@@ -40,7 +40,7 @@
         "cors": "2.8.5",
         "csv-parse": "4.11.1",
         "dotenv": "8.2.0",
-        "ethers": "4.0.47",
+        "ethers": "5.0.7",
         "express": "4.17.1",
         "fs-extra": "9.0.1",
         "geo-tz": "6.0.0",

--- a/packages/solar-simulator/src/consumerService.ts
+++ b/packages/solar-simulator/src/consumerService.ts
@@ -3,8 +3,7 @@ import moment from 'moment-timezone';
 import * as Winston from 'winston';
 import dotenv from 'dotenv';
 import fs from 'fs';
-import { ethers, Wallet } from 'ethers';
-import { bigNumberify, BigNumber } from 'ethers/utils';
+import { ethers, Wallet, BigNumber } from 'ethers';
 
 import { ProducingDevice } from '@energyweb/device-registry';
 import { Configuration } from '@energyweb/utils-general';
@@ -68,7 +67,7 @@ export async function startConsumerService(
         const smartMeterReadings = await device.getSmartMeterReads();
         const latestSmRead = smartMeterReadings[smartMeterReadings.length - 1];
 
-        return latestSmRead?.meterReading ?? bigNumberify(0);
+        return latestSmRead?.meterReading ?? BigNumber.from(0);
     }
 
     async function saveProducingDeviceSmartMeterReads(

--- a/packages/solar-simulator/src/importIRECDevices.ts
+++ b/packages/solar-simulator/src/importIRECDevices.ts
@@ -1,6 +1,6 @@
 import program from 'commander';
 import parse from 'csv-parse/lib/sync';
-import { HDNode, bigNumberify } from 'ethers/utils';
+import { utils, BigNumber } from 'ethers';
 import fs from 'fs';
 import geoTz from 'geo-tz';
 
@@ -10,7 +10,7 @@ const configLocation = 'config/config.json';
 
 let generatedAccountIndex = CONFIG.config.ACCOUNT_GENERATION.startIndex;
 function generateNextAccount() {
-    const node = HDNode.fromMnemonic(CONFIG.config.ACCOUNT_GENERATION.mnemonic);
+    const node = utils.HDNode.fromMnemonic(CONFIG.config.ACCOUNT_GENERATION.mnemonic);
     const wallet = node.derivePath(`m/44'/60'/0'/0/${generatedAccountIndex}`);
 
     generatedAccountIndex++;
@@ -84,7 +84,7 @@ const processDevices = async (parsedContent) => {
                 owner: program.owner || '',
                 operationalSince: new Date(registrationDate).getTime() / 1000,
                 capacityInW: maxCapacity,
-                lastSmartMeterReadWh: bigNumberify(0),
+                lastSmartMeterReadWh: BigNumber.from(0),
                 active: true,
                 country,
                 address,

--- a/packages/solar-simulator/src/utils/Energy.ts
+++ b/packages/solar-simulator/src/utils/Energy.ts
@@ -1,7 +1,7 @@
 import moment from 'moment-timezone';
 import { IEnergyGenerated } from '@energyweb/origin-backend-core';
 
-import { BigNumber, bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers';
 import { IGeneratingDevice } from './GeneratingDevice';
 
 type TableRowType = string[3];
@@ -36,7 +36,7 @@ export function getEnergyFromCSVRows(
         const maxCapacityInDeviceUnit =
             device.maxCapacity * ENERGY_UNIT_TO_RATIO_MAPPING[device.energy_unit];
 
-        return bigNumberify(Math.round(parseFloat(ratio) * maxCapacityInDeviceUnit));
+        return BigNumber.from(Math.round(parseFloat(ratio) * maxCapacityInDeviceUnit));
     }
 
     function checkTimeInBounds(time: moment.Moment) {
@@ -59,7 +59,7 @@ export function getEnergyFromCSVRows(
 
     if (accumulated) {
         parsedRows.push({
-            energy: bigNumberify(0),
+            energy: BigNumber.from(0),
             timestamp: 0
         });
 

--- a/packages/solar-simulator/src/workers/mockReadingsWorker.ts
+++ b/packages/solar-simulator/src/workers/mockReadingsWorker.ts
@@ -8,8 +8,7 @@ import { ProducingDevice } from '@energyweb/device-registry';
 import { Configuration } from '@energyweb/utils-general';
 import { OffChainDataSource } from '@energyweb/origin-backend-client';
 import { ISmartMeterRead } from '@energyweb/origin-backend-core';
-import { bigNumberify, BigNumber } from 'ethers/utils';
-import { Wallet, providers } from 'ethers';
+import { Wallet, providers, BigNumber } from 'ethers';
 
 async function getProducingDeviceSmartMeterRead(
     deviceId: string,
@@ -20,7 +19,7 @@ async function getProducingDeviceSmartMeterRead(
     const smartMeterReadings = await device.getSmartMeterReads();
     const latestSmRead = smartMeterReadings[smartMeterReadings.length - 1];
 
-    return latestSmRead?.meterReading ?? bigNumberify(0);
+    return latestSmRead?.meterReading ?? BigNumber.from(0);
 }
 
 async function saveProducingDeviceSmartMeterReads(
@@ -89,9 +88,7 @@ const currentTime = moment.tz(device.timezone);
         parseInt(process.env.SOLAR_SIMULATOR_PAST_READINGS_MINUTES_INTERVAL, 10) || 15;
 
     let measurementTime = currentTime.clone().subtract(1, 'day').startOf('day');
-    let currentMeterRead: BigNumber = bigNumberify(
-        await getProducingDeviceSmartMeterRead(device.id, conf)
-    );
+    let currentMeterRead = BigNumber.from(await getProducingDeviceSmartMeterRead(device.id, conf));
 
     const allSmartMeterReadings: ISmartMeterRead[] = [];
 
@@ -115,7 +112,7 @@ const currentTime = moment.tz(device.timezone);
             .reduce((a, b) => a + parseFloat(b[1]), 0);
 
         const multiplier = combinedMultiplierForMatchingRows ?? 0;
-        const energyGenerated = bigNumberify(Math.round(device.maxCapacity * multiplier));
+        const energyGenerated = BigNumber.from(Math.round(device.maxCapacity * multiplier));
 
         const isValidMeterReading = energyGenerated.gt(0);
 

--- a/packages/utils-general/package.json
+++ b/packages/utils-general/package.json
@@ -35,7 +35,6 @@
         "ethers": "5.0.7",
         "jsonschema": "1.2.6",
         "moment": "^2.24.0",
-        "precise-proofs-js": "1.1.0",
         "winston": "3.3.3"
     },
     "devDependencies": {

--- a/packages/utils-general/package.json
+++ b/packages/utils-general/package.json
@@ -30,8 +30,9 @@
     "types": "dist/js/src/index.d.ts",
     "dependencies": {
         "@energyweb/origin-backend-client": "6.2.1",
+        "chai": "^4.2.0",
         "eth-sig-util": "2.5.2",
-        "ethers": "4.0.47",
+        "ethers": "5.0.7",
         "jsonschema": "1.2.6",
         "moment": "^2.24.0",
         "precise-proofs-js": "1.1.0",

--- a/packages/utils-general/src/Signing.ts
+++ b/packages/utils-general/src/Signing.ts
@@ -1,5 +1,5 @@
 import ethSigUtil from 'eth-sig-util';
-import { JsonRpcProvider } from 'ethers/providers';
+import { providers } from 'ethers';
 
 const getData = (text: string): ethSigUtil.EIP712TypedData => {
     return {
@@ -19,7 +19,7 @@ const getData = (text: string): ethSigUtil.EIP712TypedData => {
             text
         }
     };
-}
+};
 
 export async function recoverTypedSignatureAddress(text: string, signedMessage: string) {
     return ethSigUtil.recoverTypedSignature({
@@ -31,7 +31,7 @@ export async function recoverTypedSignatureAddress(text: string, signedMessage: 
 export async function signTypedMessage(
     from: string,
     text: string,
-    web3: JsonRpcProvider
+    web3: providers.JsonRpcProvider
 ): Promise<string> {
     return web3.send('eth_signTypedData_v4', [from, JSON.stringify(getData(text))]);
 }
@@ -40,8 +40,5 @@ export async function signTypedMessagePrivateKey(
     privateKey: string,
     text: string
 ): Promise<string> {
-    return ethSigUtil.signTypedData(
-        Buffer.from(privateKey, 'hex'),
-        { data: getData(text) }
-    );
+    return ethSigUtil.signTypedData(Buffer.from(privateKey, 'hex'), { data: getData(text) });
 }

--- a/packages/utils-general/src/TimeSeries.ts
+++ b/packages/utils-general/src/TimeSeries.ts
@@ -11,7 +11,7 @@ export class TS {
         resolution: Resolution,
         value: number
     ): TimeSeries {
-        return [...Array(length).keys()].map(i => ({
+        return [...Array(length).keys()].map((i) => ({
             time: moment
                 .unix(startTimeStamp)
                 .startOf(resolution as moment.unitOfTime.StartOf)
@@ -36,7 +36,7 @@ export class TS {
 
     public static inRange(timeSeries: TimeSeries, startTimeStamp: number, endTimeStamp: number) {
         return timeSeries.filter(
-            timeSeriesElement =>
+            (timeSeriesElement) =>
                 timeSeriesElement.time >= startTimeStamp && timeSeriesElement.time <= endTimeStamp
         );
     }

--- a/packages/utils-general/src/blockchain-facade/Configuration.ts
+++ b/packages/utils-general/src/blockchain-facade/Configuration.ts
@@ -1,6 +1,5 @@
 import * as Winston from 'winston';
-import { Signer } from 'ethers';
-import { JsonRpcProvider } from 'ethers/providers';
+import { Signer, providers } from 'ethers';
 
 import { IOffChainDataSource } from '@energyweb/origin-backend-client';
 import { IDeviceTypeService } from './DeviceTypeService';
@@ -13,7 +12,7 @@ export interface Entity<TRegistry = any, TIssuer = any> {
 }
 
 export interface BlockchainProperties<TRegistry = any, TIssuer = any> {
-    web3?: JsonRpcProvider;
+    web3?: providers.JsonRpcProvider;
     registry?: TRegistry;
     issuer?: TIssuer;
     activeUser?: Signer;

--- a/packages/utils-general/src/blockchain-facade/DeviceTypeService.ts
+++ b/packages/utils-general/src/blockchain-facade/DeviceTypeService.ts
@@ -19,7 +19,7 @@ export class DeviceTypeService implements IDeviceTypeService {
     }
 
     encode(deviceTypes: DecodedDeviceType): EncodedDeviceType {
-        const encoded = deviceTypes.map(group => group.join(';'));
+        const encoded = deviceTypes.map((group) => group.join(';'));
 
         const { areValid, unknown } = this.validate(encoded);
         if (!areValid) {
@@ -35,57 +35,57 @@ export class DeviceTypeService implements IDeviceTypeService {
             throw new Error(`DeviceTypeService::decode Unknown device types ${unknown}`);
         }
 
-        return encodedDeviceType.map(deviceType => deviceType.split(';'));
+        return encodedDeviceType.map((deviceType) => deviceType.split(';'));
     }
 
     filterForHighestSpecificity(types: string[]): string[] {
-        const decodedTypes = types.map(type => [...this.decode([type])[0]]);
+        const decodedTypes = types.map((type) => [...this.decode([type])[0]]);
 
         return this.encode(
             decodedTypes.filter(
-                type =>
+                (type) =>
                     !decodedTypes.some(
-                        nestedType => nestedType[0] === type[0] && type.length < nestedType.length
+                        (nestedType) => nestedType[0] === type[0] && type.length < nestedType.length
                     )
             )
         );
     }
 
     includesDeviceType(checkedType: string, types: string[]): boolean {
-        const highestSpecificityTypes = this.filterForHighestSpecificity(types).map(type => [
+        const highestSpecificityTypes = this.filterForHighestSpecificity(types).map((type) => [
             ...this.decode([type])[0]
         ]);
 
-        return highestSpecificityTypes.some(requestedDeviceType =>
+        return highestSpecificityTypes.some((requestedDeviceType) =>
             checkedType.startsWith(this.encode([requestedDeviceType])[0])
         );
     }
 
     includesSomeDeviceType(checkedTypes: string[], types: string[]): boolean {
-        const highestSpecificityTypes = this.filterForHighestSpecificity(types).map(type => [
+        const highestSpecificityTypes = this.filterForHighestSpecificity(types).map((type) => [
             ...this.decode([type])[0]
         ]);
 
-        return highestSpecificityTypes.some(requestedDeviceType =>
-            checkedTypes.some(checkedType =>
+        return highestSpecificityTypes.some((requestedDeviceType) =>
+            checkedTypes.some((checkedType) =>
                 checkedType.startsWith(this.encode([requestedDeviceType])[0])
             )
         );
     }
 
     validate(deviceTypes: string[]): { areValid: boolean; unknown: string[] } {
-        const encoded: EncodedDeviceType = this.deviceTypes.map(group => group.join(';'));
+        const encoded: EncodedDeviceType = this.deviceTypes.map((group) => group.join(';'));
         const unknown: string[] = [];
 
         const areValid = deviceTypes
-            .map(deviceType => {
+            .map((deviceType) => {
                 const valid = encoded.includes(deviceType);
                 if (!valid) {
                     unknown.push(deviceType);
                 }
                 return valid;
             })
-            .every(deviceType => deviceType);
+            .every((deviceType) => deviceType);
 
         return { areValid, unknown };
     }

--- a/packages/utils-general/src/blockchain-facade/LocationService.ts
+++ b/packages/utils-general/src/blockchain-facade/LocationService.ts
@@ -9,9 +9,9 @@ export class LocationService implements ILocationService {
     public matches(currentLocation: string[], checkedLocation: string) {
         const highestSpecificityTypes = this.filterForHighestSpecificity(
             currentLocation
-        ).map(type => [...this.decode([type])[0]]);
+        ).map((type) => [...this.decode([type])[0]]);
 
-        return highestSpecificityTypes.some(location =>
+        return highestSpecificityTypes.some((location) =>
             checkedLocation.startsWith(this.encode([location])[0])
         );
     }
@@ -19,31 +19,31 @@ export class LocationService implements ILocationService {
     public matchesSome(currentLocation: string[], checkedLocations: string[]) {
         const highestSpecificityTypes = this.filterForHighestSpecificity(
             currentLocation
-        ).map(type => [...this.decode([type])[0]]);
+        ).map((type) => [...this.decode([type])[0]]);
 
-        return highestSpecificityTypes.some(location =>
-            checkedLocations.some(checkedLocation =>
+        return highestSpecificityTypes.some((location) =>
+            checkedLocations.some((checkedLocation) =>
                 checkedLocation.startsWith(this.encode([location])[0])
             )
         );
     }
 
     public encode(decoded: string[][]): string[] {
-        return decoded.map(group => group.join(';'));
+        return decoded.map((group) => group.join(';'));
     }
 
     public decode(encoded: string[]): string[][] {
-        return encoded.map(item => item.split(';'));
+        return encoded.map((item) => item.split(';'));
     }
 
     private filterForHighestSpecificity(types: string[]): string[] {
-        const decodedTypes = types.map(type => [...this.decode([type])[0]]);
+        const decodedTypes = types.map((type) => [...this.decode([type])[0]]);
 
         return this.encode(
             decodedTypes.filter(
-                type =>
+                (type) =>
                     !decodedTypes.some(
-                        nestedType => nestedType[0] === type[0] && type.length < nestedType.length
+                        (nestedType) => nestedType[0] === type[0] && type.length < nestedType.length
                     )
             )
         );

--- a/packages/utils-general/src/extensions/array.extensions.ts
+++ b/packages/utils-general/src/extensions/array.extensions.ts
@@ -1,4 +1,4 @@
-interface ArrayExtended<T> {
+interface IArrayExtended<T> {
     removeLast(): T;
 
     empty(): boolean;
@@ -16,9 +16,9 @@ interface ArrayExtended<T> {
     ifEmpty(action: () => void): T[];
 }
 
-export function extendArray<T>(target: any = Array.prototype): Array<T> & ArrayExtended<T> {
+export function extendArray<T>(target: any = Array.prototype): Array<T> & IArrayExtended<T> {
     // prevent custom methods to be listed in the for.. in statement
-    let methods = [
+    const methods = [
         'removeLast',
         'empty',
         'contains',
@@ -28,36 +28,36 @@ export function extendArray<T>(target: any = Array.prototype): Array<T> & ArrayE
         'ifFound',
         'ifEmpty'
     ];
-    for (let m of methods)
+    for (const m of methods)
         Object.defineProperty(target, m, {
             enumerable: false,
             writable: true
         });
 
     if (!target.removeLast) {
-        target.removeLast = function<T>(): T {
+        target.removeLast = function <T>(): T {
             if (this.length == 0) return null;
-            else if (this.length > 0) {
-                let last = this.splice(this.length - 1, 1);
+            if (this.length > 0) {
+                const last = this.splice(this.length - 1, 1);
                 return last[0];
             }
         };
     }
     if (!target.contains) {
-        target.contains = function<T>(e: T): boolean {
+        target.contains = function <T>(e: T): boolean {
             return this.indexOf(e) >= 0;
         };
     }
     if (!target.empty) {
-        target.empty = function<T>(): boolean {
+        target.empty = function <T>(): boolean {
             return this.length == 0;
         };
     }
     if (!target.findBy) {
-        target.findBy = function<T>(e: Partial<T>): T[] {
+        target.findBy = function <T>(e: Partial<T>): T[] {
             return this.filter((item: T) => {
                 let include = true;
-                for (let k in e) {
+                for (const k in e) {
                     include = include && item[k] == e[k];
                 }
                 return include;
@@ -65,12 +65,12 @@ export function extendArray<T>(target: any = Array.prototype): Array<T> & ArrayE
         };
     }
     if (!target.filterBy) {
-        target.filterBy = function<T>(e: Partial<T>): T[] {
+        target.filterBy = function <T>(e: Partial<T>): T[] {
             return this.findBy(e);
         };
     }
     if (!target.ifFound) {
-        target.ifFound = function<T>(action: (first: T) => void): T[] {
+        target.ifFound = function <T>(action: (first: T) => void): T[] {
             if (this.length > 0) {
                 action(this[0]);
             }
@@ -78,7 +78,7 @@ export function extendArray<T>(target: any = Array.prototype): Array<T> & ArrayE
         };
     }
     if (!target.ifEmpty) {
-        target.ifEmpty = function<T>(action: () => void): T[] {
+        target.ifEmpty = function <T>(action: () => void): T[] {
             if (this.length == 0) {
                 action();
             }
@@ -86,10 +86,10 @@ export function extendArray<T>(target: any = Array.prototype): Array<T> & ArrayE
         };
     }
     if (!target.sortBy) {
-        target.sortBy = function<T>(e: Partial<{ [k in keyof T]: 'asc' | 'desc' }>): T[] {
+        target.sortBy = function <T>(e: Partial<{ [k in keyof T]: 'asc' | 'desc' }>): T[] {
             let key = '';
             let sorting = 1;
-            for (let ekey in e) {
+            for (const ekey in e) {
                 key = ekey;
                 sorting = e[ekey] == 'asc' ? 1 : -1;
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,6 +1339,335 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@ethersproject/abi@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.2.tgz#7fe8f080aa1483fe32cd27bb5b8f2019266af1e2"
+  integrity sha512-Z+5f7xOgtRLu/W2l9Ry5xF7ehh9QVQ0m1vhynmTcS7DMfHgqTd1/PDFC62aw91ZPRCRZsYdZJu8ymokC5e1JSw==
+  dependencies:
+    "@ethersproject/address" "^5.0.0"
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/constants" "^5.0.0"
+    "@ethersproject/hash" "^5.0.0"
+    "@ethersproject/keccak256" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+    "@ethersproject/strings" "^5.0.0"
+
+"@ethersproject/abstract-provider@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.0.2.tgz#9b4e8f4870f0691463e8d5b092c95dd5275c635d"
+  integrity sha512-U1s60+nG02x8FKNMoVNI6MG8SguWCoG9HJtwOqWZ38LBRMsDV4c0w4izKx98kcsN3wXw4U2/YAyJ9LlH7+/hkg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/networks" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+    "@ethersproject/transactions" "^5.0.0"
+    "@ethersproject/web" "^5.0.0"
+
+"@ethersproject/abstract-signer@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.0.2.tgz#5776f888fda816de1d08ddb0e74778ecb9590f69"
+  integrity sha512-CzzXbeqKlgayE4YTnvvreGBG3n+HxakGXrxaGM6LjBZnOOIVSYi6HMFG8ZXls7UspRY4hvMrtnKEJKDCOngSBw==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.0.0"
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+
+"@ethersproject/address@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.0.2.tgz#80d0ddfb7d4bd0d32657747fa4bdd2defef2e00a"
+  integrity sha512-+rz26RKj7ujGfQynys4V9VJRbR+wpC6eL8F22q3raWMH3152Ha31GwJPWzxE/bEA+43M/zTNVwY0R53gn53L2Q==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/keccak256" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/rlp" "^5.0.0"
+    bn.js "^4.4.0"
+
+"@ethersproject/base64@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.0.2.tgz#48b3bb8d640a963bd8ee196cfeacd592155a0ca8"
+  integrity sha512-0FE5RH5cUDddOiQEDpWtyHjkSW4D5/rdJzA3KTZo8Fk5ab/Y8vdzqbamsXPyPsXU3gS+zCE5Qq4EKVOWlWLLTA==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+
+"@ethersproject/basex@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.0.2.tgz#13029ce0ad63674f4d4dbebf6763181fb22f0e6d"
+  integrity sha512-p4m2CeQqI9vma3XipRbP2iDf6zTsbroE0MEXBAYXidsoJQSvePKrC6MVRKfTzfcHej1b9wfmjVBzqhqn3FRhIA==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+
+"@ethersproject/bignumber@^5.0.0":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.0.5.tgz#31bd7e75aad46ace345fae69b1f5bb120906af1b"
+  integrity sha512-24ln7PV0g8ZzjcVZiLW9Wod0i+XCmK6zKkAaxw5enraTIT1p7gVOcSXFSzNQ9WYAwtiFQPvvA+TIO2oEITZNJA==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    bn.js "^4.4.0"
+
+"@ethersproject/bytes@^5.0.0":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.0.3.tgz#b3769963ae0188a35713d343890a903bda20af9c"
+  integrity sha512-AyPMAlY+Amaw4Zfp8OAivm1xYPI8mqiUYmEnSUk1CnS2NrQGHEMmFJFiOJdS3gDDpgSOFhWIjZwxKq2VZpqNTA==
+  dependencies:
+    "@ethersproject/logger" "^5.0.0"
+
+"@ethersproject/constants@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.0.2.tgz#f7ac0b320e2bbec1a5950da075015f8bc4e8fed1"
+  integrity sha512-nNoVlNP6bgpog7pQ2EyD1xjlaXcy1Cl4kK5v1KoskHj58EtB6TK8M8AFGi3GgHTdMldfT4eN3OsoQ/CdOTVNFA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.0"
+
+"@ethersproject/contracts@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.0.2.tgz#f19ed8335ceeb6abb60f5d45641f0a2a62b6fbc5"
+  integrity sha512-Ud3oW8mBNIWE+WHRjvwVEwfvshn7lfYWSSKG0fPSb6baRN9mLOoNguX+VIv3W5Sne9w2utnBmxLF2ESXitw64A==
+  dependencies:
+    "@ethersproject/abi" "^5.0.0"
+    "@ethersproject/abstract-provider" "^5.0.0"
+    "@ethersproject/abstract-signer" "^5.0.0"
+    "@ethersproject/address" "^5.0.0"
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/constants" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+
+"@ethersproject/hash@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.0.2.tgz#6d69558786961836d530b8b4a8714eac5388aec7"
+  integrity sha512-dWGvNwmVRX2bxoQQ3ciMw46Vzl1nqfL+5R8+2ZxsRXD3Cjgw1dL2mdjJF7xMMWPvPdrlhKXWSK0gb8VLwHZ8Cw==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/keccak256" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/strings" "^5.0.0"
+
+"@ethersproject/hdnode@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.0.2.tgz#c4f2152590a64822d0c0feb90f09cc247af657e0"
+  integrity sha512-QAUI5tfseTFqv00Vnbwzofqse81wN9TaL+x5GufTHIHJXgVdguxU+l39E3VYDCmO+eVAA6RCn5dJgeyra+PU2g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.0.0"
+    "@ethersproject/basex" "^5.0.0"
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/pbkdf2" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+    "@ethersproject/sha2" "^5.0.0"
+    "@ethersproject/signing-key" "^5.0.0"
+    "@ethersproject/strings" "^5.0.0"
+    "@ethersproject/transactions" "^5.0.0"
+    "@ethersproject/wordlists" "^5.0.0"
+
+"@ethersproject/json-wallets@^5.0.0":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.0.3.tgz#072021fe79f69c9ca1300f780abd9b9d0c8ea42e"
+  integrity sha512-VfDXn5ylugkfiM6SrvQfhX9oAHVU5dsNpRw8PjjTCn4k5E2JuVRO5A8sibkYXDhcBmRISZIWqclIxka6FI/chg==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.0.0"
+    "@ethersproject/address" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/hdnode" "^5.0.0"
+    "@ethersproject/keccak256" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/pbkdf2" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+    "@ethersproject/random" "^5.0.0"
+    "@ethersproject/strings" "^5.0.0"
+    "@ethersproject/transactions" "^5.0.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
+"@ethersproject/keccak256@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.0.2.tgz#7ed4a95bb45ee502cf4532223833740a83602797"
+  integrity sha512-MbroXutc0gPNYIrUjS4Aw0lDuXabdzI7+l7elRWr1G6G+W0v00e/3gbikWkCReGtt2Jnt4lQSgnflhDwQGcIhA==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    js-sha3 "0.5.7"
+
+"@ethersproject/logger@^5.0.0":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.0.4.tgz#09fa4765b5691233e3afb6617cb38a700f9dd2e4"
+  integrity sha512-alA2LiAy1LdQ/L1SA9ajUC7MvGAEQLsICEfKK4erX5qhkXE1LwLSPIzobtOWFsMHf2yrXGKBLnnpuVHprI3sAw==
+
+"@ethersproject/networks@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.0.2.tgz#a49e82cf071e3618e87e3c5d69fdbcf54dc6766c"
+  integrity sha512-T7HVd62D4izNU2tDHf6xUDo7k4JOGX4Lk7vDmVcDKrepSWwL2OmGWrqSlkRe2a1Dnz4+1VPE6fb6+KsmSRe82g==
+  dependencies:
+    "@ethersproject/logger" "^5.0.0"
+
+"@ethersproject/pbkdf2@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.0.2.tgz#d12c5f434bbdf6f52401eddb7d753a713dd9e4ea"
+  integrity sha512-OJFxdX/VtGI5M04lAzXKEOb76XBzjCOzGyko3/bMWat3ePAw7RveBOLyhm79SBs2fh21MSYgdG6JScEMHoSImw==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/sha2" "^5.0.0"
+
+"@ethersproject/properties@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.0.2.tgz#2facb62d2f2d968c7b3d0befa5bcc884cc565d3b"
+  integrity sha512-FxAisPGAOACQjMJzewl9OJG6lsGCPTm5vpUMtfeoxzAlAb2lv+kHzQPUh9h4jfAILzE8AR1jgXMzRmlhwyra1Q==
+  dependencies:
+    "@ethersproject/logger" "^5.0.0"
+
+"@ethersproject/providers@^5.0.0":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.0.5.tgz#fa28498ce9683d1d99f6cb11e1a7fe8d4886e0ce"
+  integrity sha512-ZR3yFg/m8qDl7317yXOHE7tKeGfoyZIZ/imhVC4JqAH+SX1rb6bdZcSjhJfet7rLmnJSsnYLTgIiVIT85aVLgg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.0.0"
+    "@ethersproject/abstract-signer" "^5.0.0"
+    "@ethersproject/address" "^5.0.0"
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/constants" "^5.0.0"
+    "@ethersproject/hash" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/networks" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+    "@ethersproject/random" "^5.0.0"
+    "@ethersproject/rlp" "^5.0.0"
+    "@ethersproject/strings" "^5.0.0"
+    "@ethersproject/transactions" "^5.0.0"
+    "@ethersproject/web" "^5.0.0"
+    ws "7.2.3"
+
+"@ethersproject/random@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.0.2.tgz#bb58aca69a85e8de506686117f050d03dac69023"
+  integrity sha512-kLeS+6bwz37WR2zbe69gudyoGVoUzljQO0LhifnATsZ7rW0JZ9Zgt0h5aXY7tqFDo9TvdqeCwUFdp1t3T5Fkhg==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+
+"@ethersproject/rlp@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.0.2.tgz#d6b550a2ac5e484f15f0f63337e522004d2e78cd"
+  integrity sha512-oE0M5jqQ67fi2SuMcrpoewOpEuoXaD8M9JeR9md1bXRMvDYgKXUtDHs22oevpEOdnO2DPIRabp6MVHa4aDuWmw==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+
+"@ethersproject/sha2@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.0.2.tgz#baefc78c071be8729b180759eb29267129314252"
+  integrity sha512-VFl4qSStjQZaygpqoAHswaCY59qBm1Sm0rf8iv0tmgVsRf0pBg2nJaNf9NXXvcuJ9AYPyXl57dN8kozdC4z5Cg==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    hash.js "1.1.3"
+
+"@ethersproject/signing-key@^5.0.0":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.0.3.tgz#adb84360e147bfd336cb2fe114100120732dc10a"
+  integrity sha512-5QPZaBRGCLzfVMbFb3LcVjNR0UbTXnwDHASnQYfbzwUOnFYHKxHsrcbl/5ONGoppgi8yXgOocKqlPCFycJJVWQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+    elliptic "6.5.3"
+
+"@ethersproject/solidity@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.0.2.tgz#431cee341ec51e022bd897b93fef04521f414756"
+  integrity sha512-RygurUe1hPW1LDYAPXy4471AklGWNnxgFWc3YUE6H11gzkit26jr6AyZH4Yyjw38eBBL6j0AOfQzMWm+NhxZ9g==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/keccak256" "^5.0.0"
+    "@ethersproject/sha2" "^5.0.0"
+    "@ethersproject/strings" "^5.0.0"
+
+"@ethersproject/strings@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.0.2.tgz#1753408c3c889813fd0992abd76393e3e47a2619"
+  integrity sha512-oNa+xvSqsFU96ndzog0IBTtsRFGOqGpzrXJ7shXLBT7juVeSEyZA/sYs0DMZB5mJ9FEjHdZKxR/rTyBY91vuXg==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/constants" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+
+"@ethersproject/transactions@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.0.2.tgz#590ede71fc87b45be7bd46002e18ae52246a2347"
+  integrity sha512-jZp0ZbbJlq4JLZY6qoMzNtp2HQsX6USQposi3ns0MPUdn3OdZJBDtrcO15r/2VS5t/K1e1GE5MI1HmMKlcTbbQ==
+  dependencies:
+    "@ethersproject/address" "^5.0.0"
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/constants" "^5.0.0"
+    "@ethersproject/keccak256" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+    "@ethersproject/rlp" "^5.0.0"
+    "@ethersproject/signing-key" "^5.0.0"
+
+"@ethersproject/units@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.0.2.tgz#de1461ff3ad2587e57bf367d056b6b72cfceda78"
+  integrity sha512-PSuzycBA1zmRysTtKtp+XYZ3HIJfbmfRdZchOUxdyeGo5siUi9H6mYQcxdJHv82oKp/FniMj8qS8qtLQThhOEg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/constants" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+
+"@ethersproject/wallet@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.0.2.tgz#714ca8324c1b3b66e51b9b4e0358c882e88caf1d"
+  integrity sha512-gg86ynLV5k5caNnYpJoYc6WyIUHKMTjOITCk5zXGyVbbkXE07y/fGql4A51W0C6mWkeb5Mzz8AKqzHZECdH30w==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.0.0"
+    "@ethersproject/abstract-signer" "^5.0.0"
+    "@ethersproject/address" "^5.0.0"
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/hash" "^5.0.0"
+    "@ethersproject/hdnode" "^5.0.0"
+    "@ethersproject/json-wallets" "^5.0.0"
+    "@ethersproject/keccak256" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+    "@ethersproject/random" "^5.0.0"
+    "@ethersproject/signing-key" "^5.0.0"
+    "@ethersproject/transactions" "^5.0.0"
+    "@ethersproject/wordlists" "^5.0.0"
+
+"@ethersproject/web@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.0.2.tgz#6565b4c4fe2f56de9556d0e9a966c4ccc1b7b7da"
+  integrity sha512-uAlcxdrAWB9PXZlb5NPzbOOt5/m9EJP2c6eLw15/PXPkNNohEIKvdXXOWdcQgTjZ0pcAaD/9mnJ6HXg7NbqXiw==
+  dependencies:
+    "@ethersproject/base64" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+    "@ethersproject/strings" "^5.0.0"
+
+"@ethersproject/wordlists@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.0.2.tgz#eded47314509c8608373fc2b22879ee2b71b7c7c"
+  integrity sha512-6vKDQcjjpnfdSCr0+jNxpFH3ieKxUPkm29tQX2US7a3zT/sJU/BGlKBR7D8oOpwdE0hpkHhJyMlypRBK+A2avA==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/hash" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+    "@ethersproject/strings" "^5.0.0"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"
@@ -3874,6 +4203,13 @@
   integrity sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==
   dependencies:
     "@turf/helpers" "6.x"
+
+"@typechain/ethers-v5@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-0.0.3.tgz#20a9dea64daa6dc39b73dad5d44d3de443ac236f"
+  integrity sha512-Ul8U1pkPj6nafZI3ZbYqndoH6DtCXzX2+clj2olqVZl8fwVPJuJ2Jr7tK3Q+CAH3n6dsZQiEfW7tSkiLOgbNGA==
+  dependencies:
+    ethers "^5.0.2"
 
 "@types/anymatch@*":
   version "1.3.1"
@@ -6906,7 +7242,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chai@4.2.0:
+chai@4.2.0, chai@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
   integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
@@ -8971,6 +9307,19 @@ elliptic@6.5.2:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+elliptic@6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
+
 elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.4.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.1.tgz#c380f5f909bf1b9b4428d028cd18d3b0efd6b52b"
@@ -9796,20 +10145,40 @@ ethers@4.0.0-beta.3:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@4.0.47:
-  version "4.0.47"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.47.tgz#91b9cd80473b1136dd547095ff9171bd1fc68c85"
-  integrity sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==
+ethers@5.0.7, ethers@^5.0.2:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.0.7.tgz#41c3d774e0a57bfde12b0198885789fb41a14976"
+  integrity sha512-1Zu9s+z4BgsDAZcGIYACJdWBB6mVtCCmUonj68Njul7STcSdgwOyj0sCAxCUr2Nsmsamckr4E12q3ecvZPGAUw==
   dependencies:
-    aes-js "3.0.0"
-    bn.js "^4.4.0"
-    elliptic "6.5.2"
-    hash.js "1.1.3"
-    js-sha3 "0.5.7"
-    scrypt-js "2.0.4"
-    setimmediate "1.0.4"
-    uuid "2.0.1"
-    xmlhttprequest "1.8.0"
+    "@ethersproject/abi" "^5.0.0"
+    "@ethersproject/abstract-provider" "^5.0.0"
+    "@ethersproject/abstract-signer" "^5.0.0"
+    "@ethersproject/address" "^5.0.0"
+    "@ethersproject/base64" "^5.0.0"
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/constants" "^5.0.0"
+    "@ethersproject/contracts" "^5.0.0"
+    "@ethersproject/hash" "^5.0.0"
+    "@ethersproject/hdnode" "^5.0.0"
+    "@ethersproject/json-wallets" "^5.0.0"
+    "@ethersproject/keccak256" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/networks" "^5.0.0"
+    "@ethersproject/pbkdf2" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+    "@ethersproject/providers" "^5.0.0"
+    "@ethersproject/random" "^5.0.0"
+    "@ethersproject/rlp" "^5.0.0"
+    "@ethersproject/sha2" "^5.0.0"
+    "@ethersproject/signing-key" "^5.0.0"
+    "@ethersproject/solidity" "^5.0.0"
+    "@ethersproject/strings" "^5.0.0"
+    "@ethersproject/transactions" "^5.0.0"
+    "@ethersproject/units" "^5.0.0"
+    "@ethersproject/wallet" "^5.0.0"
+    "@ethersproject/web" "^5.0.0"
+    "@ethersproject/wordlists" "^5.0.0"
 
 ethers@^4.0.20, ethers@^4.0.32:
   version "4.0.39"
@@ -19216,6 +19585,11 @@ scrypt-js@2.0.4:
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
   integrity sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
 
+scrypt-js@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
+
 "scrypt-shim@github:web3-js/scrypt-shim":
   version "0.1.0"
   resolved "https://codeload.github.com/web3-js/scrypt-shim/tar.gz/be5e616323a8b5e568788bf94d03c1b8410eac54"
@@ -21374,13 +21748,6 @@ type@^2.0.0:
   resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
   integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
 
-typechain-target-ethers@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/typechain-target-ethers/-/typechain-target-ethers-1.0.4.tgz#597d92bb7db66a656126c930db4a0f5be287a37d"
-  integrity sha512-ay4qcan8erubMgBUcMErKplwQXydWCo/mBmrYGfbnnbUYzRe99jGs4uuSEi1JH2jGDtRi1sRDpIW0q9V4fd14A==
-  dependencies:
-    lodash "^4.17.15"
-
 typechain-target-truffle@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/typechain-target-truffle/-/typechain-target-truffle-1.0.2.tgz#52ecbd8b7a854960567ad223660d60fcb42eaa17"
@@ -23488,6 +23855,11 @@ write@1.0.3:
   integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   dependencies:
     mkdirp "^0.5.1"
+
+ws@7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
+  integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
 
 ws@^3.0.0:
   version "3.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4288,13 +4288,6 @@
   resolved "https://registry.yarnpkg.com/@types/bcryptjs/-/bcryptjs-2.4.2.tgz#e3530eac9dd136bfdfb0e43df2c4c5ce1f77dfae"
   integrity sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ==
 
-"@types/bignumber.js@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@types/bignumber.js/-/bignumber.js-5.0.0.tgz#d9f1a378509f3010a3255e9cc822ad0eeb4ab969"
-  integrity sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==
-  dependencies:
-    bignumber.js "*"
-
 "@types/bn.js@^4.11.3", "@types/bn.js@^4.11.4":
   version "4.11.5"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.5.tgz#40e36197433f78f807524ec623afcf0169ac81dc"
@@ -6604,11 +6597,6 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
-bignumber.js@*, bignumber.js@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
-  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
-
 bignumber.js@^7.2.0:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
@@ -6618,6 +6606,11 @@ bignumber.js@^8.0.2:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.1.1.tgz#4b072ae5aea9c20f6730e4e5d529df1271c4d885"
   integrity sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==
+
+bignumber.js@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
+  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
 
 binary-extensions@^1.0.0:
   version "1.13.1"
@@ -6979,7 +6972,7 @@ buffer@^5.0.5, buffer@^5.1.0, buffer@^5.2.1:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
-build@^0.1.4:
+build@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/build/-/build-0.1.4.tgz#707fe026ffceddcacbfdcdf356eafda64f151046"
   integrity sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=
@@ -7760,7 +7753,7 @@ colornames@^1.1.1:
   resolved "https://registry.yarnpkg.com/colornames/-/colornames-1.1.1.tgz#f8889030685c7c4ff9e2a559f5077eb76a816f96"
   integrity sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=
 
-colors@^1.1.2, colors@^1.2.1, colors@^1.4.0:
+colors@1.4.0, colors@^1.1.2, colors@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -9294,19 +9287,6 @@ elliptic@6.3.3:
     hash.js "^1.0.0"
     inherits "^2.0.1"
 
-elliptic@6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
-  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
-  dependencies:
-    bn.js "^4.4.0"
-    brorand "^1.0.1"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.0"
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.0"
-
 elliptic@6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
@@ -10189,21 +10169,6 @@ ethers@^4.0.20, ethers@^4.0.32:
     aes-js "3.0.0"
     bn.js "^4.4.0"
     elliptic "6.3.3"
-    hash.js "1.1.3"
-    js-sha3 "0.5.7"
-    scrypt-js "2.0.4"
-    setimmediate "1.0.4"
-    uuid "2.0.1"
-    xmlhttprequest "1.8.0"
-
-ethers@^4.0.46:
-  version "4.0.46"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.46.tgz#13cd3ed099487f43ece00194b89a8a8781f71507"
-  integrity sha512-/dPMzzpInhtiip4hKFvsDiJKeRk64IhyA+Po7CtNXneQFSOCYXg8eBFt+jXbxUQyApgWnWOtYxWdfn9+CvvxDA==
-  dependencies:
-    aes-js "3.0.0"
-    bn.js "^4.4.0"
-    elliptic "6.5.2"
     hash.js "1.1.3"
     js-sha3 "0.5.7"
     scrypt-js "2.0.4"
@@ -17541,26 +17506,16 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-precise-proofs-js@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/precise-proofs-js/-/precise-proofs-js-1.1.0.tgz#e519f81c4eb288d55274d68267c08aae7c535ad2"
-  integrity sha512-fT/3CBEpR3tcCTR9jzEIrpyK4xrKyCKcvAU5ma73VBhTx/h6hbqZu2wnQ90p0tjYU7oTLCX/Zdqn6Qg7B6+64g==
+precise-proofs-js@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/precise-proofs-js/-/precise-proofs-js-1.2.0.tgz#7027b2b828b22191ca3684085dbb187f0089de54"
+  integrity sha512-epihRcFUK7z4OBvlmk58o285zSi93ZQKY060FRGlscThzwWYn0Q74ff6b1jv5hTe2LR1Pp+OWhX1t4hkOiSpxQ==
   dependencies:
-    build "^0.1.4"
-    colors "^1.4.0"
-    ethers "^4.0.46"
-    treeify "^1.1.0"
-    web3-utils "^1.2.6"
-
-precise-proofs-js@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/precise-proofs-js/-/precise-proofs-js-1.0.2.tgz#6ec496d893ccc0993994904f3e3456510075a699"
-  integrity sha512-4IVlsBs92WjaalqZ70OVE0k31ptJrCjGKDFmgi2cGk90INep/+AsblCMvGCeARC6GMifH587KKdHAZ1+DYzDlg==
-  dependencies:
-    build "^0.1.4"
-    colors "^1.4.0"
-    treeify "^1.1.0"
-    web3 "1.2.4"
+    build "0.1.4"
+    colors "1.4.0"
+    ethers "5.0.7"
+    treeify "1.1.0"
+    web3-utils "1.2.6"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -21443,7 +21398,7 @@ tree-kill@1.2.2, tree-kill@^1.1.0, tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-treeify@^1.1.0:
+treeify@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
   integrity sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==
@@ -22392,16 +22347,6 @@ web3-bzz@1.2.2:
     swarm-js "0.1.39"
     underscore "1.9.1"
 
-web3-bzz@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.2.4.tgz#a4adb7a8cba3d260de649bdb1f14ed359bfb3821"
-  integrity sha512-MqhAo/+0iQSMBtt3/QI1rU83uvF08sYq8r25+OUZ+4VtihnYsmkkca+rdU0QbRyrXY2/yGIpI46PFdh0khD53A==
-  dependencies:
-    "@types/node" "^10.12.18"
-    got "9.6.0"
-    swarm-js "0.1.39"
-    underscore "1.9.1"
-
 web3-bzz@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.2.6.tgz#0b88c0b96029eaf01b10cb47c4d5f79db4668883"
@@ -22429,15 +22374,6 @@ web3-core-helpers@1.2.2:
     underscore "1.9.1"
     web3-eth-iban "1.2.2"
     web3-utils "1.2.2"
-
-web3-core-helpers@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz#ffd425861f4d66b3f38df032afdb39ea0971fc0f"
-  integrity sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==
-  dependencies:
-    underscore "1.9.1"
-    web3-eth-iban "1.2.4"
-    web3-utils "1.2.4"
 
 web3-core-helpers@1.2.6:
   version "1.2.6"
@@ -22470,17 +22406,6 @@ web3-core-method@1.2.2:
     web3-core-subscriptions "1.2.2"
     web3-utils "1.2.2"
 
-web3-core-method@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.2.4.tgz#a0fbc50b8ff5fd214021435cc2c6d1e115807aed"
-  integrity sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==
-  dependencies:
-    underscore "1.9.1"
-    web3-core-helpers "1.2.4"
-    web3-core-promievent "1.2.4"
-    web3-core-subscriptions "1.2.4"
-    web3-utils "1.2.4"
-
 web3-core-method@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.2.6.tgz#f5a3e4d304abaf382923c8ab88ec8eeef45c1b3b"
@@ -22504,14 +22429,6 @@ web3-core-promievent@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.2.2.tgz#3b60e3f2a0c96db8a891c927899d29d39e66ab1c"
   integrity sha512-tKvYeT8bkUfKABcQswK6/X79blKTKYGk949urZKcLvLDEaWrM3uuzDwdQT3BNKzQ3vIvTggFPX9BwYh0F1WwqQ==
-  dependencies:
-    any-promise "1.3.0"
-    eventemitter3 "3.1.2"
-
-web3-core-promievent@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz#75e5c0f2940028722cdd21ba503ebd65272df6cb"
-  integrity sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==
   dependencies:
     any-promise "1.3.0"
     eventemitter3 "3.1.2"
@@ -22546,17 +22463,6 @@ web3-core-requestmanager@1.2.2:
     web3-providers-ipc "1.2.2"
     web3-providers-ws "1.2.2"
 
-web3-core-requestmanager@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz#0a7020a23fb91c6913c611dfd3d8c398d1e4b4a8"
-  integrity sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==
-  dependencies:
-    underscore "1.9.1"
-    web3-core-helpers "1.2.4"
-    web3-providers-http "1.2.4"
-    web3-providers-ipc "1.2.4"
-    web3-providers-ws "1.2.4"
-
 web3-core-requestmanager@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.2.6.tgz#5808c0edc0d6e2991a87b65508b3a1ab065b68ec"
@@ -22585,15 +22491,6 @@ web3-core-subscriptions@1.2.2:
     eventemitter3 "3.1.2"
     underscore "1.9.1"
     web3-core-helpers "1.2.2"
-
-web3-core-subscriptions@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz#0dc095b5cfd82baa527a39796e3515a846b21b99"
-  integrity sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==
-  dependencies:
-    eventemitter3 "3.1.2"
-    underscore "1.9.1"
-    web3-core-helpers "1.2.4"
 
 web3-core-subscriptions@1.2.6:
   version "1.2.6"
@@ -22626,19 +22523,6 @@ web3-core@1.2.2:
     web3-core-requestmanager "1.2.2"
     web3-utils "1.2.2"
 
-web3-core@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.2.4.tgz#2df13b978dcfc59c2abaa887d27f88f21ad9a9d6"
-  integrity sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==
-  dependencies:
-    "@types/bignumber.js" "^5.0.0"
-    "@types/bn.js" "^4.11.4"
-    "@types/node" "^12.6.1"
-    web3-core-helpers "1.2.4"
-    web3-core-method "1.2.4"
-    web3-core-requestmanager "1.2.4"
-    web3-utils "1.2.4"
-
 web3-core@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.2.6.tgz#bb42a1d7ae49a7258460f0d95ddb00906f59ef92"
@@ -22668,15 +22552,6 @@ web3-eth-abi@1.2.2:
     ethers "4.0.0-beta.3"
     underscore "1.9.1"
     web3-utils "1.2.2"
-
-web3-eth-abi@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz#5b73e5ef70b03999227066d5d1310b168845e2b8"
-  integrity sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==
-  dependencies:
-    ethers "4.0.0-beta.3"
-    underscore "1.9.1"
-    web3-utils "1.2.4"
 
 web3-eth-abi@1.2.6:
   version "1.2.6"
@@ -22721,24 +22596,6 @@ web3-eth-accounts@1.2.2:
     web3-core-helpers "1.2.2"
     web3-core-method "1.2.2"
     web3-utils "1.2.2"
-
-web3-eth-accounts@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-eth-accounts/-/web3-eth-accounts-1.2.4.tgz#ada6edc49542354328a85cafab067acd7f88c288"
-  integrity sha512-04LzT/UtWmRFmi4hHRewP5Zz43fWhuHiK5XimP86sUQodk/ByOkXQ3RoXyGXFMNoRxdcAeRNxSfA2DpIBc9xUw==
-  dependencies:
-    "@web3-js/scrypt-shim" "^0.1.0"
-    any-promise "1.3.0"
-    crypto-browserify "3.12.0"
-    eth-lib "0.2.7"
-    ethereumjs-common "^1.3.2"
-    ethereumjs-tx "^2.1.1"
-    underscore "1.9.1"
-    uuid "3.3.2"
-    web3-core "1.2.4"
-    web3-core-helpers "1.2.4"
-    web3-core-method "1.2.4"
-    web3-utils "1.2.4"
 
 web3-eth-accounts@1.2.6:
   version "1.2.6"
@@ -22787,21 +22644,6 @@ web3-eth-contract@1.2.2:
     web3-eth-abi "1.2.2"
     web3-utils "1.2.2"
 
-web3-eth-contract@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz#68ef7cc633232779b0a2c506a810fbe903575886"
-  integrity sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==
-  dependencies:
-    "@types/bn.js" "^4.11.4"
-    underscore "1.9.1"
-    web3-core "1.2.4"
-    web3-core-helpers "1.2.4"
-    web3-core-method "1.2.4"
-    web3-core-promievent "1.2.4"
-    web3-core-subscriptions "1.2.4"
-    web3-eth-abi "1.2.4"
-    web3-utils "1.2.4"
-
 web3-eth-contract@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.2.6.tgz#39111543960035ed94c597a239cf5aa1da796741"
@@ -22845,20 +22687,6 @@ web3-eth-ens@1.2.2:
     web3-eth-contract "1.2.2"
     web3-utils "1.2.2"
 
-web3-eth-ens@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-eth-ens/-/web3-eth-ens-1.2.4.tgz#b95b3aa99fb1e35c802b9e02a44c3046a3fa065e"
-  integrity sha512-g8+JxnZlhdsCzCS38Zm6R/ngXhXzvc3h7bXlxgKU4coTzLLoMpgOAEz71GxyIJinWTFbLXk/WjNY0dazi9NwVw==
-  dependencies:
-    eth-ens-namehash "2.0.8"
-    underscore "1.9.1"
-    web3-core "1.2.4"
-    web3-core-helpers "1.2.4"
-    web3-core-promievent "1.2.4"
-    web3-eth-abi "1.2.4"
-    web3-eth-contract "1.2.4"
-    web3-utils "1.2.4"
-
 web3-eth-ens@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/web3-eth-ens/-/web3-eth-ens-1.2.6.tgz#bf86a624c4c72bc59913c2345180d3ea947e110d"
@@ -22888,14 +22716,6 @@ web3-eth-iban@1.2.2:
   dependencies:
     bn.js "4.11.8"
     web3-utils "1.2.2"
-
-web3-eth-iban@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz#8e0550fd3fd8e47a39357d87fe27dee9483ee476"
-  integrity sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==
-  dependencies:
-    bn.js "4.11.8"
-    web3-utils "1.2.4"
 
 web3-eth-iban@1.2.6:
   version "1.2.6"
@@ -22927,18 +22747,6 @@ web3-eth-personal@1.2.2:
     web3-core-method "1.2.2"
     web3-net "1.2.2"
     web3-utils "1.2.2"
-
-web3-eth-personal@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz#3224cca6851c96347d9799b12c1b67b2a6eb232b"
-  integrity sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==
-  dependencies:
-    "@types/node" "^12.6.1"
-    web3-core "1.2.4"
-    web3-core-helpers "1.2.4"
-    web3-core-method "1.2.4"
-    web3-net "1.2.4"
-    web3-utils "1.2.4"
 
 web3-eth-personal@1.2.6:
   version "1.2.6"
@@ -22990,25 +22798,6 @@ web3-eth@1.2.2:
     web3-net "1.2.2"
     web3-utils "1.2.2"
 
-web3-eth@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.2.4.tgz#24c3b1f1ac79351bbfb808b2ab5c585fa57cdd00"
-  integrity sha512-+j+kbfmZsbc3+KJpvHM16j1xRFHe2jBAniMo1BHKc3lho6A8Sn9Buyut6odubguX2AxoRArCdIDCkT9hjUERpA==
-  dependencies:
-    underscore "1.9.1"
-    web3-core "1.2.4"
-    web3-core-helpers "1.2.4"
-    web3-core-method "1.2.4"
-    web3-core-subscriptions "1.2.4"
-    web3-eth-abi "1.2.4"
-    web3-eth-accounts "1.2.4"
-    web3-eth-contract "1.2.4"
-    web3-eth-ens "1.2.4"
-    web3-eth-iban "1.2.4"
-    web3-eth-personal "1.2.4"
-    web3-net "1.2.4"
-    web3-utils "1.2.4"
-
 web3-eth@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.2.6.tgz#15a8c65fdde0727872848cae506758d302d8d046"
@@ -23046,15 +22835,6 @@ web3-net@1.2.2:
     web3-core-method "1.2.2"
     web3-utils "1.2.2"
 
-web3-net@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.2.4.tgz#1d246406d3aaffbf39c030e4e98bce0ca5f25458"
-  integrity sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==
-  dependencies:
-    web3-core "1.2.4"
-    web3-core-method "1.2.4"
-    web3-utils "1.2.4"
-
 web3-net@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.2.6.tgz#035ca0fbe55282fda848ca17ebb4c8966147e5ea"
@@ -23078,14 +22858,6 @@ web3-providers-http@1.2.2:
   integrity sha512-BNZ7Hguy3eBszsarH5gqr9SIZNvqk9eKwqwmGH1LQS1FL3NdoOn7tgPPdddrXec4fL94CwgNk4rCU+OjjZRNDg==
   dependencies:
     web3-core-helpers "1.2.2"
-    xhr2-cookies "1.1.0"
-
-web3-providers-http@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.2.4.tgz#514fcad71ae77832c2c15574296282fbbc5f4a67"
-  integrity sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==
-  dependencies:
-    web3-core-helpers "1.2.4"
     xhr2-cookies "1.1.0"
 
 web3-providers-http@1.2.6:
@@ -23114,15 +22886,6 @@ web3-providers-ipc@1.2.2:
     underscore "1.9.1"
     web3-core-helpers "1.2.2"
 
-web3-providers-ipc@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz#9d6659f8d44943fb369b739f48df09092be459bd"
-  integrity sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==
-  dependencies:
-    oboe "2.1.4"
-    underscore "1.9.1"
-    web3-core-helpers "1.2.4"
-
 web3-providers-ipc@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.2.6.tgz#adabab5ac66b3ff8a26c7dc97af3f1a6a7609701"
@@ -23149,15 +22912,6 @@ web3-providers-ws@1.2.2:
     underscore "1.9.1"
     web3-core-helpers "1.2.2"
     websocket "github:web3-js/WebSocket-Node#polyfill/globalThis"
-
-web3-providers-ws@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz#099ee271ee03f6ea4f5df9cfe969e83f4ce0e36f"
-  integrity sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==
-  dependencies:
-    "@web3-js/websocket" "^1.0.29"
-    underscore "1.9.1"
-    web3-core-helpers "1.2.4"
 
 web3-providers-ws@1.2.6:
   version "1.2.6"
@@ -23187,16 +22941,6 @@ web3-shh@1.2.2:
     web3-core-method "1.2.2"
     web3-core-subscriptions "1.2.2"
     web3-net "1.2.2"
-
-web3-shh@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.2.4.tgz#5c8ff5ab624a3b14f08af0d24d2b16c10e9f70dd"
-  integrity sha512-z+9SCw0dE+69Z/Hv8809XDbLj7lTfEv9Sgu8eKEIdGntZf4v7ewj5rzN5bZZSz8aCvfK7Y6ovz1PBAu4QzS4IQ==
-  dependencies:
-    web3-core "1.2.4"
-    web3-core-method "1.2.4"
-    web3-core-subscriptions "1.2.4"
-    web3-net "1.2.4"
 
 web3-shh@1.2.6:
   version "1.2.6"
@@ -23235,21 +22979,7 @@ web3-utils@1.2.2:
     underscore "1.9.1"
     utf8 "3.0.0"
 
-web3-utils@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.2.4.tgz#96832a39a66b05bf8862a5b0bdad2799d709d951"
-  integrity sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==
-  dependencies:
-    bn.js "4.11.8"
-    eth-lib "0.2.7"
-    ethereum-bloom-filters "^1.0.6"
-    ethjs-unit "0.1.6"
-    number-to-bn "1.7.0"
-    randombytes "^2.1.0"
-    underscore "1.9.1"
-    utf8 "3.0.0"
-
-web3-utils@1.2.6, web3-utils@^1.2.6:
+web3-utils@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.2.6.tgz#b9a25432da00976457fcc1094c4af8ac6d486db9"
   integrity sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==
@@ -23303,20 +23033,6 @@ web3@1.2.2:
     web3-net "1.2.2"
     web3-shh "1.2.2"
     web3-utils "1.2.2"
-
-web3@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3/-/web3-1.2.4.tgz#6e7ab799eefc9b4648c2dab63003f704a1d5e7d9"
-  integrity sha512-xPXGe+w0x0t88Wj+s/dmAdASr3O9wmA9mpZRtixGZxmBexAF0MjfqYM+MS4tVl5s11hMTN3AZb8cDD4VLfC57A==
-  dependencies:
-    "@types/node" "^12.6.1"
-    web3-bzz "1.2.4"
-    web3-core "1.2.4"
-    web3-eth "1.2.4"
-    web3-eth-personal "1.2.4"
-    web3-net "1.2.4"
-    web3-shh "1.2.4"
-    web3-utils "1.2.4"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Update Origin to use the latest version of the Ethers.js library.

Closes https://github.com/energywebfoundation/origin/pull/1169.