### PR TITLE
fix/remove global providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "test:ci:contracts": "lerna run --scope @energyweb/issuer --scope @energyweb/utils-general test:concurrent --since master --parallel --stream",
         "test:ci:apps": "lerna run --scope @energyweb/exchange --scope @energyweb/origin-backend test:concurrent --since master --parallel --stream",
         "test:ci:ui": "yarn test:ui",
-        "test:ci:e2e": "lerna run test:e2e --stream --scope @energyweb/exchange --scope @energyweb/origin-backend --scope @energyweb/origin-backend-app",
+        "test:ci:e2e": "lerna run test:e2e --stream --scope @energyweb/exchange --scope @energyweb/origin-backend --scope @energyweb/origin-backend-app --scope @energyweb/origin-organization-irec-api",
         "publish:canary": "lerna publish --yes --skip-git --exact --cd-version=prerelease --pre-dist-tag canary --preid=alpha.$TRAVIS_BUILD_NUMBER",
         "publish:release": "lerna version --create-release github --conventional-commits --exact --yes --message \"chore(release): publish /skip-deploy\" && lerna publish from-git --yes",
         "build:containers:canary": "lerna run build:container:canary --stream",

--- a/packages/exchange/src/app.module.ts
+++ b/packages/exchange/src/app.module.ts
@@ -38,8 +38,6 @@ const getEnvFilePath = () => {
     return finalPath;
 };
 
