### PR TITLE
fix/remove inappropriate actions of processed invitation ov 258

### DIFF
--- a/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
@@ -146,22 +146,6 @@ export function OrganizationInvitationTable(props: IProps) {
         dispatch(setLoading(false));
     }
 
-    const actions =
-        typeof props.organizationId === 'undefined'
-            ? [
-                  {
-                      icon: <Check />,
-                      name: 'Accept',
-                      onClick: (row: string) => accept(parseInt(row, 10))
-                  },
-                  {
-                      icon: <Clear />,
-                      name: 'Reject',
-                      onClick: (row: string) => reject(parseInt(row, 10))
-                  }
-              ]
-            : [];
-
     const columns = [
         { id: 'organization', label: 'Organization' },
         { id: 'email', label: 'Email' },
@@ -175,6 +159,27 @@ export function OrganizationInvitationTable(props: IProps) {
             email: invitation.email
         };
     });
+
+    const actions =
+        typeof props.organizationId === 'undefined'
+            ? rows.map((currentRow) =>
+                  OrganizationInvitationStatus[currentRow.status] ===
+                  OrganizationInvitationStatus.Pending
+                      ? [
+                            {
+                                icon: <Check />,
+                                name: 'Accept',
+                                onClick: (row: string) => accept(parseInt(row, 10))
+                            },
+                            {
+                                icon: <Clear />,
+                                name: 'Reject',
+                                onClick: (row: string) => reject(parseInt(row, 10))
+                            }
+                        ]
+                      : []
+              )
+            : [];
 
     return (
         <TableMaterial

--- a/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
@@ -16,6 +16,7 @@ import {
 } from '../Table/PaginatedLoaderHooks';
 import { getOffChainDataSource } from '../../features/general/selectors';
 import { refreshUserOffchain } from '../../features/users/actions';
+import { useTranslation } from '../..';
 
 interface IRecord {
     organization: IOrganization;
@@ -43,6 +44,7 @@ export function OrganizationInvitationTable(props: IProps) {
     const organizationClient = useSelector(getOffChainDataSource)?.organizationClient;
 
     const dispatch = useDispatch();
+    const { t } = useTranslation();
 
     async function getPaginatedData({
         requestedPageSize,
@@ -172,12 +174,12 @@ export function OrganizationInvitationTable(props: IProps) {
                       ? [
                             {
                                 icon: <Check />,
-                                name: 'Accept',
+                                name: t('organization.invitations.actions.accept'),
                                 onClick: (row: string) => accept(parseInt(row, 10))
                             },
                             {
                                 icon: <Clear />,
-                                name: 'Reject',
+                                name: t('organization.invitations.actions.decline'),
                                 onClick: (row: string) => reject(parseInt(row, 10))
                             }
                         ]

--- a/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
@@ -105,6 +105,10 @@ export function OrganizationInvitationTable(props: IProps) {
 
         try {
             await organizationClient.acceptInvitation(invitation.id);
+            const invitations = await organizationClient.getInvitationsForEmail(props.email);
+            invitations
+                .filter((inv) => inv.id !== invitation.id)
+                .forEach((inv) => organizationClient.rejectInvitation(inv.id));
 
             showNotification(`Invitation accepted.`, NotificationType.Success);
             dispatch(refreshUserOffchain());

--- a/packages/origin-ui-core/src/components/Table/TableMaterial.tsx
+++ b/packages/origin-ui-core/src/components/Table/TableMaterial.tsx
@@ -64,7 +64,7 @@ interface IProps<T extends readonly ITableColumn[]> {
     loadPage?: (page: number, filters?: ICustomFilter[]) => void | Promise<any>;
     pageSize?: number;
     total?: number;
-    actions?: ITableAction[];
+    actions?: ITableAction[] | ITableAction[][];
     onSelect?: TableOnSelectFunction;
     currentSort?: CurrentSortType;
     sortAscending?: boolean;
@@ -119,6 +119,46 @@ export function TableMaterial<T extends readonly ITableColumn[]>(props: IProps<T
         } else {
             resetSelection();
         }
+    }
+
+    function renderActions(
+        actionsArr,
+        allowed,
+        row: TTableRow<GetReadonlyArrayItemType<T>['id']>,
+        rowId: number,
+        id: string,
+        classes: Record<'root' | 'tableWrapper' | 'tableCellWrappingActions', string>
+    ) {
+        if (!actionsArr?.length) {
+            return <TableCell key={id}></TableCell>;
+        }
+
+        const is2DArray = Array.isArray(actionsArr[0]);
+
+        let finalActionsList;
+
+        if (!is2DArray) {
+            finalActionsList = actionsArr;
+        } else if (actionsArr[rowId].length > 0) {
+            finalActionsList = actionsArr[rowId];
+        } else {
+            return <TableCell key={id}></TableCell>;
+        }
+
+        return (
+            <TableCell key={id} className={classes.tableCellWrappingActions}>
+                <Actions
+                    actions={
+                        allowed
+                            ? finalActionsList.filter((action) =>
+                                  allowed[(row as any).source]?.includes(action.id)
+                              )
+                            : finalActionsList
+                    }
+                    id={id}
+                />
+            </TableCell>
+        );
     }
 
     const {
@@ -304,24 +344,13 @@ export function TableMaterial<T extends readonly ITableColumn[]>(props: IProps<T
                                                     </TableCell>
                                                 );
                                             })}
-                                            {actions && actions.length > 0 && (
-                                                <TableCell
-                                                    key={id}
-                                                    className={classes.tableCellWrappingActions}
-                                                >
-                                                    <Actions
-                                                        actions={
-                                                            allowedActions
-                                                                ? actions.filter((action) =>
-                                                                      allowedActions[
-                                                                          (row as any).source
-                                                                      ]?.includes(action.id)
-                                                                  )
-                                                                : actions
-                                                        }
-                                                        id={id}
-                                                    />
-                                                </TableCell>
+                                            {renderActions(
+                                                actions,
+                                                allowedActions,
+                                                row,
+                                                rowIndex,
+                                                id,
+                                                classes
                                             )}
                                         </TableRow>
                                         {customRow?.shouldDisplay(row) && (


### PR DESCRIPTION
Remove inappropriate actions of processed invitation.
After invitation is accepted or rejected Accept or Reject actions are still appears in organization/invitations tab: 
![image-20200821-103259](https://user-images.githubusercontent.com/69903849/91630460-4cde4980-e9da-11ea-883c-16171e07befd.png)

Done:
1.  
![1 BothPending](https://user-images.githubusercontent.com/69903849/91630463-536cc100-e9da-11ea-903b-f64099a2aa5a.png)

2. 
![2  OneWouldAccept](https://user-images.githubusercontent.com/69903849/91630470-5d8ebf80-e9da-11ea-8f42-68ded9ec3166.png)

3.
![3  AfterAccepted_OnePending](https://user-images.githubusercontent.com/69903849/91630476-6384a080-e9da-11ea-962d-23745e6b8dd6.png) 
(This was fixed in the second commit)

4.
![4  OneAcceptedOneRejected](https://user-images.githubusercontent.com/69903849/91630498-7303e980-e9da-11ea-861b-e01e74bacf6d.png)


