### PR TITLE
bug(origin-ui-core): cant verify blockchain account of inactive user 

### DIFF
--- a/packages/origin-backend-utils/index.ts
+++ b/packages/origin-backend-utils/index.ts
@@ -2,3 +2,4 @@ export * from './src/decorator/UserDecorator';
 export * from './src/decorator/RolesDecorator';
 export * from './src/guard/RolesGuard';
 export * from './src/guard/ActiveUserGuard';
+export * from './src/guard/NotDeletedUserGuard';

--- a/packages/origin-backend-utils/src/guard/NotDeletedUserGuard.ts
+++ b/packages/origin-backend-utils/src/guard/NotDeletedUserGuard.ts
@@ -1,22 +1,20 @@
 import { Injectable, CanActivate, ExecutionContext, HttpException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { IUserWithRelationsIds, UserStatus } from '@energyweb/origin-backend-core';
+import { UserStatus } from '@energyweb/origin-backend-core';
 
 @Injectable()
 export class NotDeletedUserGuard implements CanActivate {
     constructor(private reflector: Reflector) {}
 
     canActivate(context: ExecutionContext): boolean {
-        const request = context.switchToHttp().getRequest();
-        const user = request.user as IUserWithRelationsIds;
-        const _user = user as IUserWithRelationsIds;
+        const { user } = context.switchToHttp().getRequest();
 
-        if (_user.status === UserStatus.Deleted) {
+        if (user.status === UserStatus.Deleted) {
             throw new HttpException(
                 `Only not deleted users can perform this action. Your status is ${
-                    UserStatus[_user.status]
+                    UserStatus[user.status]
                 }`,
-                412
+                403
             );
         }
 

--- a/packages/origin-backend-utils/src/guard/NotDeletedUserGuard.ts
+++ b/packages/origin-backend-utils/src/guard/NotDeletedUserGuard.ts
@@ -1,0 +1,25 @@
+import { Injectable, CanActivate, ExecutionContext, HttpException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { IUserWithRelationsIds, UserStatus } from '@energyweb/origin-backend-core';
+
+@Injectable()
+export class NotDeletedUserGuard implements CanActivate {
+    constructor(private reflector: Reflector) {}
+
+    canActivate(context: ExecutionContext): boolean {
+        const request = context.switchToHttp().getRequest();
+        const user = request.user as IUserWithRelationsIds;
+        const _user = user as IUserWithRelationsIds;
+
+        if (_user.status === UserStatus.Deleted) {
+            throw new HttpException(
+                `Only not deleted users can perform this action. Your status is ${
+                    UserStatus[_user.status]
+                }`,
+                412
+            );
+        }
+
+        return true;
+    }
+}

--- a/packages/origin-backend/src/pods/user/user.controller.ts
+++ b/packages/origin-backend/src/pods/user/user.controller.ts
@@ -55,7 +55,7 @@ export class UserController {
     }
 
     @Put()
-    @UseGuards(AuthGuard('jwt'), ActiveUserGuard)
+    @UseGuards(AuthGuard('jwt'))
     public async update(
         @UserDecorator() user: ILoggedInUser,
         @Body() body: UserUpdateData
@@ -112,7 +112,7 @@ export class UserController {
     }
 
     @Put('chainAddress')
-    @UseGuards(AuthGuard('jwt'), ActiveUserGuard)
+    @UseGuards(AuthGuard('jwt'))
     public async updateOwnBlockchainAddress(
         @UserDecorator() { id }: ILoggedInUser,
         @Body() body: IUser

--- a/packages/origin-backend/src/pods/user/user.controller.ts
+++ b/packages/origin-backend/src/pods/user/user.controller.ts
@@ -10,7 +10,11 @@ import {
     ISuccessResponse,
     EmailConfirmationResponse
 } from '@energyweb/origin-backend-core';
-import { UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
+import {
+    UserDecorator,
+    ActiveUserGuard,
+    NotDeletedUserGuard
+} from '@energyweb/origin-backend-utils';
 import {
     BadRequestException,
     Body,
@@ -55,7 +59,7 @@ export class UserController {
     }
 
     @Put()
-    @UseGuards(AuthGuard('jwt'))
+    @UseGuards(AuthGuard('jwt'), NotDeletedUserGuard)
     public async update(
         @UserDecorator() user: ILoggedInUser,
         @Body() body: UserUpdateData
@@ -112,7 +116,7 @@ export class UserController {
     }
 
     @Put('chainAddress')
-    @UseGuards(AuthGuard('jwt'))
+    @UseGuards(AuthGuard('jwt'), NotDeletedUserGuard)
     public async updateOwnBlockchainAddress(
         @UserDecorator() { id }: ILoggedInUser,
         @Body() body: IUser


### PR DESCRIPTION
Fixed issue:
- Only active user can verify his blockchain account

Current behavior: Only deleted user is not allowed to verify account
