### PR TITLE
fix/spelling and allowed actions info

### DIFF
--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -370,8 +370,10 @@
                 "roleChanged": {
                     "succesfullyJoinedOrg": "Successfully joined {{orgName}}",
                     "asMemberYouCan": "You have successfully joined {{orgName}} of {{admin}}. As a member you can",
-                    "asDeviceManYouCan": "You have successfully joined {{orgName}} of {{admin}}. As a Device Manager you have permissions",
-                    "asOrgAdminYouCan": "You have successfully joined {{orgName}} of {{admin}}. As an Organization Admin you have permissions",
+                    "asDeviceManYouCan": "You have successfully joined {{orgName}} of {{admin}}. As a Device Manager you have permission to",
+                    "asOrgAdminYouCan": "You have successfully joined {{orgName}} of {{admin}}. As an Organization Admin you have permission to",
+                    "canAddOrRemoveOrgMembers": "Add or remove members from the organization",
+                    "canEditUserRoles": "Give and edit user roles",
                     "canPlaceOrder": "Place orders on the exchange",
                     "canBuyIRec": "Directly buy I-RECs",
                     "canCreateAndBuyIRecBundles": "Create and buy I-REC bundles",
@@ -380,8 +382,8 @@
                     "canRegisterDevices": "Register devices and device groups",
                     "canRequestIssuenceOfIRec": "Request the issuance of I-RECs",
                     "canConfigureAutomatedOrderCreation": "Configure automated order creation",
-                    "canAddOrRemoveOrgMembers": "Add or remove members from the organization",
                     "connectOrgToIRec": "Connect the organization to the I-REC registry",
+                    "asDeviceManagerYouCanAlso": "You can also perform all actions of a device manager",
                     "asAMemberYouCanAlso": "You can also perform all actions that a regular organization member can perform"
                 }
             },
