### PR TITLE
fix/remove inappropriate actions of processed invitation ov 258

### DIFF
--- a/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
@@ -90,6 +90,10 @@ export function OrganizationInvitationTable(props: IProps) {
 
     async function accept(rowIndex: number) {
         const invitation = paginatedData[rowIndex]?.invitation;
+        const invitations = await organizationClient.getInvitationsForEmail(props.email);
+        invitations
+                .filter((inv) => inv.id !== invitation.id)
+                .forEach((inv) => organizationClient.rejectInvitation(inv.id));
 
         if (
             [OrganizationInvitationStatus.Accepted, OrganizationInvitationStatus.Rejected].includes(

--- a/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
@@ -146,22 +146,6 @@ export function OrganizationInvitationTable(props: IProps) {
         dispatch(setLoading(false));
     }
 
-    const actions =
-        typeof props.organizationId === 'undefined'
-            ? [
-                  {
-                      icon: <Check />,
-                      name: 'Accept',
-                      onClick: (row: string) => accept(parseInt(row, 10))
-                  },
-                  {
-                      icon: <Clear />,
-                      name: 'Reject',
-                      onClick: (row: string) => reject(parseInt(row, 10))
-                  }
-              ]
-            : [];
-
     const columns = [
         { id: 'organization', label: 'Organization' },
         { id: 'email', label: 'Email' },
@@ -175,6 +159,26 @@ export function OrganizationInvitationTable(props: IProps) {
             email: invitation.email
         };
     });
+
+    const actions =
+        typeof props.organizationId === 'undefined'
+            ? rows.map((currentRow) =>
+                  currentRow.status === 'Pending'
+                      ? [
+                            {
+                                icon: <Check />,
+                                name: 'Accept',
+                                onClick: (row: string) => accept(parseInt(row, 10))
+                            },
+                            {
+                                icon: <Clear />,
+                                name: 'Reject',
+                                onClick: (row: string) => reject(parseInt(row, 10))
+                            }
+                        ]
+                      : []
+              )
+            : [];
 
     return (
         <TableMaterial

--- a/packages/origin-ui-core/src/components/Table/TableMaterial.tsx
+++ b/packages/origin-ui-core/src/components/Table/TableMaterial.tsx
@@ -64,7 +64,7 @@ interface IProps<T extends readonly ITableColumn[]> {
     loadPage?: (page: number, filters?: ICustomFilter[]) => void | Promise<any>;
     pageSize?: number;
     total?: number;
-    actions?: ITableAction[];
+    actions?: ITableAction[] | ITableAction[][];
     onSelect?: TableOnSelectFunction;
     currentSort?: CurrentSortType;
     sortAscending?: boolean;
@@ -118,6 +118,57 @@ export function TableMaterial<T extends readonly ITableColumn[]>(props: IProps<T
             setSelectedIds(props.rows.map((row, index) => index?.toString()));
         } else {
             resetSelection();
+        }
+    }
+
+    function renderActions(
+        actionsArr,
+        allowed,
+        row: TTableRow<GetReadonlyArrayItemType<T>['id']>,
+        rowId: number,
+        id: string,
+        classes: Record<'root' | 'tableWrapper' | 'tableCellWrappingActions', string>
+    ) {
+        if (actionsArr && !actionsArr.length) {
+            return <TableCell key={id}></TableCell>;
+        }
+        if (actionsArr && actionsArr.length > 0) {
+            const arrayCheck = Array.isArray(actionsArr[0]);
+            if (!arrayCheck) {
+                return (
+                    <TableCell key={id} className={classes.tableCellWrappingActions}>
+                        <Actions
+                            actions={
+                                allowed
+                                    ? actionsArr.filter((action) =>
+                                          allowed[(row as any).source]?.includes(action.id)
+                                      )
+                                    : actionsArr
+                            }
+                            id={id}
+                        />
+                    </TableCell>
+                );
+            }
+            if (arrayCheck && actionsArr[rowId].length > 0) {
+                return (
+                    <TableCell key={id} className={classes.tableCellWrappingActions}>
+                        <Actions
+                            actions={
+                                allowed
+                                    ? actionsArr[rowId].filter((action) =>
+                                          allowed[(row as any).source]?.includes(action.id)
+                                      )
+                                    : actionsArr[rowId]
+                            }
+                            id={id}
+                        />
+                    </TableCell>
+                );
+            }
+            if (arrayCheck && actionsArr[rowId].length === 0) {
+                return <TableCell key={id}></TableCell>;
+            }
         }
     }
 
@@ -304,24 +355,13 @@ export function TableMaterial<T extends readonly ITableColumn[]>(props: IProps<T
                                                     </TableCell>
                                                 );
                                             })}
-                                            {actions && actions.length > 0 && (
-                                                <TableCell
-                                                    key={id}
-                                                    className={classes.tableCellWrappingActions}
-                                                >
-                                                    <Actions
-                                                        actions={
-                                                            allowedActions
-                                                                ? actions.filter((action) =>
-                                                                      allowedActions[
-                                                                          (row as any).source
-                                                                      ]?.includes(action.id)
-                                                                  )
-                                                                : actions
-                                                        }
-                                                        id={id}
-                                                    />
-                                                </TableCell>
+                                            {renderActions(
+                                                actions,
+                                                allowedActions,
+                                                row,
+                                                rowIndex,
+                                                id,
+                                                classes
                                             )}
                                         </TableRow>
                                         {customRow?.shouldDisplay(row) && (


### PR DESCRIPTION
Remove inappropriate actions of processed invitation.
After invitation is accepted or rejected Accept or Reject actions are still appears in organization/invitations tab:

![image-20200821-103259](https://user-images.githubusercontent.com/69903849/91580005-1b6f6a80-e955-11ea-99ba-79fa04152a3f.png)

Fixed version:
1.  ![1 BothPending](https://user-images.githubusercontent.com/69903849/91580428-c2540680-e955-11ea-8179-bef40fd98d9b.png)
2.  ![2  OneWouldAccept](https://user-images.githubusercontent.com/69903849/91580443-c7b15100-e955-11ea-83a4-0cbf19eb6e6b.png)
3.  ![3  AfterAccepted_OnePending](https://user-images.githubusercontent.com/69903849/91580458-cc760500-e955-11ea-854d-92a7392aebd5.png) (This issue was solved in latest commit)
4.  ![4  OneAcceptedOneRejected](https://user-images.githubusercontent.com/69903849/91580470-d3047c80-e955-11ea-8430-b1c44efccc42.png)


