### PR TITLE
fix/configure redirects for logout and accepted invite

### DIFF
--- a/packages/origin-ui-core/src/components/Header.tsx
+++ b/packages/origin-ui-core/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { NavLink, Link } from 'react-router-dom';
+import { NavLink, Link, useHistory } from 'react-router-dom';
 import {
     makeStyles,
     createStyles,
@@ -55,6 +55,7 @@ export function Header() {
     const userOffchain = useSelector(getUserOffchain);
 
     const dispatch = useDispatch();
+    const history = useHistory();
 
     const classes = useStyles(useTheme());
 
@@ -170,7 +171,10 @@ export function Header() {
                                 <ExitToApp
                                     color="primary"
                                     className={classes.logOutIcon}
-                                    onClick={() => dispatch(clearAuthenticationToken())}
+                                    onClick={() => {
+                                        history.push(getDefaultLink());
+                                        dispatch(clearAuthenticationToken());
+                                    }}
                                 />
                             </Tooltip>
                         </div>

--- a/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationInvitationTable.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { Check, Clear } from '@material-ui/icons';
 import {
     IOrganization,
@@ -16,7 +17,7 @@ import {
 } from '../Table/PaginatedLoaderHooks';
 import { getOffChainDataSource } from '../../features/general/selectors';
 import { refreshUserOffchain } from '../../features/users/actions';
-import { useTranslation } from '../..';
+import { useTranslation, useLinks } from '../..';
 
 interface IRecord {
     organization: IOrganization;
@@ -45,6 +46,8 @@ export function OrganizationInvitationTable(props: IProps) {
 
     const dispatch = useDispatch();
     const { t } = useTranslation();
+    const history = useHistory();
+    const { getDefaultLink } = useLinks();
 
     async function getPaginatedData({
         requestedPageSize,
@@ -114,7 +117,7 @@ export function OrganizationInvitationTable(props: IProps) {
 
             showNotification(`Invitation accepted.`, NotificationType.Success);
             dispatch(refreshUserOffchain());
-            await loadPage(1);
+            history.push(getDefaultLink());
         } catch (error) {
             showNotification(`Could not accept invitation.`, NotificationType.Error);
             console.error(error);


### PR DESCRIPTION
Configure redirects for logout and accepting organization invitation from Invitations table.

1. When logging out, while on some pages that are not allowed for unlogged user - the page can stuck on this page with no content. 

2. When the assigned role for invited user is Member or Device Manager and he accepts the invitation from Invitation table (not from the modal window) he stays in Organizations Tab and can see the pages he is not allowed to see, such as “My organization”, “Invitations”, “Register I-Rec”.