@@ -399,8 +401,8 @@
             },
             "dialog": {
                 "dontHaveAccAsk": "Don't have an account?",
-                "userRegisteredModalTitle": "Thanks for registering a user on the [platform name] marketplace",
-                "userRegisteredModalContent": "You should have received an E-Mail from us. In order to activate your user, please confirm your E-Mail address by clicking confirmation link in the E-Mail"
+                "userRegisteredModalTitle": "Thanks for registering a user on the marketplace",
+                "userRegisteredModalContent": "You should have received an E-Mail from us. In order to activate your user, please confirm your E-Mail address by clicking the confirmation link in the E-Mail"
             }
         },
         "notification": {
@@ -457,8 +459,8 @@
                     "admin": "Admin"
                 },
                 "dialog": {
-                    "invitationsModalTitle": "Invitation to join the [marketplace name]",
-                    "invitationMessage": "{{admin}} has invited you to join the [marketplace name] as a {{role}} for {{orgName}}. Click accept to join the Organization"
+                    "invitationsModalTitle": "Invitation to join the marketplace",
+                    "invitationMessage": "{{admin}} has invited you to join the marketplace as a {{role}} for {{orgName}}. Click accept to join the Organization"
                 },
                 "actions": {
                     "later": "Maybe later",
@@ -475,8 +477,8 @@
                 }
             },
             "registration": {
-                "loginNoInvitationsModalTitle": "Thank you for registering as a user on the [platform name] marketplace",
-                "loginNoInvitationsModalContent": "To unlock all the functionalities of the marketpalce, like trading I-REC's, users also need to register an organization",
+                "loginNoInvitationsModalTitle": "Thank you for registering as a user on the marketplace",
+                "loginNoInvitationsModalContent": "Aby odblokować wszystkie funkcje rynku, takie jak handel I-REC, użytkownicy muszą również zarejestrować organizację",
                 "registerOrganization": "Register organization",
                 "organizationInformation": "Organization information",
                 "organizationName": "Organization Name",
@@ -515,8 +517,8 @@
                 
                 "titleRegisterIREC": "I-REC Registration information",
                 "IRECAccountType": "I-REC Account type",
-                "irecParticipantDescription": "Registrant Account for device owner",
-                "irecRegistrantDescription": "Participant Account for traders that also trade outside of marketplace",
+                "irecParticipantDescription": "Participant Account for traders that also trade outside of marketplace",
+                "irecRegistrantDescription": "Registrant Account for device owners",
                 "orgHeadquatersCompany": "Organization Headquaters Company",
                 "yearOfRegistration": "Year of Registration",
                 "numberOfEmployees": "Number of employees",

--- a/packages/localization/src/languages/pl.json
+++ b/packages/localization/src/languages/pl.json
@@ -251,8 +251,10 @@
                 "roleChanged": {
                     "succesfullyJoinedOrg": "Pomyślnie dołączył do {{orgName}}",
                     "asMemberYouCan": "Dołączyłeś do {{orgName}} {{admin}}. Jako członek możesz",
-                    "asDeviceManYouCan": "Dołączyłeś do {{orgName}} {{admin}}. Jako Menedżer urządzeń masz uprawnienia",
-                    "asOrgAdminYouCan": "Dołączyłeś do {{orgName}} {{admin}}. Jako Administrator organizacji masz uprawnienia",
+                    "asDeviceManYouCan": "Dołączyłeś do {{orgName}} z {{admin}}. Jako menedżer urządzeń masz uprawnienia do",
+                    "asOrgAdminYouCan": "Dołączyłeś do {{orgName}} z {{admin}}. Jako administrator organizacji masz uprawnienia do",
+                    "canAddOrRemoveOrgMembers": "Dodaj lub usuń członków z organizacji",
+                    "canEditUserRoles": "Przydziel i edytuj role użytkowników",
                     "canPlaceOrder": "Składaj zamówienia na giełdzie",
                     "canBuyIRec": "Kupuj bezpośrednio I-REC",
                     "canCreateAndBuyIRecBundles": "Twórz i kupuj pakiety I-REC",
@@ -261,14 +263,14 @@
                     "canRegisterDevices": "Zarejestruj urządzenia i grupy urządzeń",
                     "canRequestIssuenceOfIRec": "Poproś o wydanie I-REC",
                     "canConfigureAutomatedOrderCreation": "Skonfiguruj automatyczne tworzenie zamówień",
-                    "canAddOrRemoveOrgMembers": "Dodaj lub usuń członków z organizacji",
                     "connectOrgToIRec": "Podłącz organizację do rejestru I-REC",
+                    "asDeviceManagerYouCanAlso": "Możesz także wykonywać wszystkie czynności menedżera urządzeń",
                     "asAMemberYouCanAlso": "Możesz także wykonywać wszystkie czynności, które może wykonywać zwykły członek organizacji"
                 }
             },
             "dialog": {
                 "dontHaveAccAsk": "Nie masz konta?",
-                "userRegisteredModalTitle": "Dziękujemy za zarejestrowanie użytkownika na platformie handlowej [nazwa platformy]",
+                "userRegisteredModalTitle": "Dziękujemy za zarejestrowanie użytkownika na rynku",
                 "userRegisteredModalContent": "Powinieneś otrzymać od nas e-mail. Aby aktywować użytkownika, potwierdź swój adres e-mail, klikając łącze potwierdzające w wiadomości e-mail"
             }
         },
