### PR TITLE
feat/irec account successfully registered modal ov 197

### DIFF
--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -498,6 +498,8 @@
                 "contentConnectOrRegisterIREC": "We are checking your information as soon as possible and will contact you once everything is approved and you can start trading.<1/> <2/> In order to register devices and request I-RECs, users also need to connect to existing I-REC account.",
                 "titleIRecInfoSuccess": "Thank you for providing your I-REC account information.",
                 "contentIRecInfoSuccess": "We will connect your organization to this account shortly!",
+                "titleIRecAccountRegistered": "Thank you for registering an I-REC account!",
+                "contentIRecAccountRegistered": "We will forward your application to I-REC and inform you as soon as it is approved.",
                 "titleConnectIREC": "Requesting I-REC API Access",
                 "platformOrganizationId": "Platform Organization ID",
                 "IRECAPICredentials": "I-REC API Credentials",

--- a/packages/localization/src/languages/pl.json
+++ b/packages/localization/src/languages/pl.json
@@ -333,6 +333,8 @@
                 "contentConnectOrRegisterIREC": "Sprawdzamy Twoje dane tak szybko, jak to możliwe i skontaktujemy się z Tobą, gdy wszystko zostanie zatwierdzone i będziesz mógł rozpocząć handel. <1/> <2/> Aby zarejestrować urządzenia i poprosić o I-REC, użytkownicy muszą również połączyć się z istniejącym kontem I-REC.",
                 "titleIRecInfoSuccess": "Dziękujemy za podanie informacji o koncie I-REC.",
                 "contentIRecInfoSuccess": "Wkrótce połączymy Twoją organizację z tym kontem!",
+                "titleIRecAccountRegistered": "Dziękujemy za zarejestrowanie konta I-REC!",
+                "contentIRecAccountRegistered": "Prześlemy Twoją aplikację do I-REC i poinformujemy Cię, gdy tylko zostanie zatwierdzona.",
                 "titleConnectIREC": "Żądanie dostępu do I-REC API",
                 "platformOrganizationId": "ID organizacji platformy",
                 "IRECAPICredentials": "I-REC API Kwalifikacje",

--- a/packages/origin-ui-core/src/components/Modal/IRecAccontRegisteredModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/IRecAccontRegisteredModal.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Dialog, DialogTitle, DialogActions, Button, Box, useTheme, Grid } from '@material-ui/core';
+import { useTranslation } from '../..';
+import iconAdded from '../../../assets/icon-org-added.svg';
+
+export const IRecAccountRegisteredModal = () => {
+    const [isOpen, setIsOpen] = useState(true);
+    const history = useHistory();
+
+    const showModal = isOpen;
+
+    const {
+        typography: { fontSizeMd }
+    } = useTheme();
+    const { t } = useTranslation();
+
+    const closeModal = () => {
+        setIsOpen(false);
+        history.push('/');
+    };
+
+    return (
+        <Dialog open={showModal} onClose={() => closeModal()} maxWidth={'sm'} fullWidth={true}>
+            <DialogTitle>
+                <Grid container>
+                    <Grid item xs={2}>
+                        <div style={{ position: 'relative', height: '100%', width: '100%' }}>
+                            <Box>
+                                <img
+                                    src={iconAdded}
+                                    style={{
+                                        width: '100%',
+                                        height: '100%',
+                                        position: 'absolute',
+                                        top: 0
+                                    }}
+                                />
+                            </Box>
+                        </div>
+                    </Grid>
+                    <Grid item xs>
+                        <Box pl={2} mt={4}>
+                            {t('organization.registration.titleIRecAccountRegistered')}
+                            <Box fontSize={fontSizeMd} mt={3}>
+                                {t('organization.registration.contentIRecAccountRegistered')}
+                            </Box>
+                        </Box>
+                    </Grid>
+                </Grid>
+            </DialogTitle>
+            <DialogActions>
+                <Box pr={2.5} pb={2.5}>
+                    <Button variant="contained" color="primary" onClick={() => closeModal()}>
+                        {t('general.responses.ok')}
+                    </Button>
+                </Box>
+            </DialogActions>
+        </Dialog>
+    );
+};


### PR DESCRIPTION
When the user successfully provides all data to register a new I-REC account and clicks register, a  modal window opens with the following text and a clickable button:

“Thanks for registering an I-REC account!
We will forward your application to I-REC and inform you as soon as it is approved.

Button: Ok”

Ok leads the user to the platform homepage.
![IRecAccountRegisteredModalScreen](https://user-images.githubusercontent.com/69903849/91410740-078e1080-e850-11ea-818b-8d2721092b0b.png)
