### PR TITLE
feature/backend invitation processing

### DIFF
--- a/packages/origin-backend-client-mocks/src/OrganizationClientMock.ts
+++ b/packages/origin-backend-client-mocks/src/OrganizationClientMock.ts
@@ -69,15 +69,21 @@ export class OrganizationClientMock implements IOrganizationClient {
         throw new Error('Method not implemented.');
     }
 
-    inviteMocked(email: string, organizationId: number, role: OrganizationRole): ISuccessResponse {
+    inviteMocked(
+        email: string,
+        organization: IOrganization,
+        role: OrganizationRole,
+        sender: string
+    ): ISuccessResponse {
         this.invitationCounter++;
 
         const organizationInvitation: IOrganizationInvitation = {
             id: this.invitationCounter,
             email,
             role,
-            organization: { id: organizationId } as IOrganization,
-            status: OrganizationInvitationStatus.Pending
+            organization,
+            status: OrganizationInvitationStatus.Pending,
+            sender
         };
 
         this.invitationStorage.set(organizationInvitation.id, organizationInvitation);
@@ -149,6 +155,10 @@ export class OrganizationClientMock implements IOrganizationClient {
     }
 
     rejectInvitation(id: number): Promise<any> {
+        throw new Error('Method not implemented.');
+    }
+
+    viewInvitation(id: number): Promise<any> {
         throw new Error('Method not implemented.');
     }
 }

--- a/packages/origin-backend-client/src/OrganizationClient.ts
+++ b/packages/origin-backend-client/src/OrganizationClient.ts
@@ -79,6 +79,12 @@ export class OrganizationClient implements IOrganizationClient {
         });
     }
 
+    public async viewInvitation(id: number): Promise<any> {
+        await this.updateInvitation(id, {
+            status: OrganizationInvitationStatus.Viewed
+        });
+    }
+
     public async invite(email: string, role: OrganizationRole): Promise<ISuccessResponse> {
         const response = await this.requestClient.post<
             OrganizationInviteCreateData,

--- a/packages/origin-backend-core/src/OrganizationInvitation.ts
+++ b/packages/origin-backend-core/src/OrganizationInvitation.ts
@@ -4,7 +4,8 @@ import { Role } from './User';
 export enum OrganizationInvitationStatus {
     Pending,
     Rejected,
-    Accepted
+    Accepted,
+    Viewed
 }
 
 export type OrganizationRole =
@@ -21,6 +22,7 @@ export interface IOrganizationInvitationProperties {
 
 export interface IOrganizationInvitation extends IOrganizationInvitationProperties {
     organization: IOrganization;
+    sender: string;
 }
 
 export type OrganizationInviteCreateData = { email: string; role: OrganizationRole };

--- a/packages/origin-backend-core/src/client/index.ts
+++ b/packages/origin-backend-core/src/client/index.ts
@@ -119,6 +119,7 @@ export interface IOrganizationClient {
     getInvitationsForEmail(email: string): Promise<IOrganizationInvitation[]>;
     acceptInvitation(id: number): Promise<any>;
     rejectInvitation(id: number): Promise<any>;
+    viewInvitation(id: number): Promise<any>;
 
     getMembers(id: number): Promise<IUserWithRelationsIds[]>;
     removeMember(organizationId: number, userId: number): Promise<ISuccessResponse>;

--- a/packages/origin-backend/migrations/1596616659110-OrganizationInvitationSender.ts
+++ b/packages/origin-backend/migrations/1596616659110-OrganizationInvitationSender.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class OrganizationInvitationSender1596616659110 implements MigrationInterface {
+    name = 'OrganizationInvitationSender1596616659110';
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(
+            `ALTER TABLE "organization_invitation" ADD "sender" character varying NOT NULL DEFAULT ''`,
+            undefined
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(
+            `ALTER TABLE "organization_invitation" DROP COLUMN "sender"`,
+            undefined
+        );
+    }
+}

--- a/packages/origin-backend/src/pods/organization/organization-invitation.entity.ts
+++ b/packages/origin-backend/src/pods/organization/organization-invitation.entity.ts
@@ -25,6 +25,9 @@ export class OrganizationInvitation extends ExtendedBaseEntity implements IOrgan
     @Column()
     status: OrganizationInvitationStatus;
 
+    @Column()
+    sender: string;
+
     @ManyToOne(() => Organization, (organization) => organization.users)
     organization: Organization;
 }

--- a/packages/origin-backend/src/pods/organization/organization-invitation.service.ts
+++ b/packages/origin-backend/src/pods/organization/organization-invitation.service.ts
@@ -35,7 +35,7 @@ export class OrganizationInvitationService {
                 error: 'Provided email address is incorrect'
             });
         }
-
+        const sender = await this.userService.findByEmail(user.email);
         const { organizationId } = user;
         if (typeof organizationId === 'undefined') {
             throw new BadRequestException({
@@ -56,7 +56,8 @@ export class OrganizationInvitationService {
             email: lowerCaseEmail,
             organization,
             role,
-            status: OrganizationInvitationStatus.Pending
+            status: OrganizationInvitationStatus.Pending,
+            sender: `${sender.firstName} ${sender.lastName}`
         });
 
         const eventData: OrganizationInvitationEvent = {

--- a/packages/origin-backend/src/pods/organization/organization.controller.ts
+++ b/packages/origin-backend/src/pods/organization/organization.controller.ts
@@ -71,8 +71,9 @@ export class OrganizationController {
     ): Promise<IOrganizationInvitation[]> {
         return this.organizationInvitationRepository.find({
             where: { email: loggedUser.email },
+            loadRelationIds: false,
             relations: ['organization']
-        }) as Promise<IOrganizationInvitation[]>;
+        });
     }
 
     @Get('/:id/users')
@@ -232,8 +233,9 @@ export class OrganizationController {
 
         return this.organizationInvitationRepository.find({
             where: { organization: organizationId },
+            loadRelationIds: false,
             relations: ['organization']
-        }) as Promise<IOrganizationInvitation[]>;
+        });
     }
 
     @Put('/invitation/:invitationId')
@@ -243,7 +245,7 @@ export class OrganizationController {
         @Param('invitationId') invitationId: string,
         @UserDecorator() loggedUser: ILoggedInUser
     ) {
-        await this.organizationInvitationService.acceptOrReject(loggedUser, invitationId, status);
+        await this.organizationInvitationService.update(loggedUser, invitationId, status);
         return true;
     }
 


### PR DESCRIPTION
- `IOrganizationInvitation` extended with `sender` property to display invitation sender to the invited user 
- add `Viewed` status to `IOrganizationInvitationStatus` enum to track whether invitation was communicated
- `organization` property type of `IOrganizationInvitation` changed to `IOrganization`
- Changes to `OrganizationInvitation` entity are migrated
- Since invitation updating now is not only about acceptance or rejection `OrganizationInvitationService.acceptOrReject` renamed to `update` and its logic is changed 