### PR TITLE
feat/connect blockchain modal

### DIFF
--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -255,7 +255,9 @@
                 "tryingToSignAndBoundIs": "You are trying to sign a transaction with account different than the one that has been linked to your account. Blockchain address bound to your user is:",
                 "andYouAreTrying": "and you are trying to use address:",
                 "noBlockchainAccount1": "Make sure you have the MetaMask browser extension installed and set up.",
-                "noBlockchainAccount2": "Check the User Settings page and make sure your blockchain account is verified."
+                "noBlockchainAccount2": "Check the User Settings page and make sure your blockchain account is verified.",
+                "connectBlockchainTitle": "Connect Blockchain Address",
+                "connectBlockchainContent": "In order to unlock all functionalities of the marketplace, like requesting certificate issuance, users have to connect a blockchain address"
             }
         },
         "importAccount": {

--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -232,6 +232,8 @@
             },
             "actions": {
                 "update": "Update",
+                "maybeLater": "Maybe Later",
+                "connectAddress": "Connect Address",
                 "continue": "Continue",
                 "cancel": "Cancel",
                 "search": "Search",

--- a/packages/localization/src/languages/pl.json
+++ b/packages/localization/src/languages/pl.json
@@ -149,6 +149,8 @@
             },
             "actions": {
                 "update": "Zaktualizuj",
+                "maybeLater": "Może później",
+                "connectAddress": "Połącz adres",
                 "continue": "Kontynuuj",
                 "cancel": "Anuluj"
             },

--- a/packages/localization/src/languages/pl.json
+++ b/packages/localization/src/languages/pl.json
@@ -155,6 +155,14 @@
             "feedback": {
                 "noChangesMade": "Nie dokonano żadnych zmian.",
                 "unknownError": "Nieznany błąd"
+            },
+            "info": {
+                "tryingToSignAndBoundIs": "Próbujesz podpisać transakcję za pomocą innego konta niż to, które zostało połączone z Twoim kontem. Adres Blockchain powiązany z Twoim użytkownikiem to:",
+                "andYouAreTrying": "i próbujesz użyć adresu:",
+                "noBlockchainAccount1": "Upewnij się, że masz zainstalowane i skonfigurowane rozszerzenie przeglądarki MetaMask.",
+                "noBlockchainAccount2": "Sprawdź stronę Ustawienia użytkownika i upewnij się, że Twoje konto blockchain jest zweryfikowane.",
+                "connectBlockchainTitle": "Połącz adres Blockchain",
+                "connectBlockchainContent": "Aby odblokować wszystkie funkcje rynku, takie jak żądanie wydania certyfikatu, użytkownicy muszą połączyć adres łańcucha bloków"
             }
         },
         "importAccount": {

--- a/packages/origin-ui-core/src/components/Modal/ConnectBlockchainAccountModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/ConnectBlockchainAccountModal.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+    Dialog,
+    DialogTitle,
+    DialogActions,
+    Button,
+    Box,
+    useTheme,
+    Grid,
+    makeStyles,
+    createStyles
+} from '@material-ui/core';
+import { useTranslation, useLinks } from '../..';
+
+interface IProps {
+    showModal?: boolean;
+    setShowModal?: (showModal: boolean) => void;
+}
+
+export const ConnectBlockchainAccountModal = ({ showModal, setShowModal }: IProps) => {
+    const history = useHistory();
+    const { t } = useTranslation();
+    const { getDefaultLink, getUserProfileLink } = useLinks();
+
+    const {
+        typography: { fontSizeMd }
+    } = useTheme();
+
+    const useStyles = makeStyles(() =>
+        createStyles({
+            maybeButton: {
+                marginRight: '1rem'
+            },
+            modalContent: {
+                fontSize: '16px'
+            },
+            modalTitle: {
+                fontSize: '24px'
+            }
+        })
+    );
+    const classes = useStyles(useTheme());
+
+    const closeModal = () => {
+        setShowModal(false);
+        history.push(getDefaultLink());
+    };
+
+    const connectAddress = () => {
+        setShowModal(false);
+        history.push(getUserProfileLink());
+    };
+
+    return (
+        <Dialog open={showModal} onClose={() => closeModal()} maxWidth={'sm'} fullWidth={true}>
+            <DialogTitle>
+                <Grid container>
+                    <Grid item xs>
+                        <Box px={3} mt={4} className={classes.modalTitle}>
+                            {t('general.info.connectBlockchainTitle')}
+                            <Box fontSize={fontSizeMd} mt={3} className={classes.modalContent}>
+                                {t('general.info.connectBlockchainContent')}
+                            </Box>
+                        </Box>
+                    </Grid>
+                </Grid>
+            </DialogTitle>
+            <DialogActions>
+                <Box p={2}>
+                    <Button
+                        variant="outlined"
+                        color="primary"
+                        onClick={() => closeModal()}
+                        className={classes.maybeButton}
+                    >
+                        {'Maybe Later'}
+                    </Button>
+                    <Button variant="contained" color="primary" onClick={() => connectAddress()}>
+                        {'Connect Address'}
+                    </Button>
+                </Box>
+            </DialogActions>
+        </Dialog>
+    );
+};

