### PR TITLE
Fix/devices organizations

### DIFF
--- a/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
+++ b/packages/device-registry/src/blockchain-facade/ProducingDevice.ts
@@ -6,7 +6,6 @@ import {
     DeviceStatus,
     IExternalDeviceId,
     DeviceCreateData,
-    IDeviceWithRelationsIds,
     ISmartMeterReadStats,
     IPublicOrganization
 } from '@energyweb/origin-backend-core';
@@ -61,17 +60,13 @@ export class Entity implements IDevice {
 
     initialized: boolean;
 
-    organization: number | IPublicOrganization;
+    organization: IPublicOrganization;
 
     automaticPostForSale: boolean;
 
     defaultAskPrice: number;
 
-    constructor(
-        public id: number,
-        public configuration: Configuration.Entity,
-        data?: IDeviceWithRelationsIds
-    ) {
+    constructor(public id: number, public configuration: Configuration.Entity, data?: IDevice) {
         if (data) {
             Object.assign(this, data);
             this.initialized = true;
@@ -153,9 +148,7 @@ export const getAllDevices = async (
         loadRelationIds
     );
 
-    return allDevices.map(
-        (device: IDeviceWithRelationsIds) => new Entity(device.id, configuration, device)
-    );
+    return allDevices.map((device: IDevice) => new Entity(device.id, configuration, device));
 };
 
 export const createDevice = async (

--- a/packages/device-registry/src/test/DeviceFacade.test.ts
+++ b/packages/device-registry/src/test/DeviceFacade.test.ts
@@ -7,7 +7,7 @@ import dotenv from 'dotenv';
 
 import { Configuration, getProviderWithFallback } from '@energyweb/utils-general';
 import { OffChainDataSourceMock } from '@energyweb/origin-backend-client-mocks';
-import { DeviceStatus, IDevice } from '@energyweb/origin-backend-core';
+import { DeviceCreateData, DeviceStatus } from '@energyweb/origin-backend-core';
 
 import { ProducingDevice } from '..';
 import { logger } from '../Logger';
@@ -44,8 +44,7 @@ describe('Device Facade', () => {
 
             const FACILITY_NAME = 'Wuthering Heights Windfarm';
 
-            const deviceProps: IDevice = {
-                id: 1,
+            const deviceProps: DeviceCreateData = {
                 status: DeviceStatus.Active,
                 operationalSince: 0,
                 capacityInW: 10,
@@ -64,7 +63,6 @@ describe('Device Facade', () => {
                 images: '',
                 region: '',
                 province: '',
-                organization: 4,
                 gridOperator: '',
                 automaticPostForSale: false,
                 defaultAskPrice: null

--- a/packages/exchange/test/deposits-auto-post-for-sale.e2e-spec.ts
+++ b/packages/exchange/test/deposits-auto-post-for-sale.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { OrderSide, OrderStatus } from '@energyweb/exchange-core';
 import { DeviceService } from '@energyweb/origin-backend';
-import { IDeviceProductInfo, IDeviceWithRelationsIds } from '@energyweb/origin-backend-core';
-import { ExtendedBaseEntity, DatabaseService } from '@energyweb/origin-backend-utils';
+import { IDeviceProductInfo, IDevice } from '@energyweb/origin-backend-core';
+import { DatabaseService } from '@energyweb/origin-backend-utils';
 import { INestApplication } from '@nestjs/common';
 import { expect } from 'chai';
 import { Contract, ethers } from 'ethers';
@@ -41,7 +41,7 @@ describe('Deposits automatic posting for sale', () => {
                 gridOperator: 'TH-PEA'
             };
         },
-        findByExternalId: async (): Promise<ExtendedBaseEntity & IDeviceWithRelationsIds> => {
+        findByExternalId: async (): Promise<IDevice> => {
             return {
                 deviceType: 'Solar;Photovoltaic;Classic silicon',
                 country: 'Thailand',
@@ -51,7 +51,7 @@ describe('Deposits automatic posting for sale', () => {
                 gridOperator: 'TH-PEA',
                 automaticPostForSale: true,
                 defaultAskPrice
-            } as ExtendedBaseEntity & IDeviceWithRelationsIds;
+            } as IDevice;
         }
     } as unknown) as DeviceService;
 

--- a/packages/exchange/test/exchange.ts
+++ b/packages/exchange/test/exchange.ts
@@ -2,12 +2,8 @@
 import { PriceStrategy } from '@energyweb/exchange-core';
 import { Contracts } from '@energyweb/issuer';
 import { ConfigurationService, DeviceService } from '@energyweb/origin-backend';
-import {
-    IDeviceProductInfo,
-    IDeviceWithRelationsIds,
-    UserStatus
-} from '@energyweb/origin-backend-core';
-import { DatabaseService, ExtendedBaseEntity, RolesGuard } from '@energyweb/origin-backend-utils';
+import { IDevice, IDeviceProductInfo, UserStatus } from '@energyweb/origin-backend-core';
+import { DatabaseService, RolesGuard } from '@energyweb/origin-backend-utils';
 import { getProviderWithFallback } from '@energyweb/utils-general';
 import { CanActivate, ExecutionContext, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -145,9 +141,7 @@ export const bootstrapTestInstance = async (deviceServiceMock?: DeviceService) =
                                 gridOperator: 'TH-PEA'
                             };
                         },
-                        findByExternalId: async (): Promise<
-                            ExtendedBaseEntity & IDeviceWithRelationsIds
-                        > => {
+                        findByExternalId: async (): Promise<IDevice> => {
                             return {
                                 deviceType: 'Solar;Photovoltaic;Classic silicon',
                                 country: 'Thailand',
@@ -157,7 +151,7 @@ export const bootstrapTestInstance = async (deviceServiceMock?: DeviceService) =
                                 gridOperator: 'TH-PEA',
                                 automaticPostForSale: false,
                                 defaultAskPrice: null
-                            } as ExtendedBaseEntity & IDeviceWithRelationsIds;
+                            } as IDevice;
                         }
                     } as unknown) as DeviceService)
             }

--- a/packages/origin-backend-client-mocks/src/DeviceClientMock.ts
+++ b/packages/origin-backend-client-mocks/src/DeviceClientMock.ts
@@ -3,7 +3,6 @@ import {
     DeviceStatus,
     DeviceUpdateData,
     IDevice,
-    IDeviceWithRelationsIds,
     IExternalDeviceId,
     ISmartMeterRead,
     ISmartMeterReadWithStatus,
@@ -14,28 +13,28 @@ import {
 } from '@energyweb/origin-backend-core';
 
 export class DeviceClientMock implements IDeviceClient {
-    private storage = new Map<number, IDeviceWithRelationsIds>();
+    private storage = new Map<number, IDevice>();
 
     private idCounter = 0;
 
-    async getByExternalId(id: IExternalDeviceId): Promise<IDeviceWithRelationsIds> {
+    async getByExternalId(id: IExternalDeviceId): Promise<IDevice> {
         return [...this.storage.values()].find((d) =>
             d.externalDeviceIds?.find((i) => i.type === id.type && i.id === id.id)
         );
     }
 
-    async getById(id: number): Promise<IDeviceWithRelationsIds> {
+    async getById(id: number): Promise<IDevice> {
         return this.storage.get(id);
     }
 
-    async getAll(withMeterStats: boolean): Promise<IDeviceWithRelationsIds[]> {
+    async getAll(withMeterStats: boolean): Promise<IDevice[]> {
         return [...this.storage.values()];
     }
 
-    async add(data: IDeviceWithRelationsIds): Promise<IDeviceWithRelationsIds> {
+    async add(data: IDevice): Promise<IDevice> {
         this.idCounter++;
 
-        const device: IDeviceWithRelationsIds = {
+        const device: IDevice = {
             ...data,
             id: this.idCounter,
             status: data.status ?? DeviceStatus.Submitted,
@@ -81,10 +80,7 @@ export class DeviceClientMock implements IDeviceClient {
         this.storage.set(id, device);
     }
 
-    public async getSupplyBy(
-        facilityName: string,
-        status: number
-    ): Promise<IDeviceWithRelationsIds[]> {
+    public async getSupplyBy(facilityName: string, status: number): Promise<IDevice[]> {
         return [...this.storage.values()];
     }
 
@@ -99,7 +95,7 @@ export class DeviceClientMock implements IDeviceClient {
         throw new Error('Method not implemented.');
     }
 
-    public async getMyDevices(withMeterStats: boolean): Promise<IDeviceWithRelationsIds[]> {
+    public async getMyDevices(withMeterStats: boolean): Promise<IDevice[]> {
         throw new Error('Method not implemented.');
     }
 }

--- a/packages/origin-backend-client/src/DeviceClient.ts
+++ b/packages/origin-backend-client/src/DeviceClient.ts
@@ -2,14 +2,14 @@ import {
     DeviceCreateData,
     DeviceSettingsUpdateData,
     DeviceUpdateData,
-    IDeviceWithRelationsIds,
     IExternalDeviceId,
     ISmartMeterRead,
     ISmartMeterReadWithStatus,
     ISuccessResponse,
     IDeviceClient,
     IRequestClient,
-    IDevice
+    IDevice,
+    IEnergyGeneratedWithStatus
 } from '@energyweb/origin-backend-core';
 import { BigNumber } from 'ethers';
 import { RequestClient } from './RequestClient';
@@ -24,30 +24,30 @@ export class DeviceClient implements IDeviceClient {
         return `${this.dataApiUrl}/Device`;
     }
 
-    public async getByExternalId(id: IExternalDeviceId): Promise<IDeviceWithRelationsIds> {
+    public async getByExternalId(id: IExternalDeviceId): Promise<IDevice> {
         const url = `${this.endpoint}/get-by-external-id/${id.type}/${id.id}`;
-        const { data } = await this.requestClient.get<void, IDeviceWithRelationsIds>(url);
+        const { data } = await this.requestClient.get<void, IDevice>(url);
 
         return this.cleanDeviceData(data);
     }
 
-    public async getById(id: number, loadRelationIds = true): Promise<IDeviceWithRelationsIds> {
+    public async getById(id: number, loadRelationIds = true): Promise<IDevice> {
         const url = `${this.endpoint}/${id}?loadRelationIds=${loadRelationIds}`;
-        const { data } = await this.requestClient.get<void, IDeviceWithRelationsIds>(url);
+        const { data } = await this.requestClient.get<void, IDevice>(url);
 
         return this.cleanDeviceData(data);
     }
 
     public async getAll(withMeterStats = false, loadRelationIds = true): Promise<IDevice[]> {
-        const { data } = await this.requestClient.get<void, IDeviceWithRelationsIds[]>(
+        const { data } = await this.requestClient.get<void, IDevice[]>(
             `${this.endpoint}?withMeterStats=${withMeterStats}&loadRelationIds=${loadRelationIds}`
         );
 
         return data.map((device) => this.cleanDeviceData(device));
     }
 
-    public async add(device: DeviceCreateData): Promise<IDeviceWithRelationsIds> {
-        const { data } = await this.requestClient.post<DeviceCreateData, IDeviceWithRelationsIds>(
+    public async add(device: DeviceCreateData): Promise<IDevice> {
+        const { data } = await this.requestClient.post<DeviceCreateData, IDevice>(
             this.endpoint,
             device
         );
@@ -55,11 +55,8 @@ export class DeviceClient implements IDeviceClient {
         return this.cleanDeviceData(data);
     }
 
-    public async update(
-        id: number,
-        updateData: DeviceUpdateData
-    ): Promise<IDeviceWithRelationsIds> {
-        const { data } = await this.requestClient.put<DeviceUpdateData, IDeviceWithRelationsIds>(
+    public async update(id: number, updateData: DeviceUpdateData): Promise<IDevice> {
+        const { data } = await this.requestClient.put<DeviceUpdateData, IDevice>(
             `${this.endpoint}/${id}`,
             updateData
         );
@@ -95,7 +92,7 @@ export class DeviceClient implements IDeviceClient {
      *  GET requests return BigNumber in object format instead of BigNumber.
      *  This method cleans them back to BigNumber.
      */
-    private cleanDeviceData(device: IDeviceWithRelationsIds): IDeviceWithRelationsIds {
+    private cleanDeviceData(device: IDevice): IDevice {
         let cleanDevice = { ...device };
 
         if (device.meterStats) {
@@ -121,11 +118,8 @@ export class DeviceClient implements IDeviceClient {
         return cleanDevice;
     }
 
-    public async getSupplyBy(
-        facilityName: string,
-        status: number
-    ): Promise<IDeviceWithRelationsIds[]> {
-        const { data } = await this.requestClient.get<unknown, IDeviceWithRelationsIds[]>(
+    public async getSupplyBy(facilityName: string, status: number): Promise<IDevice[]> {
+        const { data } = await this.requestClient.get<unknown, IDevice[]>(
             `${this.endpoint}/supplyBy?facility=${facilityName ?? ''}&status=${status}`
         );
         return data.map((device) => this.cleanDeviceData(device));
@@ -151,8 +145,8 @@ export class DeviceClient implements IDeviceClient {
         return data;
     }
 
-    public async getMyDevices(withMeterStats = false): Promise<IDeviceWithRelationsIds[]> {
-        const { data } = await this.requestClient.get<void, IDeviceWithRelationsIds[]>(
+    public async getMyDevices(withMeterStats = false): Promise<IDevice[]> {
+        const { data } = await this.requestClient.get<void, IDevice[]>(
             `${this.endpoint}/my-devices?withMeterStats=${withMeterStats}`
         );
 

--- a/packages/origin-backend-core/src/Device.ts
+++ b/packages/origin-backend-core/src/Device.ts
@@ -54,7 +54,7 @@ export interface IDeviceProductInfo {
     gridOperator: string;
 }
 
-export interface IDeviceProperties extends IDeviceProductInfo {
+export interface IDevice extends IDeviceProductInfo {
     id: number;
     status: DeviceStatus;
     facilityName: string;
@@ -75,21 +75,10 @@ export interface IDeviceProperties extends IDeviceProductInfo {
     defaultAskPrice: number;
     automaticPostForSale: boolean;
     files?: string;
-}
-
-export interface IDevice extends IDeviceProperties {
-    organization: IPublicOrganization | IPublicOrganization['id'];
-}
-
-export interface IDeviceWithRelationsIds extends IDevice {
-    organization: IPublicOrganization['id'];
-}
-
-export interface IDeviceWithRelations extends IDevice {
     organization: IPublicOrganization;
 }
 
-export type DeviceCreateData = Omit<IDeviceProperties, 'id' | 'meterStats'>;
+export type DeviceCreateData = Omit<IDevice, 'id' | 'meterStats' | 'organization'>;
 export type DeviceUpdateData = Pick<IDevice, 'status'>;
 export type DeviceSettingsUpdateData = Pick<IDevice, 'defaultAskPrice' | 'automaticPostForSale'>;
 

--- a/packages/origin-backend-core/src/client/index.ts
+++ b/packages/origin-backend-core/src/client/index.ts
@@ -24,7 +24,6 @@ import {
     IOrganizationInvitation,
     Role,
     onUploadProgressFunction,
-    IDeviceWithRelationsIds,
     IExternalDeviceId,
     DeviceCreateData,
     DeviceUpdateData,
@@ -142,16 +141,16 @@ export interface IFilesClient {
 
 export interface IDeviceClient {
     getById(id: number, loadRelationIds?: boolean): Promise<IDevice>;
-    getByExternalId(id: IExternalDeviceId): Promise<IDeviceWithRelationsIds>;
+    getByExternalId(id: IExternalDeviceId): Promise<IDevice>;
     getAll(withMeterStats: boolean, loadRelationIds?: boolean): Promise<IDevice[]>;
-    add(device: DeviceCreateData): Promise<IDeviceWithRelationsIds>;
+    add(device: DeviceCreateData): Promise<IDevice>;
     update(id: number, data: DeviceUpdateData): Promise<IDevice>;
     getAllSmartMeterReadings(id: number): Promise<ISmartMeterReadWithStatus[]>;
     addSmartMeterReads(id: number, smartMeterReads: ISmartMeterRead[]): Promise<void>;
-    getSupplyBy(facilityName: string, status: number): Promise<IDeviceWithRelationsIds[]>;
+    getSupplyBy(facilityName: string, status: number): Promise<IDevice[]>;
     delete(id: number): Promise<ISuccessResponse>;
     updateDeviceSettings(id: number, device: DeviceSettingsUpdateData): Promise<ISuccessResponse>;
-    getMyDevices(withMeterStats: boolean): Promise<IDeviceWithRelationsIds[]>;
+    getMyDevices(withMeterStats: boolean): Promise<IDevice[]>;
 }
 
 export interface IOffChainDataSource {

--- a/packages/origin-backend/src/pods/certification-request/certification-request.service.ts
+++ b/packages/origin-backend/src/pods/certification-request/certification-request.service.ts
@@ -100,7 +100,7 @@ export class CertificationRequestService {
             type: process.env.ISSUER_ID
         });
 
-        if (device.organization !== loggedUser.organizationId) {
+        if (device.organization.id !== loggedUser.organizationId) {
             throw new UnauthorizedException('You are not the device manager.');
         }
 
@@ -192,7 +192,7 @@ export class CertificationRequestService {
         }
 
         if (loggedUser) {
-            if (device.organization !== loggedUser.organizationId) {
+            if (device.organization.id !== loggedUser.organizationId) {
                 throw new UnauthorizedException({
                     success: false,
                     message: 'You are not the device manager.'

--- a/packages/origin-backend/src/pods/device/device.controller.ts
+++ b/packages/origin-backend/src/pods/device/device.controller.ts
@@ -2,21 +2,14 @@ import {
     DeviceCreateData,
     DeviceSettingsUpdateData,
     DeviceUpdateData,
-    IDeviceWithRelationsIds,
+    IDevice,
     ILoggedInUser,
     ISmartMeterRead,
-    Role,
     ISuccessResponse,
-    IDevice,
-    OrganizationStatus
+    OrganizationStatus,
+    Role
 } from '@energyweb/origin-backend-core';
-import {
-    Roles,
-    RolesGuard,
-    UserDecorator,
-    ActiveUserGuard,
-    ExtendedBaseEntity
-} from '@energyweb/origin-backend-utils';
+import { ActiveUserGuard, Roles, RolesGuard, UserDecorator } from '@energyweb/origin-backend-utils';
 import {
     Body,
     Controller,
@@ -29,15 +22,18 @@ import {
     Post,
     Put,
     Query,
+    UnauthorizedException,
     UnprocessableEntityException,
-    UseGuards,
-    UnauthorizedException
+    UseGuards
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { BigNumber } from 'ethers';
-import { StorageErrors } from '../../enums/StorageErrors';
 
+import { StorageErrors } from '../../enums/StorageErrors';
+import { Organization } from '../organization/organization.entity';
 import { OrganizationService } from '../organization/organization.service';
+import { PublicOrganizationInfoDTO } from '../organization/public-organization-info.dto';
+import { Device } from './device.entity';
 import { DeviceService } from './device.service';
 
 @Controller('/Device')
@@ -49,17 +45,9 @@ export class DeviceController {
         private readonly organizationService: OrganizationService
     ) {}
 
-    // TODO: remove sensitive information
-
     @Get()
-    async getAll(
-        @Query('withMeterStats') withMeterStats: boolean,
-        @Query('loadRelationIds') loadRelationIds: string | boolean = true
-    ) {
-        const devices = await this.deviceService.getAll(withMeterStats ?? false, {
-            relations: ['organization'],
-            loadRelationIds: loadRelationIds === 'true' || loadRelationIds === true
-        });
+    async getAll(@Query('withMeterStats') withMeterStats: boolean): Promise<IDevice[]> {
+        const devices = await this.deviceService.getAll(withMeterStats ?? false);
 
         return this.serializeDevices(devices, withMeterStats);
     }
@@ -70,10 +58,11 @@ export class DeviceController {
     async getMyDevices(
         @Query('withMeterStats') withMeterStats: boolean,
         @UserDecorator() { organizationId }: ILoggedInUser
-    ) {
-        const devices = await this.deviceService.getAll(withMeterStats ?? false, {
-            where: { organization: { id: organizationId } }
-        });
+    ): Promise<IDevice[]> {
+        const devices = await this.deviceService.getOrganizationDevices(
+            organizationId,
+            withMeterStats ?? false
+        );
 
         return this.serializeDevices(devices, withMeterStats);
     }
@@ -85,7 +74,7 @@ export class DeviceController {
         @UserDecorator() { organizationId }: ILoggedInUser,
         @Query('facility') facilityName: string,
         @Query('status') status: string
-    ) {
+    ): Promise<IDevice[]> {
         const devices = await this.deviceService.getSupplyBy(
             organizationId,
             facilityName,
@@ -98,17 +87,9 @@ export class DeviceController {
     @Get('/:id')
     async get(
         @Param('id') id: string,
-        @Query('withMeterStats') withMeterStats: boolean,
-        @Query('loadRelationIds') loadRelationIds: string | boolean = true
-    ) {
-        const device = await this.deviceService.findOne(
-            id,
-            {
-                relations: ['organization'],
-                loadRelationIds: loadRelationIds === 'true' || loadRelationIds === true
-            },
-            withMeterStats
-        );
+        @Query('withMeterStats') withMeterStats: boolean
+    ): Promise<IDevice> {
+        const device = await this.deviceService.findOne(id, withMeterStats);
 
         if (!device) {
             throw new NotFoundException(StorageErrors.NON_EXISTENT);
@@ -122,7 +103,10 @@ export class DeviceController {
     @Post()
     @UseGuards(AuthGuard(), ActiveUserGuard, RolesGuard)
     @Roles(Role.OrganizationAdmin, Role.OrganizationDeviceManager)
-    async createDevice(@Body() body: DeviceCreateData, @UserDecorator() loggedUser: ILoggedInUser) {
+    async createDevice(
+        @Body() body: DeviceCreateData,
+        @UserDecorator() loggedUser: ILoggedInUser
+    ): Promise<IDevice> {
         if (typeof loggedUser.organizationId === 'undefined') {
             throw new ForbiddenException('general.feedback.noOrganization');
         }
@@ -142,8 +126,7 @@ export class DeviceController {
         @Param('id') id: string,
         @UserDecorator() loggedUser: ILoggedInUser
     ): Promise<ISuccessResponse> {
-        const device = (await this.deviceService.findOne(id)) as ExtendedBaseEntity &
-            IDeviceWithRelationsIds;
+        const device = await this.deviceService.findOne(id);
 
         if (!device) {
             throw new NotFoundException({
@@ -153,7 +136,7 @@ export class DeviceController {
         }
 
         if (
-            loggedUser.organizationId !== device.organization &&
+            loggedUser.organizationId !== device.organization.id &&
             !loggedUser.hasRole(Role.Issuer) &&
             !loggedUser.hasRole(Role.Admin)
         ) {
@@ -163,7 +146,7 @@ export class DeviceController {
             });
         }
 
-        await this.deviceService.remove(device);
+        await this.deviceService.remove(device as Device);
 
         return {
             success: true,
@@ -177,7 +160,7 @@ export class DeviceController {
     async updateDeviceStatus(
         @Param('id') id: string,
         @Body() body: DeviceUpdateData
-    ): Promise<ExtendedBaseEntity & IDeviceWithRelationsIds> {
+    ): Promise<IDevice> {
         return this.deviceService.updateStatus(id, body);
     }
 
@@ -221,7 +204,7 @@ export class DeviceController {
     }
 
     @Get('/get-by-external-id/:type/:id')
-    async getByExternalId(@Param('type') type: string, @Param('id') id: string) {
+    async getByExternalId(@Param('type') type: string, @Param('id') id: string): Promise<IDevice> {
         const existing = await this.deviceService.findByExternalId({ id, type });
 
         if (!existing) {
@@ -249,7 +232,7 @@ export class DeviceController {
         }
 
         if (
-            loggedUser.organizationId !== device.organization &&
+            loggedUser.organizationId !== device.organization.id &&
             !loggedUser.hasRole(Role.Admin, Role.SupportAgent)
         ) {
             throw new UnauthorizedException({
@@ -290,7 +273,10 @@ export class DeviceController {
                     certified: BigNumber.from(device.meterStats.certified).toString(),
                     uncertified: BigNumber.from(device.meterStats.uncertified).toString()
                 }
-            })
+            }),
+            organization: PublicOrganizationInfoDTO.fromPlatformOrganization(
+                device.organization as Organization
+            )
         }));
     }
 }

--- a/packages/origin-backend/src/pods/device/device.service.ts
+++ b/packages/origin-backend/src/pods/device/device.service.ts
@@ -7,7 +7,6 @@ import {
     ICertificationRequestBackend,
     IDevice,
     IDeviceProductInfo,
-    IDeviceWithRelationsIds,
     IEnergyGeneratedWithStatus,
     IExternalDeviceId,
     ILoggedInUser,
@@ -31,7 +30,6 @@ import { BigNumber } from 'ethers';
 import moment from 'moment';
 import { FindOneOptions, Repository } from 'typeorm';
 import { v4 as uuid } from 'uuid';
-import { ExtendedBaseEntity } from '@energyweb/origin-backend-utils';
 import { SM_READS_ADAPTER } from '../../const';
 import { StorageErrors } from '../../enums/StorageErrors';
 import { ConfigurationService } from '../configuration';
@@ -50,12 +48,8 @@ export class DeviceService {
         @Inject(SM_READS_ADAPTER) private smartMeterReadingsAdapter?: ISmartMeterReadingsAdapter
     ) {}
 
-    async findByExternalId(
-        externalId: IExternalDeviceId
-    ): Promise<ExtendedBaseEntity & IDeviceWithRelationsIds> {
-        const devices = ((await this.repository.find({
-            loadRelationIds: true
-        })) as IDevice[]) as (ExtendedBaseEntity & IDeviceWithRelationsIds)[];
+    async findByExternalId(externalId: IExternalDeviceId): Promise<IDevice> {
+        const devices = (await this.repository.find({ relations: ['organization'] })) as IDevice[];
 
         const device = devices.find((d) =>
             d.externalDeviceIds.find((id) => id.id === externalId.id && id.type === externalId.type)
@@ -64,16 +58,10 @@ export class DeviceService {
         return device;
     }
 
-    async findOne(
-        id: string,
-        options: FindOneOptions<Device> = {},
-        withMeterStats = false
-    ): Promise<ExtendedBaseEntity & IDevice> {
-        const { loadRelationIds = true } = options;
-        const device = ((await this.repository.findOne(id, {
-            loadRelationIds,
-            ...options
-        })) as IDevice) as ExtendedBaseEntity & IDevice;
+    async findOne(id: string, withMeterStats = false): Promise<IDevice> {
+        const device = (await this.repository.findOne(id, {
+            relations: ['organization']
+        })) as IDevice;
 
         if (this.smartMeterReadingsAdapter) {
             device.smartMeterReads = [];
@@ -86,7 +74,7 @@ export class DeviceService {
         return device;
     }
 
-    async create(data: DeviceCreateData, loggedUser: ILoggedInUser) {
+    async create(data: DeviceCreateData, loggedUser: ILoggedInUser): Promise<IDevice> {
         const configuration = await this.configurationService.get();
         const organization = await this.organizationService.findOne(loggedUser.organizationId);
 
@@ -124,11 +112,11 @@ export class DeviceService {
 
         await this.repository.save(newEntity);
 
-        return newEntity;
+        return this.findOne(newEntity.id.toString());
     }
 
-    async remove(entity: Device | (ExtendedBaseEntity & IDeviceWithRelationsIds)) {
-        this.repository.remove((entity as IDevice) as Device);
+    async remove(entity: Device): Promise<void> {
+        await this.repository.remove(entity);
     }
 
     async getAllSmartMeterReadings(id: string): Promise<ISmartMeterRead[]> {
@@ -189,27 +177,25 @@ export class DeviceService {
         };
     }
 
-    async getAll(
-        withMeterStats = false,
-        options: FindOneOptions<Device> = {}
-    ): Promise<Array<ExtendedBaseEntity & IDevice>> {
-        const { loadRelationIds = true } = options;
-        const devices = ((await this.repository.find({
-            loadRelationIds,
-            ...options
-        })) as IDevice[]) as (ExtendedBaseEntity & IDevice)[];
+    async getAll(withMeterStats = false, options: FindOneOptions<Device> = {}): Promise<IDevice[]> {
+        const devices = (await this.repository.find({
+            ...options,
+            relations: ['organization']
+        })) as IDevice[];
 
-        for (const device of devices) {
-            if (this.smartMeterReadingsAdapter) {
-                device.smartMeterReads = [];
-            }
+        return withMeterStats ? this.attachMeterStats(devices) : devices;
+    }
 
-            if (withMeterStats) {
-                device.meterStats = await this.getMeterStats(device.id.toString());
-            }
-        }
+    async getOrganizationDevices(
+        organizationId: number,
+        withMeterStats = false
+    ): Promise<IDevice[]> {
+        const devices = (await this.repository.find({
+            relations: ['organization'],
+            where: { organization: { id: organizationId } }
+        })) as IDevice[];
 
-        return devices;
+        return withMeterStats ? this.attachMeterStats(devices) : devices;
     }
 
     async findDeviceProductInfo(externalId: IExternalDeviceId): Promise<IDeviceProductInfo> {
@@ -222,11 +208,8 @@ export class DeviceService {
         );
     }
 
-    async updateStatus(
-        id: string,
-        update: DeviceUpdateData
-    ): Promise<ExtendedBaseEntity & IDeviceWithRelationsIds> {
-        const device = (await this.findOne(id)) as ExtendedBaseEntity & IDeviceWithRelationsIds;
+    async updateStatus(id: string, update: DeviceUpdateData): Promise<IDevice> {
+        const device = await this.findOne(id);
 
         if (!device) {
             throw new NotFoundException(StorageErrors.NON_EXISTENT);
@@ -236,7 +219,7 @@ export class DeviceService {
             await this.repository.update(device.id, { status: update.status });
 
             const deviceManagers = await this.organizationService.getDeviceManagers(
-                device.organization
+                device.organization.id
             );
 
             const event: DeviceStatusChangedEvent = {
@@ -358,7 +341,7 @@ export class DeviceService {
     async getSupplyBy(organizationId: number, facilityName: string, status: number) {
         const _facilityName = `%${facilityName}%`;
         const _status = status === 1;
-        const devices = ((await this.repository
+        const devices = (await this.repository
             .createQueryBuilder('device')
             .leftJoinAndSelect('device.organization', 'organization')
             .where(
@@ -367,7 +350,7 @@ export class DeviceService {
                 }`,
                 { organizationId, _facilityName, _status }
             )
-            .getMany()) as IDevice[]) as (ExtendedBaseEntity & IDeviceWithRelationsIds)[];
+            .getMany()) as IDevice[];
 
         for (const device of devices) {
             if (this.smartMeterReadingsAdapter) {
@@ -378,5 +361,19 @@ export class DeviceService {
         }
 
         return devices;
+    }
+
+    private async attachMeterStats(devices: IDevice[]) {
+        return Promise.all(
+            devices.map(async (d) => {
+                const device = d;
+                if (this.smartMeterReadingsAdapter) {
+                    device.smartMeterReads = [];
+                }
+                device.meterStats = await this.getMeterStats(device.id.toString());
+
+                return device;
+            })
+        );
     }
 }

--- a/packages/origin-backend/test/device.e2e-spec.ts
+++ b/packages/origin-backend/test/device.e2e-spec.ts
@@ -2,11 +2,11 @@
 import {
     DeviceSettingsUpdateData,
     DeviceStatus,
-    IDeviceWithRelationsIds,
     Role,
     ILoggedInUser,
     DeviceCreateData,
-    OrganizationStatus
+    OrganizationStatus,
+    IDevice
 } from '@energyweb/origin-backend-core';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
@@ -133,7 +133,7 @@ describe('Device e2e tests', () => {
             .get(`/device/${deviceId}`)
             .set('Authorization', `Bearer ${accessToken}`)
             .expect((res) => {
-                const device = res.body as IDeviceWithRelationsIds;
+                const device = res.body as IDevice;
                 expect(device.defaultAskPrice).equals(null);
                 expect(device.automaticPostForSale).equals(false);
             });
@@ -180,7 +180,7 @@ describe('Device e2e tests', () => {
             .get(`/device/${deviceId}`)
             .set('Authorization', `Bearer ${accessToken}`)
             .expect((res) => {
-                const device = res.body as IDeviceWithRelationsIds;
+                const device = res.body as IDevice;
 
                 expect(device.defaultAskPrice).equals(settingWithCorrectPrice.defaultAskPrice);
                 expect(device.automaticPostForSale).equals(true);
@@ -225,7 +225,7 @@ describe('Device e2e tests', () => {
             .get(`/device/${device.id}?withMeterStats=true`)
             .set('Authorization', `Bearer ${accessToken}`)
             .expect((res) => {
-                const resultDevice = res.body as IDeviceWithRelationsIds;
+                const resultDevice = res.body as IDevice;
 
                 const [firstRead] = resultDevice.smartMeterReads;
 
@@ -291,7 +291,7 @@ describe('Device e2e tests', () => {
             .get(`/device/${device.id}?withMeterStats=true`)
             .set('Authorization', `Bearer ${accessToken}`)
             .expect((res) => {
-                const resultDevice = res.body as IDeviceWithRelationsIds;
+                const resultDevice = res.body as IDevice;
 
                 expect(
                     BigNumber.from(resultDevice.meterStats.certified).toNumber()

--- a/packages/origin-ui-core/src/__tests__/unit/SmartMeterReadingsChart.test.tsx
+++ b/packages/origin-ui-core/src/__tests__/unit/SmartMeterReadingsChart.test.tsx
@@ -5,7 +5,7 @@ import { SmartMeterReadingsChart } from '../../components/devices/SmartMeterRead
 import { ProducingDevice } from '@energyweb/device-registry';
 import { Bar } from 'react-chartjs-2';
 import { formatDate, EnergyFormatter, moment } from '../../utils';
-import { IDeviceWithRelationsIds, IEnergyGenerated } from '@energyweb/origin-backend-core';
+import { IDevice, IEnergyGenerated } from '@energyweb/origin-backend-core';
 import { initializeI18N } from '../../components';
 import { createRenderedHelpers } from '../utils/helpers';
 
@@ -20,7 +20,7 @@ describe('SmartMeterReadingsChart', () => {
             .map((x, i) => currentTime.clone().startOf('month').add(i, 'days'));
         const currentDayHour = currentTime.hour();
 
-        const offChainProperties: Partial<IDeviceWithRelationsIds> = {
+        const offChainProperties: Partial<IDevice> = {
             timezone: 'Asia/Bangkok'
         };
 

--- a/packages/origin-ui-core/src/components/certificates/CertificationRequestsTable.tsx
+++ b/packages/origin-ui-core/src/components/certificates/CertificationRequestsTable.tsx
@@ -67,7 +67,7 @@ export function CertificationRequestsTable(props: IProps) {
 
                 if (
                     request.approved !== props.approved ||
-                    (!isIssuer && user?.organization.id !== requestDevice?.organization)
+                    (!isIssuer && user?.organization.id !== requestDevice?.organization.id)
                 ) {
                     continue;
                 }

--- a/packages/origin-ui-core/src/components/devices/DeviceMap.tsx
+++ b/packages/origin-ui-core/src/components/devices/DeviceMap.tsx
@@ -135,8 +135,9 @@ export function DeviceMap(props: IProps) {
                             <br />
                             {t('deviceMap.properties.owner')}:{' '}
                             {
-                                organizations?.find((o) => o?.id === deviceHighlighted.organization)
-                                    ?.name
+                                organizations?.find(
+                                    (o) => o?.id === deviceHighlighted.organization.id
+                                )?.name
                             }
                             <br />
                             <br />

--- a/packages/origin-ui-core/src/components/exchange/Asks.tsx
+++ b/packages/origin-ui-core/src/components/exchange/Asks.tsx
@@ -4,7 +4,7 @@ import { getExchangeClient, getOffChainDataSource, getEnvironment } from '../../
 import React, { useState, useEffect } from 'react';
 import { formatDate, moment, useTranslation, useValidation, EnergyFormatter } from '../../utils';
 import { IAsset, IOrderBookOrderDTO, calculateTotalPrice } from '../../utils/exchange';
-import { IDeviceWithRelationsIds } from '@energyweb/origin-backend-core';
+import { IDevice } from '@energyweb/origin-backend-core';
 import { Orders } from '.';
 import { TableCell, Button, InputAdornment, Grid } from '@material-ui/core';
 import { getUserOffchain } from '../../features/users/selectors';
@@ -32,7 +32,7 @@ export function Asks(props: Props) {
 
     const [selectedOrder, setSelectedOrder] = useState<IOrderBookOrderDTO>(null);
     const [asset, setAsset] = useState<IAsset>();
-    const [device, setDevice] = useState<IDeviceWithRelationsIds>();
+    const [device, setDevice] = useState<IDevice>();
     const [buyDirectExpanded, setBuyDirectExpanded] = useState(false);
 
     async function fetchDetails(assetId: string) {


### PR DESCRIPTION
This PR fixes provides:
- fix the mismatch between declared and returned data from device endpoint
- simplifies return device interfaces, no longer ambiguous organization property
- fixes the issue where complete (incl private data) Organization info was leaked with public device call 