### PR TITLE
feat/email confirmation notification

### DIFF
--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -482,7 +482,7 @@
             },
             "registration": {
                 "loginNoInvitationsModalTitle": "Thank you for registering as a user on the marketplace",
-                "loginNoInvitationsModalContent": "Aby odblokować wszystkie funkcje rynku, takie jak handel I-REC, użytkownicy muszą również zarejestrować organizację",
+                "loginNoInvitationsModalContent": "To unlock all the functionalities of the marketplace, like trading I-RECs, users also need to register an organization.",
                 "registerOrganization": "Register organization",
                 "organizationInformation": "Organization information",
                 "organizationName": "Organization Name",

--- a/packages/origin-ui-core/src/components/Account/ConfirmEmail.tsx
+++ b/packages/origin-ui-core/src/components/Account/ConfirmEmail.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation, useLinks } from '../../utils';
 import { useSelector } from 'react-redux';
+import { showNotification, NotificationType } from '../../utils/notifications';
 
 import * as queryString from 'query-string';
 import { getOffChainDataSource } from '../..';
@@ -54,5 +55,8 @@ export function ConfirmEmail(props: any) {
             message = 'loading';
     }
 
-    return <div>{t(`user.feedback.emailConfirmation.${message}`)}</div>;
+    return showNotification(
+        t(`user.feedback.emailConfirmation.${message}`),
+        NotificationType.Success
+    );
 }


### PR DESCRIPTION
After the user has clicked the confirmation link in the email and the user is directed to the log-in page, the user should get a notification that the email confirmation was successful.

“Successfully confirmed E-Mail”