-export const providers = [IntUnitsOfEnergy];
-
 @Module({
     imports: [
         ConfigModule.forRoot({
@@ -63,6 +61,6 @@ export const providers = [IntUnitsOfEnergy];
         RunnerModule,
         BundleModule
     ],
-    providers
+    providers: [IntUnitsOfEnergy]
 })
 export class AppModule {}

--- a/packages/exchange/src/app.module.ts
+++ b/packages/exchange/src/app.module.ts
@@ -1,19 +1,15 @@
-import { Module, ValidationPipe } from '@nestjs/common';
+import { IntUnitsOfEnergy } from '@energyweb/origin-backend-utils';
+import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import fs from 'fs';
 import path from 'path';
 
-import { APP_PIPE, APP_INTERCEPTOR } from '@nestjs/core';
-import {
-    IntUnitsOfEnergy,
-    HTTPLoggingInterceptor,
-    NullOrUndefinedResultInterceptor
-} from '@energyweb/origin-backend-utils';
 import { AccountBalanceModule } from './pods/account-balance/account-balance.module';
 import { AccountDeployerModule } from './pods/account-deployer/account-deployer.module';
 import { AccountModule } from './pods/account/account.module';
 import { AssetModule } from './pods/asset/asset.module';
+import { BundleModule } from './pods/bundle/bundle.module';
 import { DemandModule } from './pods/demand/demand.module';
 import { DepositWatcherModule } from './pods/deposit-watcher/deposit-watcher.module';
 import { MatchingEngineModule } from './pods/matching-engine/matching-engine.module';
@@ -24,7 +20,6 @@ import { RunnerModule } from './pods/runner/runner.module';
 import { TradeModule } from './pods/trade/trade.module';
 import { TransferModule } from './pods/transfer/transfer.module';
 import { WithdrawalProcessorModule } from './pods/withdrawal-processor/withdrawal-processor.module';
-import { BundleModule } from './pods/bundle/bundle.module';
 
 const getEnvFilePath = () => {
     const pathsToTest = ['../../../../../.env', '../../../../../../.env'];
@@ -43,12 +38,7 @@ const getEnvFilePath = () => {
     return finalPath;
 };
 
-export const providers = [
-    { provide: APP_PIPE, useClass: ValidationPipe },
-    { provide: APP_INTERCEPTOR, useClass: NullOrUndefinedResultInterceptor },
-    { provide: APP_INTERCEPTOR, useClass: HTTPLoggingInterceptor },
-    IntUnitsOfEnergy
-];
+export const providers = [IntUnitsOfEnergy];
 
 @Module({
     imports: [

--- a/packages/exchange/src/index.ts
+++ b/packages/exchange/src/index.ts
@@ -27,7 +27,7 @@ import { BundleModule } from './pods/bundle/bundle.module';
 export { BulkTradeExecutedEvent } from './pods/matching-engine/bulk-trade-executed.event';
 export { TradePersistedEvent } from './pods/trade/trade-persisted.event';
 
-export { AppModule, providers } from './app.module';
+export { AppModule } from './app.module';
 
 export const entities = [
     Demand,

--- a/packages/exchange/src/pods/account/account.controller.ts
+++ b/packages/exchange/src/pods/account/account.controller.ts
@@ -1,11 +1,17 @@
 import { ILoggedInUser } from '@energyweb/origin-backend-core';
-import { UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
+import {
+    UserDecorator,
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor
+} from '@energyweb/origin-backend-utils';
 import {
     Controller,
     Get,
     UseGuards,
     UseInterceptors,
-    ClassSerializerInterceptor
+    ClassSerializerInterceptor,
+    ValidationPipe,
+    UsePipes
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
@@ -13,6 +19,8 @@ import { AccountService } from './account.service';
 import { AccountDTO } from './account.dto';
 
 @Controller('account')
+@UseInterceptors(NullOrUndefinedResultInterceptor)
+@UsePipes(ValidationPipe)
 export class AccountController {
     constructor(private readonly accountService: AccountService) {}
 

--- a/packages/exchange/src/pods/asset/asset.controller.ts
+++ b/packages/exchange/src/pods/asset/asset.controller.ts
@@ -1,16 +1,20 @@
+import { NullOrUndefinedResultInterceptor } from '@energyweb/origin-backend-utils';
 import {
     ClassSerializerInterceptor,
     Controller,
     Get,
     Param,
     ParseUUIDPipe,
-    UseInterceptors
+    UseInterceptors,
+    UsePipes,
+    ValidationPipe
 } from '@nestjs/common';
 
 import { AssetService } from './asset.service';
 
 @Controller('asset')
-@UseInterceptors(ClassSerializerInterceptor)
+@UseInterceptors(ClassSerializerInterceptor, NullOrUndefinedResultInterceptor)
+@UsePipes(ValidationPipe)
 export class AssetController {
     constructor(private readonly assetService: AssetService) {}
 

--- a/packages/exchange/src/pods/bundle/bundle.controller.ts
+++ b/packages/exchange/src/pods/bundle/bundle.controller.ts
@@ -1,5 +1,9 @@
 import { ILoggedInUser } from '@energyweb/origin-backend-core';
-import { UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
+import {
+    UserDecorator,
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor
+} from '@energyweb/origin-backend-utils';
 import {
     Body,
     Controller,
@@ -11,7 +15,9 @@ import {
     Get,
     Param,
     ParseUUIDPipe,
-    Put
+    Put,
+    UsePipes,
+    ValidationPipe
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
@@ -23,8 +29,9 @@ import { BundleTrade } from './bundle-trade.entity';
 import { BundlePublicDTO } from './bundle-public.dto';
 import { BundleSplitDTO } from './bundle-split.dto';
 
-@UseInterceptors(ClassSerializerInterceptor)
 @Controller('bundle')
+@UseInterceptors(ClassSerializerInterceptor, NullOrUndefinedResultInterceptor)
+@UsePipes(ValidationPipe)
 export class BundleController {
     private readonly logger = new Logger(BundleController.name);
 

--- a/packages/exchange/src/pods/demand/demand.controller.ts
+++ b/packages/exchange/src/pods/demand/demand.controller.ts
@@ -1,5 +1,9 @@
 import { ILoggedInUser } from '@energyweb/origin-backend-core';
-import { UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
+import {
+    UserDecorator,
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor
+} from '@energyweb/origin-backend-utils';
 import {
     Body,
     Controller,
@@ -10,7 +14,10 @@ import {
     Param,
     ParseUUIDPipe,
     Post,
-    UseGuards
+    UseGuards,
+    UseInterceptors,
+    UsePipes,
+    ValidationPipe
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
@@ -19,6 +26,8 @@ import { CreateDemandDTO } from './create-demand.dto';
 import { DemandService } from './demand.service';
 
 @Controller('demand')
+@UseInterceptors(NullOrUndefinedResultInterceptor)
+@UsePipes(ValidationPipe)
 export class DemandController {
     private readonly logger = new Logger(DemandController.name);
 

--- a/packages/exchange/src/pods/order-book/order-book.controller.ts
+++ b/packages/exchange/src/pods/order-book/order-book.controller.ts
@@ -1,6 +1,19 @@
 import { ILoggedInUser } from '@energyweb/origin-backend-core';
-import { UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
-import { Body, Controller, Post, UseGuards, HttpCode } from '@nestjs/common';
+import {
+    UserDecorator,
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor
+} from '@energyweb/origin-backend-utils';
+import {
+    Body,
+    Controller,
+    Post,
+    UseGuards,
+    HttpCode,
+    UseInterceptors,
+    ValidationPipe,
+    UsePipes
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 import { OrderBookOrderDTO } from './order-book-order.dto';
@@ -9,6 +22,8 @@ import { ProductFilterDTO } from './product-filter.dto';
 import { TradeService } from '../trade/trade.service';
 
 @Controller('orderbook')
+@UseInterceptors(NullOrUndefinedResultInterceptor)
+@UsePipes(ValidationPipe)
 export class OrderBookController {
     constructor(
         private readonly orderBookService: OrderBookService,

--- a/packages/exchange/src/pods/order/order.controller.ts
+++ b/packages/exchange/src/pods/order/order.controller.ts
@@ -1,5 +1,9 @@
 import { ILoggedInUser } from '@energyweb/origin-backend-core';
-import { UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
+import {
+    UserDecorator,
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor
+} from '@energyweb/origin-backend-utils';
 import {
     Body,
     ClassSerializerInterceptor,
@@ -12,7 +16,9 @@ import {
     ParseUUIDPipe,
     Post,
     UseGuards,
-    UseInterceptors
+    UseInterceptors,
+    UsePipes,
+    ValidationPipe
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
@@ -22,8 +28,9 @@ import { DirectBuyDTO } from './direct-buy.dto';
 import { Order } from './order.entity';
 import { OrderService } from './order.service';
 
-@UseInterceptors(ClassSerializerInterceptor)
 @Controller('orders')
+@UseInterceptors(ClassSerializerInterceptor, NullOrUndefinedResultInterceptor)
+@UsePipes(ValidationPipe)
 export class OrderController {
     private readonly logger = new Logger(OrderController.name);
 

--- a/packages/exchange/src/pods/trade/trade.controller.ts
+++ b/packages/exchange/src/pods/trade/trade.controller.ts
@@ -1,12 +1,26 @@
 import { ILoggedInUser } from '@energyweb/origin-backend-core';
-import { UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
-import { Controller, Get, Logger, UseGuards } from '@nestjs/common';
+import {
+    UserDecorator,
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor
+} from '@energyweb/origin-backend-utils';
+import {
+    Controller,
+    Get,
+    Logger,
+    UseGuards,
+    UseInterceptors,
+    UsePipes,
+    ValidationPipe
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 import { TradeDTO } from './trade.dto';
 import { TradeService } from './trade.service';
 
 @Controller('trade')
+@UseInterceptors(NullOrUndefinedResultInterceptor)
+@UsePipes(ValidationPipe)
 export class TradeController {
     private readonly logger = new Logger(TradeController.name);
 

--- a/packages/exchange/src/pods/transfer/transfer.controller.ts
+++ b/packages/exchange/src/pods/transfer/transfer.controller.ts
@@ -1,12 +1,30 @@
 import { ILoggedInUser, Role } from '@energyweb/origin-backend-core';
-import { Roles, RolesGuard, UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
-import { Body, Controller, ForbiddenException, Get, Post, UseGuards } from '@nestjs/common';
+import {
+    Roles,
+    RolesGuard,
+    UserDecorator,
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor
+} from '@energyweb/origin-backend-utils';
+import {
+    Body,
+    Controller,
+    ForbiddenException,
+    Get,
+    Post,
+    UseGuards,
+    UseInterceptors,
+    UsePipes,
+    ValidationPipe
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 import { RequestWithdrawalDTO } from './create-withdrawal.dto';
 import { TransferService } from './transfer.service';
 
 @Controller('transfer')
+@UseInterceptors(NullOrUndefinedResultInterceptor)
+@UsePipes(ValidationPipe)
 export class TransferController {
     constructor(private readonly transferService: TransferService) {}
 

--- a/packages/origin-backend-app/package.json
+++ b/packages/origin-backend-app/package.json
@@ -40,6 +40,7 @@
         "@energyweb/migrations": "3.1.10",
         "@energyweb/origin-backend": "7.0.2",
         "@energyweb/origin-backend-core": "5.1.0",
+        "@energyweb/origin-backend-utils": "1.2.3",
         "@energyweb/utils-general": "9.2.3",
         "@nestjs/common": "7.4.4",
         "@nestjs/config": "^0.5.0",

--- a/packages/origin-backend-app/src/origin-app.module.ts
+++ b/packages/origin-backend-app/src/origin-app.module.ts
@@ -3,16 +3,18 @@ import {
     AppModule as OriginBackendModule,
     entities as OriginBackendEntities
 } from '@energyweb/origin-backend';
+import { ISmartMeterReadingsAdapter } from '@energyweb/origin-backend-core';
+import { HTTPLoggingInterceptor } from '@energyweb/origin-backend-utils';
 import {
     AppModule as IRECOrganizationModule,
     entities as IRECOrganizationEntities
 } from '@energyweb/origin-organization-irec-api';
-
-import { ISmartMeterReadingsAdapter } from '@energyweb/origin-backend-core';
 import { DynamicModule, Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { NotificationModule } from './notification/notification.module';
+
 import { MailModule } from './mail';
+import { NotificationModule } from './notification/notification.module';
 
 const OriginAppTypeOrmModule = () => {
     const entities = [...OriginBackendEntities, ...ExchangeEntities, ...IRECOrganizationEntities];
@@ -51,7 +53,8 @@ export class OriginAppModule {
                 IRECOrganizationModule,
                 MailModule,
                 NotificationModule
-            ]
+            ],
+            providers: [{ provide: APP_INTERCEPTOR, useClass: HTTPLoggingInterceptor }]
         };
     }
 }

--- a/packages/origin-backend/src/pods/admin/admin.controller.ts
+++ b/packages/origin-backend/src/pods/admin/admin.controller.ts
@@ -1,11 +1,26 @@
 import { IUser, IUserFilter, Role } from '@energyweb/origin-backend-core';
-import { ActiveUserGuard, Roles, RolesGuard } from '@energyweb/origin-backend-utils';
-import { Body, Controller, Get, Param, Put, Query, UseGuards } from '@nestjs/common';
+import {
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor,
+    Roles,
+    RolesGuard
+} from '@energyweb/origin-backend-utils';
+import {
+    Body,
+    Controller,
+    Get,
+    Param,
+    Put,
+    Query,
+    UseGuards,
+    UseInterceptors
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 import { UserService } from '../user/user.service';
 
 @Controller('admin')
+@UseInterceptors(NullOrUndefinedResultInterceptor)
 export class AdminController {
     constructor(private readonly userService: UserService) {}
 

--- a/packages/origin-backend/src/pods/certificate/certificate.controller.ts
+++ b/packages/origin-backend/src/pods/certificate/certificate.controller.ts
@@ -3,14 +3,30 @@ import {
     IOwnershipCommitmentProofWithTx,
     Role
 } from '@energyweb/origin-backend-core';
-import { Roles, RolesGuard, UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
-import { Body, Controller, Get, NotFoundException, Param, UseGuards, Put } from '@nestjs/common';
+import {
+    Roles,
+    RolesGuard,
+    UserDecorator,
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor
+} from '@energyweb/origin-backend-utils';
+import {
+    Body,
+    Controller,
+    Get,
+    NotFoundException,
+    Param,
+    UseGuards,
+    Put,
+    UseInterceptors
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 import { StorageErrors } from '../../enums/StorageErrors';
 import { CertificateService } from './certificate.service';
 
 @Controller('/Certificate')
+@UseInterceptors(NullOrUndefinedResultInterceptor)
 export class CertificateController {
     constructor(private readonly certificateService: CertificateService) {}
 

--- a/packages/origin-backend/src/pods/certification-request/certification-request.controller.ts
+++ b/packages/origin-backend/src/pods/certification-request/certification-request.controller.ts
@@ -1,5 +1,11 @@
 import { ILoggedInUser, Role, ISuccessResponse } from '@energyweb/origin-backend-core';
-import { Roles, RolesGuard, UserDecorator, ActiveUserGuard } from '@energyweb/origin-backend-utils';
+import {
+    Roles,
+    RolesGuard,
+    UserDecorator,
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor
+} from '@energyweb/origin-backend-utils';
 import {
     Body,
     Controller,
@@ -8,7 +14,8 @@ import {
     Param,
     Post,
     UseGuards,
-    Query
+    Query,
+    UseInterceptors
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
@@ -21,6 +28,7 @@ import {
 } from '.';
 
 @Controller('/CertificationRequest')
+@UseInterceptors(NullOrUndefinedResultInterceptor)
 export class CertificationRequestController {
     constructor(private readonly certificationRequestService: CertificationRequestService) {}
 

--- a/packages/origin-backend/src/pods/configuration/configuration.controller.ts
+++ b/packages/origin-backend/src/pods/configuration/configuration.controller.ts
@@ -1,11 +1,17 @@
 import { IOriginConfiguration, Role } from '@energyweb/origin-backend-core';
-import { Roles, RolesGuard, ActiveUserGuard } from '@energyweb/origin-backend-utils';
-import { Body, Controller, Get, Put, UseGuards } from '@nestjs/common';
+import {
+    Roles,
+    RolesGuard,
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor
+} from '@energyweb/origin-backend-utils';
+import { Body, Controller, Get, Put, UseGuards, UseInterceptors } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 import { ConfigurationService } from './configuration.service';
 
 @Controller('configuration')
+@UseInterceptors(NullOrUndefinedResultInterceptor)
 export class ConfigurationController {
     constructor(private readonly configurationService: ConfigurationService) {}
 

--- a/packages/origin-backend/src/pods/device/device.controller.ts
+++ b/packages/origin-backend/src/pods/device/device.controller.ts
@@ -9,7 +9,13 @@ import {
     OrganizationStatus,
     Role
 } from '@energyweb/origin-backend-core';
-import { ActiveUserGuard, Roles, RolesGuard, UserDecorator } from '@energyweb/origin-backend-utils';
+import {
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor,
+    Roles,
+    RolesGuard,
+    UserDecorator
+} from '@energyweb/origin-backend-utils';
 import {
     Body,
     Controller,
@@ -24,7 +30,8 @@ import {
     Query,
     UnauthorizedException,
     UnprocessableEntityException,
-    UseGuards
+    UseGuards,
+    UseInterceptors
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { BigNumber } from 'ethers';
@@ -37,6 +44,7 @@ import { Device } from './device.entity';
 import { DeviceService } from './device.service';
 
 @Controller('/Device')
+@UseInterceptors(NullOrUndefinedResultInterceptor)
 export class DeviceController {
     private readonly logger = new Logger(DeviceController.name);
 

--- a/packages/origin-backend/src/pods/file/file.controller.ts
+++ b/packages/origin-backend/src/pods/file/file.controller.ts
@@ -15,7 +15,6 @@ import { AuthGuard } from '@nestjs/passport';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import { Request, Response } from 'express';
 import multer from 'multer';
-import { Readable } from 'stream';
 
 import { FileService } from './file.service';
 
@@ -69,12 +68,6 @@ export class FileController {
         res.set({
             'Content-Type': file.contentType,
             'Content-Length': file.data.length
-        });
-
-        const stream = new Readable();
-        stream.push(file.data);
-        stream.push(null);
-
-        stream.pipe(res);
+        }).send(file.data);
     }
 }

--- a/packages/origin-backend/src/pods/invitation/invitation.controller.ts
+++ b/packages/origin-backend/src/pods/invitation/invitation.controller.ts
@@ -6,7 +6,13 @@ import {
     OrganizationRole,
     Role
 } from '@energyweb/origin-backend-core';
-import { ActiveUserGuard, Roles, RolesGuard, UserDecorator } from '@energyweb/origin-backend-utils';
+import {
+    ActiveUserGuard,
+    NullOrUndefinedResultInterceptor,
+    Roles,
+    RolesGuard,
+    UserDecorator
+} from '@energyweb/origin-backend-utils';
 import {
     BadRequestException,
     Body,
@@ -17,7 +23,8 @@ import {
     Param,
     Post,
     Put,
-    UseGuards
+    UseGuards,
+    UseInterceptors
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { isEmail } from 'class-validator';
@@ -26,6 +33,7 @@ import { InvitationService } from './invitation.service';
 import { Invitation } from './invitation.entity';
 
 @Controller('/invitation')
+@UseInterceptors(NullOrUndefinedResultInterceptor)
 export class InvitationController {
     private logger = new Logger(InvitationController.name);
 

--- a/packages/origin-backend/src/pods/user/user.controller.ts
+++ b/packages/origin-backend/src/pods/user/user.controller.ts
@@ -12,7 +12,8 @@ import {
 import {
     UserDecorator,
     ActiveUserGuard,
-    NotDeletedUserGuard
+    NotDeletedUserGuard,
+    NullOrUndefinedResultInterceptor
 } from '@energyweb/origin-backend-utils';
 import {
     BadRequestException,
@@ -34,7 +35,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { UserService } from './user.service';
 import { EmailConfirmationService } from '../email-confirmation/email-confirmation.service';
 
-@UseInterceptors(ClassSerializerInterceptor)
+@UseInterceptors(ClassSerializerInterceptor, NullOrUndefinedResultInterceptor)
 @Controller('user')
 export class UserController {
     private readonly logger = new Logger(UserController.name);

--- a/packages/origin-organization-irec-api/src/app.module.ts
+++ b/packages/origin-organization-irec-api/src/app.module.ts
@@ -1,21 +1,8 @@
-import {
-    HTTPLoggingInterceptor,
-    NullOrUndefinedResultInterceptor
-} from '@energyweb/origin-backend-utils';
-import { ClassSerializerInterceptor, Module, ValidationPipe } from '@nestjs/common';
-import { APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
+import { Module } from '@nestjs/common';
 
 import { RegistrationModule } from './registration/registration.module';
 
-export const providers = [
-    { provide: APP_PIPE, useClass: ValidationPipe },
-    { provide: APP_INTERCEPTOR, useClass: NullOrUndefinedResultInterceptor },
-    { provide: APP_INTERCEPTOR, useClass: HTTPLoggingInterceptor },
-    { provide: APP_INTERCEPTOR, useClass: ClassSerializerInterceptor }
-];
-
 @Module({
-    imports: [RegistrationModule],
-    providers
+    imports: [RegistrationModule]
 })
 export class AppModule {}

--- a/packages/origin-organization-irec-api/src/registration/registration.controller.ts
+++ b/packages/origin-organization-irec-api/src/registration/registration.controller.ts
@@ -1,5 +1,10 @@
 import { LoggedInUser, Role } from '@energyweb/origin-backend-core';
-import { Roles, RolesGuard, UserDecorator } from '@energyweb/origin-backend-utils';
+import {
+    NullOrUndefinedResultInterceptor,
+    Roles,
+    RolesGuard,
+    UserDecorator
+} from '@energyweb/origin-backend-utils';
 import {
     Body,
     ClassSerializerInterceptor,
@@ -7,14 +12,17 @@ import {
     Get,
     Post,
     UseGuards,
-    UseInterceptors
+    UseInterceptors,
+    UsePipes,
+    ValidationPipe
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { RegistrationDTO } from './registration.dto';
 import { Registration } from './registration.entity';
 import { RegistrationService } from './registration.service';
 
-@UseInterceptors(ClassSerializerInterceptor)
+@UseInterceptors(ClassSerializerInterceptor, NullOrUndefinedResultInterceptor)
+@UsePipes(ValidationPipe)
 @Controller('irec/registration')
 export class RegistrationController {
     constructor(private readonly registrationService: RegistrationService) {}


### PR DESCRIPTION
This PR removes the use of globally registered pipes and interceptors. The fixes the issue where GET file/{id} was throwing an 404 error due to incompatibility between native `response.send` and `NullOrUndefinedResultInterceptor`