--- a/packages/origin-ui-core/src/components/Modal/ConnectBlockchainAccountModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/ConnectBlockchainAccountModal.tsx
@@ -74,10 +74,10 @@ export const ConnectBlockchainAccountModal = ({ showModal, setShowModal }: IProp
                         onClick={() => closeModal()}
                         className={classes.maybeButton}
                     >
-                        {'Maybe Later'}
+                        {t('general.actions.maybeLater')}
                     </Button>
                     <Button variant="contained" color="primary" onClick={() => connectAddress()}>
-                        {'Connect Address'}
+                        {t('general.actions.connectAddress')}
                     </Button>
                 </Box>
             </DialogActions>

--- a/packages/origin-ui-core/src/components/Modal/IRECConnectOrRegisterModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/IRECConnectOrRegisterModal.tsx
@@ -12,6 +12,7 @@ import { OriginFeature } from '@energyweb/utils-general';
 interface IProps {
     showModal: boolean;
     setShowModal: (showModal: boolean) => void;
+    setShowBlockchainModal?: (showModal: boolean) => void;
 }
 
 export enum STEP_NAMES {
@@ -20,13 +21,18 @@ export enum STEP_NAMES {
     REGISTER_IREC = 2
 }
 
-export const IRECConnectOrRegisterModal = ({ showModal, setShowModal }: IProps) => {
+export const IRECConnectOrRegisterModal = ({
+    showModal,
+    setShowModal,
+    setShowBlockchainModal
+}: IProps) => {
     const { t } = useTranslation();
     const {
         typography: { fontSizeMd }
     } = useTheme();
     const { getOrganizationIRecRegisterLink, getOrganizationViewLink } = useLinks();
-    const orgId = useSelector(getUserOffchain)?.organization?.id;
+    const user = useSelector(getUserOffchain);
+    const orgId = user.organization?.id;
     const history = useHistory();
     const { enabledFeatures } = useContext(OriginConfigurationContext);
 
@@ -34,7 +40,11 @@ export const IRECConnectOrRegisterModal = ({ showModal, setShowModal }: IProps) 
         setShowModal(false);
         switch (step) {
             case STEP_NAMES.NOT_NOW:
-                history.push(getOrganizationViewLink(orgId.toString()));
+                if (!user.blockchainAccountAddress) {
+                    setShowBlockchainModal(true);
+                } else {
+                    history.push(getOrganizationViewLink(orgId.toString()));
+                }
                 break;
             case STEP_NAMES.REGISTER_IREC:
                 history.push(getOrganizationIRecRegisterLink());

--- a/packages/origin-ui-core/src/components/Modal/IRecAccountRegisteredModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/IRecAccountRegisteredModal.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { getUserOffchain } from '../../features/users/selectors';
 import { Dialog, DialogTitle, DialogActions, Button, Box, useTheme, Grid } from '@material-ui/core';
 import { showNotification, NotificationType, useTranslation, useLinks } from '../..';
 import iconAdded from '../../../assets/icon-org-added.svg';
@@ -7,11 +9,17 @@ import iconAdded from '../../../assets/icon-org-added.svg';
 interface IProps {
     showModal: boolean;
     setShowModal: (showModal: boolean) => void;
+    setShowBlockchainModal?: (showModal: boolean) => void;
 }
 
-export const IRecAccountRegisteredModal = ({ showModal, setShowModal }: IProps) => {
+export const IRecAccountRegisteredModal = ({
+    showModal,
+    setShowModal,
+    setShowBlockchainModal
+}: IProps) => {
     const history = useHistory();
     const { getOrganizationLink } = useLinks();
+    const user = useSelector(getUserOffchain);
 
     const {
         typography: { fontSizeMd }
@@ -20,8 +28,12 @@ export const IRecAccountRegisteredModal = ({ showModal, setShowModal }: IProps) 
 
     const onClose = () => {
         setShowModal(false);
-        history.push(getOrganizationLink());
         showNotification('Organization registered.', NotificationType.Success);
+        if (!user.blockchainAccountAddress) {
+            setShowBlockchainModal(true);
+        } else {
+            history.push(getOrganizationLink());
+        }
     };
 
     return (

--- a/packages/origin-ui-core/src/components/Modal/RoleChangedModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/RoleChangedModal.tsx
@@ -27,9 +27,15 @@ interface IProps {
     showModal?: boolean;
     setShowModal?: (showModal: boolean) => void;
     setShowIRec?: (showModal: boolean) => void;
+    setShowBlockchainModal?: (showModal: boolean) => void;
 }
 
-export const RoleChangedModal = ({ showModal, setShowModal, setShowIRec }: IProps) => {
+export const RoleChangedModal = ({
+    showModal,
+    setShowModal,
+    setShowIRec,
+    setShowBlockchainModal
+}: IProps) => {
     const user = useSelector(getUserOffchain);
     const userRef = useRef(user);
     const { t } = useTranslation();
@@ -106,6 +112,18 @@ export const RoleChangedModal = ({ showModal, setShowModal, setShowIRec }: IProp
         setShowModal(false);
         if (setShowIRec && enabledFeatures.includes(OriginFeature.IRec)) {
             setShowIRec(true);
+        }
+
+        const { rights: newRole } = user;
+        if (
+            (!setShowIRec &&
+                newRole === Role.OrganizationAdmin &&
+                !user.blockchainAccountAddress) ||
+            (!setShowIRec &&
+                newRole === Role.OrganizationDeviceManager &&
+                !user.blockchainAccountAddress)
+        ) {
+            setShowBlockchainModal(true);
         }
     };
 

--- a/packages/origin-ui-core/src/components/Organization/IRECRegisterForm.tsx
+++ b/packages/origin-ui-core/src/components/Organization/IRECRegisterForm.tsx
@@ -13,6 +13,7 @@ import { IAutocompleteMultiSelectOptionType } from '../MultiSelectAutocomplete';
 import irecLogo from '../../../assets/logo-i-rec.svg';
 import { FormSelect } from '../Form/FormSelect';
 import { IRecAccountRegisteredModal } from '../Modal/IRecAccountRegisteredModal';
+import { ConnectBlockchainAccountModal } from '../Modal/ConnectBlockchainAccountModal';
 
 interface IFormValues {
     accountType: string;
@@ -49,6 +50,7 @@ export const IRECRegisterForm = () => {
     const { t } = useTranslation();
     const { Yup } = useValidation();
     const [showIRecRegisteredModal, setShowIRecRegisteredModal] = useState<boolean>(false);
+    const [showBlockchainModal, setShowBlockchainModal] = useState(false);
 
     const iRecClient = useSelector(getIRecClient);
     const dispatch = useDispatch();
@@ -350,6 +352,11 @@ export const IRECRegisterForm = () => {
             <IRecAccountRegisteredModal
                 showModal={showIRecRegisteredModal}
                 setShowModal={setShowIRecRegisteredModal}
+                setShowBlockchainModal={setShowBlockchainModal}
+            />
+            <ConnectBlockchainAccountModal
+                showModal={showBlockchainModal}
+                setShowModal={setShowBlockchainModal}
             />
         </Paper>
     );

--- a/packages/origin-ui-core/src/components/Organization/OrganizationForm.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationForm.tsx
@@ -28,6 +28,7 @@ import { setUserOffchain } from '../../features/users/actions';
 import { getUserOffchain } from '../../features/users/selectors';
 import { RoleChangedModal } from '../Modal/RoleChangedModal';
 import { IRECConnectOrRegisterModal } from '../Modal/IRECConnectOrRegisterModal';
+import { ConnectBlockchainAccountModal } from '../Modal/ConnectBlockchainAccountModal';
 
 interface IProps {
     entity: IFullOrganization;
@@ -103,6 +104,7 @@ export function OrganizationForm(props: IProps) {
 
     const [showRoleModal, setShowRoleModal] = useState(false);
     const [showIRecModal, setShowIRecModal] = useState(false);
+    const [showBlockchainModal, setShowBlockchainModal] = useState(false);
 
     const useStyles = makeStyles(() =>
         createStyles({
@@ -404,7 +406,15 @@ export function OrganizationForm(props: IProps) {
                 setShowModal={setShowRoleModal}
                 setShowIRec={setShowIRecModal}
             />
-            <IRECConnectOrRegisterModal showModal={showIRecModal} setShowModal={setShowIRecModal} />
+            <IRECConnectOrRegisterModal
+                showModal={showIRecModal}
+                setShowModal={setShowIRecModal}
+                setShowBlockchainModal={setShowBlockchainModal}
+            />
+            <ConnectBlockchainAccountModal
+                showModal={showBlockchainModal}
+                setShowModal={setShowBlockchainModal}
+            />
         </Paper>
     );
 }

--- a/packages/origin-ui-core/src/components/certificates/Certificates.tsx
+++ b/packages/origin-ui-core/src/components/certificates/Certificates.tsx
@@ -17,6 +17,7 @@ import { CreateBundleForm } from '../bundles/CreateBundleForm';
 import { MyOrders } from '../orders/MyOrders';
 import { OriginConfigurationContext } from '..';
 import { RoleChangedModal } from '../Modal/RoleChangedModal';
+import { ConnectBlockchainAccountModal } from '../Modal/ConnectBlockchainAccountModal';
 
 function CertificateDetailViewId(id: number) {
     return <CertificateDetailView id={id} />;
@@ -40,6 +41,7 @@ export function Certificates() {
     const { baseURL, getCertificatesLink } = useLinks();
     const { t } = useTranslation();
     const [showRoleModal, setShowRoleModal] = useState(false);
+    const [showBlockchainModal, setShowBlockchainModal] = useState(false);
 
     const originConfiguration = useContext(OriginConfigurationContext);
 
@@ -213,7 +215,15 @@ export function Certificates() {
                     path={`${baseURL}/`}
                     render={() => <Redirect to={defaultRedirect} />}
                 />
-                <RoleChangedModal showModal={showRoleModal} setShowModal={setShowRoleModal} />
+                <RoleChangedModal
+                    showModal={showRoleModal}
+                    setShowModal={setShowRoleModal}
+                    setShowBlockchainModal={setShowBlockchainModal}
+                />
+                <ConnectBlockchainAccountModal
+                    showModal={showBlockchainModal}
+                    setShowModal={setShowBlockchainModal}
+                />
             </div>
         )
     );

--- a/packages/origin-ui-core/src/components/devices/Device.tsx
+++ b/packages/origin-ui-core/src/components/devices/Device.tsx
@@ -15,6 +15,7 @@ import { ProducingDeviceDetailView } from './ProducingDeviceDetailView';
 import { ProducingDeviceTable } from './ProducingDeviceTable';
 import { OriginConfigurationContext } from '../OriginConfigurationContext';
 import { RoleChangedModal } from '../Modal/RoleChangedModal';
+import { ConnectBlockchainAccountModal } from '../Modal/ConnectBlockchainAccountModal';
 
 export function Device() {
     const userOffchain = useSelector(getUserOffchain);
@@ -24,6 +25,7 @@ export function Device() {
         userOffchain?.organization &&
         isRole(userOffchain, Role.OrganizationDeviceManager, Role.OrganizationAdmin);
     const [showRoleModal, setShowRoleModal] = useState(false);
+    const [showBlockchainModal, setShowBlockchainModal] = useState(false);
 
     function ProductionDetailView(id: number): JSX.Element {
         return (
@@ -192,7 +194,15 @@ export function Device() {
                     <Redirect to={{ pathname: `${getDevicesLink()}/${DevicesMenu[0].key}` }} />
                 )}
             />
-            <RoleChangedModal showModal={showRoleModal} setShowModal={setShowRoleModal} />
+            <RoleChangedModal
+                showModal={showRoleModal}
+                setShowModal={setShowRoleModal}
+                setShowBlockchainModal={setShowBlockchainModal}
+            />
+            <ConnectBlockchainAccountModal
+                showModal={showBlockchainModal}
+                setShowModal={setShowBlockchainModal}
+            />
         </div>
     );
 }

--- a/packages/origin-ui-core/src/utils/routing.ts
+++ b/packages/origin-ui-core/src/utils/routing.ts
@@ -28,6 +28,10 @@ export function getAccountLoginLink(baseURL: string) {
     return `${baseURL}/user-login`;
 }
 
+export function getUserProfileLink(baseURL: string) {
+    return `${getAccountLink(baseURL)}/user-profile`;
+}
+
 export function getDevicesAddLink(baseURL: string) {
     return `${getDevicesLink(baseURL)}/add`;
 }
@@ -108,6 +112,7 @@ export function useLinks() {
         getUserRegisterLink: () => getUserRegisterLink(baseURL),
         getAccountLoginLink: () => getAccountLoginLink(baseURL),
         getAdminLink: () => getAdminLink(baseURL),
-        getBundlesLink: () => getBundlesLink(baseURL)
+        getBundlesLink: () => getBundlesLink(baseURL),
+        getUserProfileLink: () => getUserProfileLink(baseURL)
     };
 }


### PR DESCRIPTION
This PR provides: 
- Connect Blockchain Address Modal

![ConnectBlockchainModal](https://user-images.githubusercontent.com/69903849/93570652-0017de00-f99c-11ea-859d-8aa192d6aa0b.png)

The modal appears when: 
1) User joined an organization successfully as a device manager or organization admin.
2) After Registering a Platform Organization, if the user chooses not to register an I-REC organization and chooses “Maybe Later” in the I-REC Account message window.
3) After Registering an I-REC Organization and clicking “Ok” on the successful new application message window.

_________
If this way of handling modal windows (that should appear one after another) looks cumbersome - I suggest moving all of the Modal windows to the AppContainer and handling them with redux, using a separate folder for modal windows. 
