### PR TITLE
fix(exchange): bundles volume update, more tests

### DIFF
--- a/packages/exchange/src/pods/bundle/bundle-public.dto.ts
+++ b/packages/exchange/src/pods/bundle/bundle-public.dto.ts
@@ -31,6 +31,7 @@ export class BundlePublicDTO {
         this.items = bundle.items.map((item) => new BundlePublicItemDTO(item));
         this.price = bundle.price;
         this.volume = bundle.volume;
+        this.available = bundle.available;
     }
 
     id: string;

--- a/packages/exchange/src/pods/bundle/bundle-trade.entity.ts
+++ b/packages/exchange/src/pods/bundle/bundle-trade.entity.ts
@@ -33,7 +33,7 @@ export class BundleTrade extends ExtendedBaseEntity {
             (item) =>
                 new BundleTradeItemDTO(
                     item.asset,
-                    item.startVolume.div(this.bundle.volume.div(this.volume))
+                    item.startVolume.mul(this.volume).div(this.bundle.volume)
                 )
         );
     }


### PR DESCRIPTION
This PR updates the issue where the bundle items volume was using wrong formula that leads to rounding errors. Additionally the bundle trade storing is now a part of the transaction with bundle update.