### PR TITLE
chore: allow defining features when running exchange and/or origin-ba…

### DIFF
--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -115,7 +115,7 @@ export const bootstrapTestInstance = async (deviceServiceMock?: DeviceService) =
                 entities,
                 logging: ['info']
             }),
-            AppModule
+            AppModule.register()
         ],
         providers: [
             DatabaseService,
@@ -185,7 +185,7 @@ export const bootstrapTestInstance = async (deviceServiceMock?: DeviceService) =
     app.useLogger(testLogger);
     app.enableCors();
 
-    useContainer(app.select(AppModule), { fallbackOnErrors: true });
+    useContainer(app, { fallbackOnErrors: true });
 
     return {
         transferService,


### PR DESCRIPTION
Allow running `@energyweb/exchange` and `@energyweb/origin-backend` by defining a set of `OriginFeature`s