### PR TITLE
bug/dont fetch own bundles and orders if user is invactive

### DIFF
--- a/packages/origin-ui-core/src/features/general/sagas.ts
+++ b/packages/origin-ui-core/src/features/general/sagas.ts
@@ -365,7 +365,11 @@ export function* fetchBundles() {
     yield put(clearBundles());
     const exchangeClient: IExchangeClient = yield select(getExchangeClient);
     const bundles: Bundle[] = yield apply(exchangeClient, exchangeClient.getAvailableBundles, null);
-    const ownBundles: Bundle[] = yield apply(exchangeClient, exchangeClient.getOwnBundles, null);
+    const user = yield select(getUserOffchain);
+    const ownBundles: Bundle[] =
+        user && user.status === UserStatus.Active
+            ? yield apply(exchangeClient, exchangeClient.getOwnBundles, null)
+            : [];
     for (const bundle of bundles) {
         bundle.own = ownBundles.find((b) => b.id === bundle.id) !== undefined;
         bundle.items.forEach((item) => {


### PR DESCRIPTION
Bug fixed in this PR:

Own bundles and organization orders are fetched regardless whether the user is active or not