### PR TITLE
fix/reads serialization

### DIFF
--- a/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
+++ b/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
@@ -10,6 +10,7 @@ import {
     ISmartMeterReadStats,
     IOrganization
 } from '@energyweb/origin-backend-core';
+import { BigNumber } from 'ethers';
 
 export class Entity implements IDevice {
     status: DeviceStatus;
@@ -123,8 +124,10 @@ export class Entity implements IDevice {
             const isFirstReading = i === 0;
 
             energiesGenerated.push({
-                energy: allMeterReadings[i].meterReading.sub(
-                    isFirstReading ? 0 : allMeterReadings[i - 1].meterReading
+                energy: BigNumber.from(
+                    allMeterReadings[i].meterReading.sub(
+                        isFirstReading ? 0 : allMeterReadings[i - 1].meterReading
+                    )
                 ),
                 timestamp: allMeterReadings[i].timestamp
             });

--- a/packages/origin-backend-core/src/Device.ts
+++ b/packages/origin-backend-core/src/Device.ts
@@ -18,7 +18,7 @@ export type ExternalDeviceIdType = Pick<IExternalDeviceId, 'type'> & {
 };
 
 export interface ISmartMeterRead {
-    meterReading: BigNumber;
+    meterReading: BigNumber | string;
     timestamp: number;
 }
 

--- a/packages/solar-simulator/src/consumerService.ts
+++ b/packages/solar-simulator/src/consumerService.ts
@@ -68,7 +68,7 @@ export async function startConsumerService(
         const smartMeterReadings = await device.getSmartMeterReads();
         const latestSmRead = smartMeterReadings[smartMeterReadings.length - 1];
 
-        return latestSmRead?.meterReading ?? BigNumber.from(0);
+        return BigNumber.from(latestSmRead?.meterReading ?? 0);
     }
 
     async function saveProducingDeviceSmartMeterReads(

--- a/packages/solar-simulator/src/workers/mockReadingsWorker.ts
+++ b/packages/solar-simulator/src/workers/mockReadingsWorker.ts
@@ -19,7 +19,7 @@ async function getProducingDeviceSmartMeterRead(
     const smartMeterReadings = await device.getSmartMeterReads();
     const latestSmRead = smartMeterReadings[smartMeterReadings.length - 1];
 
-    return latestSmRead?.meterReading ?? BigNumber.from(0);
+    return BigNumber.from(latestSmRead?.meterReading ?? 0);
 }
 
 async function saveProducingDeviceSmartMeterReads(


### PR DESCRIPTION
This PR fixes the issue with wrongly serialized smart meter reads. Previously these were transmitted as `{\"_hex\":\"0x13\",\"_isBigNumber\":true}` while now they become decimal strings. 