@@ -293,8 +295,8 @@
                     "admin": "Administrator"
                 },
                 "dialog": {
-                    "invitationsModalTitle": "Zaproszenie do dołączenia do [marketplace name]",
-                    "invitationMessage": "{{admin}} zaprosił Cię do dołączenia do marketplace [marketplace name] jako {{role}} w {{orgName}}. Kliknij zaakceptuj, aby dołączyć do organizacji"
+                    "invitationsModalTitle": "Zaproszenie do dołączenia do rynku",
+                    "invitationMessage": "{{admin}} zaprosił Cię do dołączenia do rynku jako {{role}} w {{orgName}}. Kliknij zaakceptuj, aby dołączyć do organizacji"
                 },
                 "actions": {
                     "later": "Może później",
@@ -311,7 +313,7 @@
                 }
             },
             "registration": {
-                "loginNoInvitationsModalTitle": "Dziękujemy za zarejestrowanie się jako użytkownik na platformie handlowej [nazwa platformy]",
+                "loginNoInvitationsModalTitle": "Dziękujemy za zarejestrowanie się jako użytkownik na rynku",
                 "loginNoInvitationsModalContent": "Aby odblokować wszystkie funkcje rynku, takie jak handel I-REC, użytkownicy muszą również zarejestrować organizację",
                 "registerOrganization": "Zarejestruj organizację",
                 "organizationInformation": "Informacje o organizacji",
@@ -348,8 +350,8 @@
                 "clientID": "Klient ID",
                 "clientSecret": "Klient Secret",
                 "titleRegisterIREC": "Informacja o rejestracji I-REC",
-                "irecParticipantDescription": "Konto rejestrującego właściciela urządzenia",
-                "irecRegistrantDescription": "Konto uczestnika dla handlowców, którzy handlują również poza rynkiem",
+                "irecParticipantDescription": "Konto uczestnika dla handlowców, którzy handlują również poza rynkiem",
+                "irecRegistrantDescription": "Konto rejestrującego dla właścicieli urządzeń",
                 "IRECAccountType": "Typ konta I-REC",
                 "orgHeadquatersCompany": "Siedziba organizacji Firma",
                 "yearOfRegistration": "Rok rejestracji",

--- a/packages/origin-ui-core/src/components/Modal/RoleChangedModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/RoleChangedModal.tsx
@@ -14,7 +14,7 @@ import {
     Box
 } from '@material-ui/core';
 import { useSelector } from 'react-redux';
-import { Role, OrganizationInvitationStatus } from '@energyweb/origin-backend-core';
+import { Role, OrganizationInvitationStatus, isRole } from '@energyweb/origin-backend-core';
 import { OriginConfigurationContext } from '..';
 import { OriginFeature } from '@energyweb/utils-general';
 import { getUserOffchain, getInvitations } from '../../features/users/selectors';
@@ -153,7 +153,7 @@ export const RoleChangedModal = ({ showModal, setShowModal, setShowIRec }: IProp
                                     </ListItem>
                                 ))}
                             </List>
