### PR TITLE
bug/styling issues in bundle item edit

### DIFF
--- a/packages/origin-ui-core/src/components/bundles/BundleItemEdit.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundleItemEdit.tsx
@@ -138,7 +138,9 @@ export const BundleItemEdit = (props: IOwnProps) => {
                                 onClick={() => setSelected(false)}
                                 style={{
                                     textTransform: 'uppercase',
-                                    cursor: 'pointer'
+                                    cursor: 'pointer',
+                                    transform: `scale(0.75)`,
+                                    fontWeight: 'bold'
                                 }}
                             >
                                 {t('general.actions.cancel')}

--- a/packages/origin-ui-core/src/components/bundles/BundleItemEdit.tsx
+++ b/packages/origin-ui-core/src/components/bundles/BundleItemEdit.tsx
@@ -70,7 +70,8 @@ export const BundleItemEdit = (props: IOwnProps) => {
         },
         formLabel: {
             marginTop: spacing(1),
-            marginLeft: spacing(1)
+            marginLeft: spacing(1),
+            transform: `scale(0.9)`
         },
         formInput: {
             textAlign: 'right'
@@ -216,12 +217,13 @@ export const BundleItemEdit = (props: IOwnProps) => {
                                             )}
                                         </Field>
                                     </Grid>
-                                    <Grid item xs={2} style={{ textAlign: 'center' }}>
+                                    <Grid item xs={2} container direction="column" justify="center">
                                         <Button
                                             type="submit"
                                             disabled={!isValid}
                                             variant="contained"
                                             color="primary"
+                                            style={{ marginLeft: spacing(1) }}
                                         >
                                             {t('user.actions.save')}
                                         </Button>


### PR DESCRIPTION
Fixed issues:
- `cancel` button is too large
- `save` button is not centered in chrome
- label is too small

Before:
![image](https://user-images.githubusercontent.com/44746858/88533000-2eb5b000-d00e-11ea-9807-369b40f032fc.png)

After:
![image](https://user-images.githubusercontent.com/44746858/88533117-64f32f80-d00e-11ea-98cf-e9dc2430ad9a.png)
