### PR TITLE
fix/organization members change roles

### DIFF
--- a/packages/origin-ui-core/src/components/Modal/ChangeRoleModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/ChangeRoleModal.tsx
@@ -35,16 +35,12 @@ export function ChangeRoleModal(props: IProps) {
 
     const [currentUserRole] = getRolesFromRights(user?.rights);
 
-    const [selectedRole, setSelectedRole] = useState<Role>(
-        currentUserRole ?? Number(Object.keys(roleNames)[0])
-    );
+    const [selectedRole, setSelectedRole] = useState<Role>(null);
 
     const dispatch = useDispatch();
 
     useEffect(() => {
-        if (selectedRole === null && currentUserRole) {
-            setSelectedRole(currentUserRole);
-        }
+        setSelectedRole(currentUserRole);
     }, [currentUserRole]);
 
     async function handleClose() {

--- a/packages/origin-ui-core/src/components/Modal/ChangeRoleModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/ChangeRoleModal.tsx
@@ -59,7 +59,7 @@ export function ChangeRoleModal(props: IProps) {
             await organizationClient.memberChangeRole(
                 userOffchain.organization.id,
                 user.id,
-                selectedRole
+                Number(selectedRole)
             );
 
             showNotification(`User role updated.`, NotificationType.Success);


### PR DESCRIPTION
This PR fixes the issues when selecting member to edit the member role always defaults to selecting a top member.