### PR TITLE
feat(origin-ui-core): successfully provided existing I-REC account info message window

### DIFF
--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -496,6 +496,8 @@
                 "uploadSignatoryId": "Upload Singatory ID",
                 "titleConnectOrRegisterIREC": "Thank you for registering organization on TK marketplace!",
                 "contentConnectOrRegisterIREC": "We are checking your information as soon as possible and will contact you once everything is approved and you can start trading.<1/> <2/> In order to register devices and request I-RECs, users also need to connect to existing I-REC account.",
+                "titleIRecInfoSuccess": "Thank you for providing your I-REC account information.",
+                "contentIRecInfoSuccess": "We will connect your organization to this account shortly!",
                 "titleConnectIREC": "Requesting I-REC API Access",
                 "platformOrganizationId": "Platform Organization ID",
                 "IRECAPICredentials": "I-REC API Credentials",

--- a/packages/localization/src/languages/pl.json
+++ b/packages/localization/src/languages/pl.json
@@ -331,6 +331,8 @@
                 "uploadSignatoryId": "Prześlij identyfikator osobisty",
                 "titleConnectOrRegisterIREC": "Dziękujemy za zarejestrowanie organizacji na platformie TK!",
                 "contentConnectOrRegisterIREC": "Sprawdzamy Twoje dane tak szybko, jak to możliwe i skontaktujemy się z Tobą, gdy wszystko zostanie zatwierdzone i będziesz mógł rozpocząć handel. <1/> <2/> Aby zarejestrować urządzenia i poprosić o I-REC, użytkownicy muszą również połączyć się z istniejącym kontem I-REC.",
+                "titleIRecInfoSuccess": "Dziękujemy za podanie informacji o koncie I-REC.",
+                "contentIRecInfoSuccess": "Wkrótce połączymy Twoją organizację z tym kontem!",
                 "titleConnectIREC": "Żądanie dostępu do I-REC API",
                 "platformOrganizationId": "ID organizacji platformy",
                 "IRECAPICredentials": "I-REC API Kwalifikacje",

--- a/packages/origin-ui-core/src/components/Modal/IRecInfoSuccessModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/IRecInfoSuccessModal.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Dialog, DialogTitle, DialogActions, Button, Box, useTheme, Grid } from '@material-ui/core';
+import { useTranslation } from '../..';
+import iconAdded from '../../../assets/icon-org-added.svg';
+
+export const IRecInfoSuccessModal = () => {
+    const [isOpen, setIsOpen] = useState(true);
+    const history = useHistory();
+
+    const showModal = isOpen;
+
+    const {
+        typography: { fontSizeMd, fontSizeLg }
+    } = useTheme();
+    const { t } = useTranslation();
+
+    const closeModal = () => {
+        setIsOpen(false);
+        history.push('/');
+    };
+
+    return (
+        <Dialog open={showModal} onClose={() => closeModal()}>
+            <DialogTitle>
+                <Grid container>
+                    <Grid item xs={2}>
+                        <div style={{ position: 'relative', height: '100%', width: '100%' }}>
+                            <Box>
+                                <img
+                                    src={iconAdded}
+                                    style={{
+                                        width: '100%',
+                                        height: '100%',
+                                        position: 'absolute',
+                                        top: 0
+                                    }}
+                                />
+                            </Box>
+                        </div>
+                    </Grid>
+                    <Grid item xs>
+                        <Box pl={2} mt={4} fontSize={fontSizeLg}>
+                            {t('organization.registration.titleIRecInfoSuccess')}
+                            <Box fontSize={fontSizeMd} mt={3}>
+                                {t('organization.registration.contentIRecInfoSuccess')}
+                            </Box>
+                        </Box>
+                    </Grid>
+                </Grid>
+            </DialogTitle>
+            <DialogActions>
+                <Box pr={2.5} pb={2.5}>
+                    <Button variant="contained" color="primary" onClick={() => closeModal()}>
+                        {t('general.responses.ok')}
+                    </Button>
+                </Box>
+            </DialogActions>
+        </Dialog>
+    );
+};


### PR DESCRIPTION
If the user successfully provides the existing I-REC Account Information data and clicks Submit it opens a modal window with the following text and a clickable button:

“Thanks for providing your I-REC account information. We will connect your organization to this account shortly!

Button: Ok”

Ok leads the user to the platform homepage.
![IRecSuccessModalScreen](https://user-images.githubusercontent.com/69903849/91319462-11b6fd00-e7c5-11ea-93f9-ed2fafe6ed08.png)