-                            {[Role.OrganizationAdmin].includes(user?.rights) && (
+                            {isRole(user, Role.OrganizationAdmin) && (
                                 <div>
                                     {t('user.feedback.roleChanged.asDeviceManagerYouCanAlso')}
                                     <br />
@@ -174,8 +174,10 @@ export const RoleChangedModal = ({ showModal, setShowModal, setShowIRec }: IProp
                                     </List>
                                 </div>
                             )}
-                            {[Role.OrganizationAdmin, Role.OrganizationDeviceManager].includes(
-                                user?.rights
+                            {isRole(
+                                user,
+                                Role.OrganizationAdmin,
+                                Role.OrganizationDeviceManager
                             ) && (
                                 <div>
                                     {t('user.feedback.roleChanged.asAMemberYouCanAlso')}

--- a/packages/origin-ui-core/src/components/Modal/RoleChangedModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/RoleChangedModal.tsx
@@ -34,7 +34,7 @@ export const RoleChangedModal = ({ showModal, setShowModal, setShowIRec }: IProp
     const userRef = useRef(user);
     const { t } = useTranslation();
     const {
-        typography: { fontSizeSm },
+        typography: { fontSizeMd },
         palette: {
             text: { primary }
         }
@@ -87,13 +87,7 @@ export const RoleChangedModal = ({ showModal, setShowModal, setShowIRec }: IProp
                 ];
                 break;
             case Role.OrganizationAdmin:
-                actions = [
-                    'canRegisterDevices',
-                    'canRequestIssuenceOfIRec',
-                    'canConfigureAutomatedOrderCreation',
-                    'canAddOrRemoveOrgMembers',
-                    'connectOrgToIRec'
-                ];
+                actions = ['canAddOrRemoveOrgMembers', 'canEditUserRoles', 'connectOrgToIRec'];
                 break;
             default:
                 actions = [];
@@ -127,12 +121,12 @@ export const RoleChangedModal = ({ showModal, setShowModal, setShowIRec }: IProp
                             <br />
                             <br />
                             <Box
-                                fontSize={fontSizeSm}
+                                fontSize={fontSizeMd}
                                 fontWeight="fontWeightRegular"
                                 color="text.secondary"
                             >
                                 <Trans
-                                    style={{ fontSize: fontSizeSm }}
+                                    style={{ fontSize: fontSizeMd }}
                                     i18nKey={getAsRoleYouCan(user?.rights)}
                                     values={{
                                         orgName: user?.organization?.name,
@@ -148,7 +142,7 @@ export const RoleChangedModal = ({ showModal, setShowModal, setShowIRec }: IProp
                 <Grid container>
                     <Grid item xs={3}></Grid>
                     <Grid item xs={9}>
-                        <Box color="text.secondary" fontSize={fontSizeSm}>
+                        <Box color="text.secondary" fontSize={fontSizeMd}>
                             <List dense>
                                 {allowedActions(user?.rights).map((action) => (
                                     <ListItem key={action}>
@@ -159,6 +153,27 @@ export const RoleChangedModal = ({ showModal, setShowModal, setShowIRec }: IProp
                                     </ListItem>
                                 ))}
                             </List>
+                            {[Role.OrganizationAdmin].includes(user?.rights) && (
+                                <div>
+                                    {t('user.feedback.roleChanged.asDeviceManagerYouCanAlso')}
+                                    <br />
+                                    <br />
+                                    <List dense>
+                                        {allowedActions(Role.OrganizationDeviceManager).map(
+                                            (action) => (
+                                                <ListItem key={action}>
+                                                    <ListItemIcon>
+                                                        <Brightness1
+                                                            style={{ fontSize: 7, color: primary }}
+                                                        />
+                                                    </ListItemIcon>
+                                                    <ListItemText>{t(action)}</ListItemText>
+                                                </ListItem>
+                                            )
+                                        )}
+                                    </List>
+                                </div>
+                            )}
                             {[Role.OrganizationAdmin, Role.OrganizationDeviceManager].includes(
                                 user?.rights
                             ) && (

--- a/packages/origin-ui-core/src/components/Organization/IRECRegisterForm.tsx
+++ b/packages/origin-ui-core/src/components/Organization/IRECRegisterForm.tsx
@@ -55,12 +55,12 @@ export const IRECRegisterForm = () => {
 
     const accountTypeOptions = [
         {
-            value: IRECAccountType.Participant,
-            label: t('organization.registration.irecParticipantDescription')
-        },
-        {
             value: IRECAccountType.Registrant,
             label: t('organization.registration.irecRegistrantDescription')
+        },
+        {
+            value: IRECAccountType.Participant,
+            label: t('organization.registration.irecParticipantDescription')
         }
     ];
 


### PR DESCRIPTION
This PR provides: 

1. Change Registration Message wording
Remove the platform name in Registration Message Window. The text should be:
"Thanks for registering a user on the marketplace. You should have received an E-Mail from us. In order to activate your user, please confirm your E-Mail address by clicking the confirmation link in the E-Mail."
![1  userRegisteredModal](https://user-images.githubusercontent.com/69903849/93485391-b2ec2b80-f90b-11ea-91ec-2196e95f2518.png)

2. Change invitation message wording
Remove the [marketplace name] from the invitation message. The text should be the following:
"[Admin Name] has invited you to join the marketplace as a [User Role] for [Organization Name]. Click accept to join the Organization."
![2 invitationModal](https://user-images.githubusercontent.com/69903849/93485487-c9928280-f90b-11ea-9a9b-fcf1ac3310f9.png)

3. Change joined as an Admin / Device Manager message wording
![roleChangedAdmin](https://user-images.githubusercontent.com/69903849/93572639-cb595600-f99e-11ea-9b64-29693c076986.png)
![4  roleDeviceManModal](https://user-images.githubusercontent.com/69903849/93485672-fc3c7b00-f90b-11ea-9b48-16fe8c8945d3.png)
![5  roleMemberModal](https://user-images.githubusercontent.com/69903849/93485761-17a78600-f90c-11ea-8b26-01a1a9fd34f1.png)

4. Typo I-REC Registration wording
Under I-REC Account Type, an S is missing at the end and the first option should be
“Registrant Account for device owners” 
not 
“Registrant Account for device owner”
![6  irecRegisterFormAdjusted](https://user-images.githubusercontent.com/69903849/93485862-34dc5480-f90c-11ea-8a34-0382de234a3e.png)
