### PR TITLE
chore(origin-backend-app): export modules

### DIFF
--- a/packages/origin-backend-app/src/index.ts
+++ b/packages/origin-backend-app/src/index.ts
@@ -1,1 +1,3 @@
 export * from './origin-app.module';
+export * from './notification/notification.module';
+export * from './mail';


### PR DESCRIPTION
`NotificationModule` and `MailModule` are not exported and can't be imported into other packages.
Export them so that they can be used in Origin derivatives.