### PR TITLE
fix(origin-backend-client): headers override on FileClient

### DIFF
--- a/packages/origin-backend-client/src/FilesClient.ts
+++ b/packages/origin-backend-client/src/FilesClient.ts
@@ -27,7 +27,10 @@ export class FilesClient implements IFilesClient {
             this.endpoint,
             formData,
             {
-                headers: { 'Content-type': 'multipart/form-data' },
+                headers: {
+                    ...this.requestClient.config.headers,
+                    'Content-type': 'multipart/form-data'
+                },
                 onUploadProgress,
                 cancelToken: cancelTokenSource?.token
             }

--- a/packages/origin-backend-client/src/RequestClient.ts
+++ b/packages/origin-backend-client/src/RequestClient.ts
@@ -24,7 +24,7 @@ export class RequestClient implements IRequestClient {
         return axios.CancelToken.source();
     }
 
-    private get config(): AxiosRequestConfig {
+    public get config(): AxiosRequestConfig {
         const config: AxiosRequestConfig = {};
 
         if (this.authenticationToken) {

--- a/packages/origin-backend-core/src/client/index.ts
+++ b/packages/origin-backend-core/src/client/index.ts
@@ -79,6 +79,8 @@ export interface IRequestClient {
     ): Promise<AxiosResponse<U>>;
 
     generateCancelToken(): CancelTokenSource;
+
+    config: { headers?: any };
 }
 
 export interface ICertificationRequestClient {


### PR DESCRIPTION
This PR fixes the issue where FileClient overrides authorization headers when sending file upload.