### PR TITLE
bug/register org shown when user belongs to organization

### DIFF
--- a/packages/origin-ui-core/src/components/Account/LoginForm.tsx
+++ b/packages/origin-ui-core/src/components/Account/LoginForm.tsx
@@ -1,17 +1,15 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Paper, Button, Theme, makeStyles, Box } from '@material-ui/core';
 import { Formik, FormikHelpers, Form, Field } from 'formik';
 import { useDispatch, useSelector } from 'react-redux';
 import { IUserClient } from '@energyweb/origin-backend-core';
 import { getOffChainDataSource, showNotification, NotificationType, useTranslation } from '../..';
 import { setLoading } from '../../features/general';
-import { getUserOffchain } from '../../features/users/selectors';
 import { useHistory } from 'react-router-dom';
 import { setAuthenticationToken } from '../../features/users/actions';
 import { useLinks, useValidation } from '../../utils';
 import { InputFixedHeight } from '../Form/InputFixedHeight';
 import EnergyWebOriginLogo from '../../../assets/EW-Origin-WhiteText.svg';
-import { FIRST_LOGIN_STORAGE_KEY } from '../Modal/LoginNoInvitationsModal';
 
 interface IFormValues {
     email: string;
@@ -23,17 +21,11 @@ const INITIAL_VALUES: IFormValues = {
     password: ''
 };
 
-interface IOwnProps {
-    redirect?: string;
-}
-
-export const LoginForm = (props: IOwnProps) => {
+export const LoginForm = () => {
     const dispatch = useDispatch();
     const userClient: IUserClient = useSelector(getOffChainDataSource)?.userClient;
-    const user = useSelector(getUserOffchain);
     const history = useHistory();
     const { t } = useTranslation();
-    const { getCertificatesLink } = useLinks();
     const { Yup } = useValidation();
     const { getAccountLink } = useLinks();
 
@@ -80,13 +72,6 @@ export const LoginForm = (props: IOwnProps) => {
         email: Yup.string().email().label(t('user.properties.email')).required(),
         password: Yup.string().label(t('user.properties.password')).required()
     });
-
-    useEffect(() => {
-        const firstLoginItem = localStorage.getItem(FIRST_LOGIN_STORAGE_KEY);
-        if (user && firstLoginItem) {
-            history.push(props.redirect || getCertificatesLink());
-        }
-    }, [user]);
 
     return (
         <Paper elevation={1} className="LoginForm" classes={{ root: styles.form }}>

--- a/packages/origin-ui-core/src/components/Account/LoginPage.tsx
+++ b/packages/origin-ui-core/src/components/Account/LoginPage.tsx
@@ -1,15 +1,63 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { LoginForm } from './LoginForm';
-// import BgOrigin from '../../../assets/bg-origin.png';
+import { LoginNoInvitationsModal } from '../Modal/LoginNoInvitationsModal';
+import { useSelector } from 'react-redux';
+import { getUserState } from '../../features/users/selectors';
+import { useLinks } from '../..';
+import { useHistory } from 'react-router-dom';
+import { OrganizationInvitationStatus } from '@energyweb/origin-backend-core';
+import { PendingInvitationsModal } from '../Modal/PendingInvitationsModal';
 
 interface IOwnProps {
     redirect?: string;
 }
 
 export const LoginPage = (props: IOwnProps) => {
+    const userState = useSelector(getUserState);
+    const user = userState.userOffchain;
+    const pending = userState.invitations.invitations.filter(
+        (i) => i.status === OrganizationInvitationStatus.Pending
+    );
+    const showInvitations = pending.length > 0 && !user?.organization?.id;
+    const { getCertificatesLink } = useLinks();
+    const history = useHistory();
+
+    const [showRegisterOrganizationModal, setShowRegisterOrganizationModal] = useState(false);
+    const [showInvitationsModal, setShowInvitationsModal] = useState(false);
+
+    useEffect(() => {
+        if (user) {
+            if (!showInvitations) {
+                const FIRST_LOGIN_KEY = `FIRST LOGIN ${user.id}`;
+                let firstLoginItem = localStorage.getItem(FIRST_LOGIN_KEY);
+                if (!firstLoginItem && user.organization?.id) {
+                    localStorage.setItem(FIRST_LOGIN_KEY, 'true');
+                    firstLoginItem = 'true';
+                }
+                if (firstLoginItem) {
+                    history.push(props.redirect || getCertificatesLink());
+                } else {
+                    localStorage.setItem(FIRST_LOGIN_KEY, 'true');
+                    setShowRegisterOrganizationModal(true);
+                }
+            } else {
+                setShowInvitationsModal(true);
+            }
+        }
+    }, [userState]);
+
     return (
         <div className="LoginPage">
-            <LoginForm redirect={props.redirect} />
+            <LoginForm />
+            <LoginNoInvitationsModal
+                showModal={showRegisterOrganizationModal}
+                setShowModal={setShowRegisterOrganizationModal}
+            />
+            <PendingInvitationsModal
+                showModal={showInvitationsModal}
+                setShowModal={setShowInvitationsModal}
+                invitations={pending}
+            />
         </div>
     );
 };

--- a/packages/origin-ui-core/src/components/AppContainer.tsx
+++ b/packages/origin-ui-core/src/components/AppContainer.tsx
@@ -18,10 +18,8 @@ import { NoBlockchainAccountModal } from './Modal/NoBlockchainAccountModal';
 import { FeatureRoute } from './route/FeatureRoute';
 import { OriginConfigurationContext } from '.';
 import { LoginPage } from './Account/LoginPage';
-import { PendingInvitationsModal } from './Modal/PendingInvitationsModal';
 import { RoleChangedModal } from './Modal/RoleChangedModal';
 import { getUserOffchain } from '../features/users/selectors';
-import { LoginNoInvitationsModal } from './Modal/LoginNoInvitationsModal';
 
 export function AppContainer() {
     const error = useSelector(getError);
@@ -63,7 +61,6 @@ export function AppContainer() {
         <Switch>
             <Route path={`${baseURL}/user-login`}>
                 <LoginPage />
-                <LoginNoInvitationsModal />
             </Route>
             <Route>
                 <div className={`AppWrapper`}>
@@ -113,7 +110,6 @@ export function AppContainer() {
                     <RequestCertificatesModal />
                     <AccountMismatchModal />
                     <NoBlockchainAccountModal />
-                    <PendingInvitationsModal />
                     <RoleChangedModal />
                 </div>
             </Route>

--- a/packages/origin-ui-core/src/components/Modal/LoginNoInvitationsModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/LoginNoInvitationsModal.tsx
@@ -1,28 +1,20 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Dialog, DialogTitle, DialogActions, Button, Box, Grid } from '@material-ui/core';
-import { useSelector } from 'react-redux';
-import { getUserOffchain } from '../../features/users/selectors';
 import { useTranslation, useLinks } from '../..';
 import { Trans } from 'react-i18next';
 import DraftOutlineIcon from '@material-ui/icons/DraftsOutlined';
 import { useHistory } from 'react-router-dom';
 
-export const FIRST_LOGIN_STORAGE_KEY = 'FIRST LOGIN';
+interface IProps {
+    showModal: boolean;
+    setShowModal: (showModal: boolean) => void;
+}
 
-export const LoginNoInvitationsModal = () => {
-    const user = useSelector(getUserOffchain);
-    const [showModal, setShowModal] = useState(false);
+export const LoginNoInvitationsModal = (props: IProps) => {
+    const { showModal, setShowModal } = props;
     const history = useHistory();
     const { t } = useTranslation();
     const { getOrganizationRegisterLink, getCertificatesLink } = useLinks();
-
-    useEffect(() => {
-        const firstLoginItem = localStorage.getItem(FIRST_LOGIN_STORAGE_KEY);
-        if (user && !firstLoginItem) {
-            localStorage.setItem(FIRST_LOGIN_STORAGE_KEY, 'true');
-            setShowModal(true);
-        }
-    }, [user]);
 
     const notNow = async () => {
         setShowModal(false);

--- a/packages/origin-ui-core/src/components/Modal/PendingInvitationsModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/PendingInvitationsModal.tsx
@@ -1,26 +1,31 @@
 import React from 'react';
 import { Dialog, DialogTitle, DialogActions, Button, Box, useTheme, Grid } from '@material-ui/core';
 import { useSelector, useDispatch } from 'react-redux';
-import { OrganizationInvitationStatus, Role } from '@energyweb/origin-backend-core';
-import { getInvitations, getUserOffchain } from '../../features/users/selectors';
 import {
-    setShowPendingInvitations,
-    setInvitations,
-    refreshUserOffchain
-} from '../../features/users/actions';
+    OrganizationInvitationStatus,
+    Role,
+    IOrganizationInvitation
+} from '@energyweb/origin-backend-core';
+import { setInvitations, refreshUserOffchain } from '../../features/users/actions';
 import { getOffChainDataSource, showNotification, NotificationType, useTranslation } from '../..';
 import { setLoading } from '../../features/general';
 import { Trans } from 'react-i18next';
 import DraftOutlineIcon from '@material-ui/icons/DraftsOutlined';
 
-export const PendingInvitationsModal = () => {
-    const invitations = useSelector(getInvitations);
-    const user = useSelector(getUserOffchain);
-    const pending = invitations.filter((i) => i.status === OrganizationInvitationStatus.Pending);
-    const showInvitations = pending.length > 0 && user && !user.organization;
-    const invitation = showInvitations
-        ? pending.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())[pending.length - 1]
-        : null;
+interface IProps {
+    showModal: boolean;
+    setShowModal: (showModal: boolean) => void;
+    invitations: IOrganizationInvitation[];
+}
+
+export const PendingInvitationsModal = (props: IProps) => {
+    const { showModal, setShowModal, invitations } = props;
+    const invitation =
+        invitations.length > 0
+            ? invitations.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())[
+                  invitations.length - 1
+              ]
+            : null;
     const {
         sender: admin,
         role,
@@ -67,7 +72,7 @@ export const PendingInvitationsModal = () => {
                 )
             )
         );
-        dispatch(setShowPendingInvitations(false));
+        setShowModal(false);
         dispatch(setLoading(false));
     };
 
@@ -91,7 +96,7 @@ export const PendingInvitationsModal = () => {
             console.error(error);
         }
         dispatch(refreshUserOffchain());
-        dispatch(setShowPendingInvitations(false));
+        setShowModal(false);
         dispatch(setLoading(false));
     };
 
@@ -120,12 +125,12 @@ export const PendingInvitationsModal = () => {
                 )
             )
         );
-        dispatch(setShowPendingInvitations(false));
+        setShowModal(false);
         dispatch(setLoading(false));
     };
 
     return (
-        <Dialog open={showInvitations} onClose={() => dispatch(setShowPendingInvitations(false))}>
+        <Dialog open={showModal} onClose={() => setShowModal(false)}>
             <DialogTitle>
                 <Grid container>
                     <Grid item xs={2}>

--- a/packages/origin-ui-core/src/features/users/actions.ts
+++ b/packages/origin-ui-core/src/features/users/actions.ts
@@ -3,6 +3,7 @@ import {
     IOrganizationWithRelationsIds,
     IOrganizationInvitation
 } from '@energyweb/origin-backend-core';
+import { IUsersState } from './reducer';
 
 export enum UsersActions {
     setActiveBlockchainAccountAddress = 'USERS_SET_ACTIVE_BLOCKCHAIN_ACCOUNT_ADDRESS',
@@ -13,7 +14,7 @@ export enum UsersActions {
     refreshUserOffchain = 'REFRESH_USER_OFFCHAIN',
     addOrganizations = 'USERS_ADD_ORGANIZATIONS',
     setInvitations = 'USERS_SET_INVITATIONS',
-    setShowPendingInvitations = 'USERS_SET_SHOW_PENDING_INVITATIONS'
+    setUserState = 'USERS_SET_USER_STATE'
 }
 
 export interface ISetActiveBlockchainAccountAddressAction {
@@ -96,15 +97,13 @@ export const setInvitations = (
     payload
 });
 
-export interface ISetShowPendingInvitations {
-    type: UsersActions.setShowPendingInvitations;
-    payload: boolean;
+export interface ISetUserState {
+    type: UsersActions.setUserState;
+    payload: IUsersState;
 }
 
-export const setShowPendingInvitations = (
-    payload: ISetShowPendingInvitations['payload']
-): ISetShowPendingInvitations => ({
-    type: UsersActions.setShowPendingInvitations,
+export const setUserState = (payload: ISetUserState['payload']): ISetUserState => ({
+    type: UsersActions.setUserState,
     payload
 });
 
@@ -118,4 +117,4 @@ export type IUsersAction =
     | IRefreshUserOffchainAction
     | IAddOrganizationsAction
     | ISetInvitationsAction
-    | ISetShowPendingInvitations;
+    | ISetUserState;

--- a/packages/origin-ui-core/src/features/users/reducer.ts
+++ b/packages/origin-ui-core/src/features/users/reducer.ts
@@ -64,14 +64,8 @@ export default function reducer(state = defaultState, action: IUsersAction): IUs
                 }
             };
 
-        case UsersActions.setShowPendingInvitations:
-            return {
-                ...state,
-                invitations: {
-                    ...state.invitations,
-                    showPendingInvitationsModal: action.payload as boolean
-                }
-            };
+        case UsersActions.setUserState:
+            return action.payload;
         default:
             return state;
     }

--- a/packages/origin-ui-core/src/features/users/selectors.ts
+++ b/packages/origin-ui-core/src/features/users/selectors.ts
@@ -1,5 +1,6 @@
 import { IStoreState } from '../../types';
 import { IOrganizationInvitation } from '@energyweb/origin-backend-core';
+import { IUsersState } from './reducer';
 
 export const getActiveBlockchainAccountAddress = (state: IStoreState) =>
     state.users.activeBlockchainAccountAddress;
@@ -15,3 +16,5 @@ export const getShowPendingInvitations = (state: IStoreState): boolean =>
     state.users.invitations.showPendingInvitationsModal;
 
 export const getIRECAccount = (state: IStoreState) => state.users.irecAccount;
+
+export const getUserState = (state: IStoreState): IUsersState => state.users;


### PR DESCRIPTION
Fixed bugs: 
- [x] When user which belongs to organization logs in on a new browser for the first time he is shown register new organization modal
- [x] Register new organization modal is shown to user independently of user id