### PR TITLE
fix/market selects

### DIFF
--- a/packages/origin-ui-core/src/components/Form/FormikDatePicker.tsx
+++ b/packages/origin-ui-core/src/components/Form/FormikDatePicker.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ArrowLeft, ArrowRight } from '@material-ui/icons';
+import { ArrowLeft, ArrowRight, Clear } from '@material-ui/icons';
 import { TextField, InputAdornment, TextFieldProps } from '@material-ui/core';
 import {
     DatePicker as DatePickerMaterial,
@@ -12,6 +12,8 @@ import { Moment, DATE_FORMAT_DMY } from '../../utils';
 interface ITextFieldWithArrowsEventHandlers {
     onLeftArrowClick: () => void;
     onRightArrowClick: () => void;
+    onClearClick?: () => void;
+    showClearButton: boolean;
 }
 
 type TextFieldWithArrowsProps = TextFieldProps & ITextFieldWithArrowsEventHandlers;
@@ -19,6 +21,8 @@ type TextFieldWithArrowsProps = TextFieldProps & ITextFieldWithArrowsEventHandle
 const TextFieldWithArrows = ({
     onLeftArrowClick,
     onRightArrowClick,
+    onClearClick,
+    showClearButton,
     ...rest
 }: TextFieldWithArrowsProps) => (
     <TextField
@@ -26,6 +30,16 @@ const TextFieldWithArrows = ({
         InputProps={{
             endAdornment: (
                 <InputAdornment position="end">
+                    {showClearButton && (
+                        <Clear
+                            style={{ cursor: 'pointer' }}
+                            onClick={(event) => {
+                                event.stopPropagation();
+
+                                onClearClick();
+                            }}
+                        />
+                    )}
                     <ArrowLeft
                         style={{ cursor: 'pointer' }}
                         onClick={(event) => {
@@ -51,6 +65,8 @@ const TextFieldWithArrows = ({
 export const FormikDatePickerWithArrows = ({
     onLeftArrowClick,
     onRightArrowClick,
+    onClearClick,
+    showClearButton,
     ...rest
 }: DatePickerProps & ITextFieldWithArrowsEventHandlers) => (
     <DatePicker
@@ -59,6 +75,8 @@ export const FormikDatePickerWithArrows = ({
             <TextFieldWithArrows
                 onLeftArrowClick={onLeftArrowClick}
                 onRightArrowClick={onRightArrowClick}
+                onClearClick={onClearClick}
+                showClearButton={showClearButton}
                 {...props}
             />
         )}
@@ -103,7 +121,11 @@ export const FormikDatePickerWithMonthArrowsFilled = ({
             component={FormikDatePickerWithArrows}
             disabled={disabled}
             views={['year', 'month']}
+            helperText={false}
+            error={false}
             format={null}
+            showClearButton={!!values[name]}
+            onClearClick={() => setFieldValue(name, null)}
             onLeftArrowClick={() =>
                 setFieldValue(
                     name,

--- a/packages/origin-ui-core/src/components/MultiSelectAutocomplete.tsx
+++ b/packages/origin-ui-core/src/components/MultiSelectAutocomplete.tsx
@@ -49,7 +49,7 @@ export function MultiSelectAutocomplete(props: IOwnProps) {
 
     const classes = useStyles(useTheme());
     const [touchFlag, setTouchFlag] = useState<boolean>(null);
-    const [textValue, setTextValue] = useState<string>(null);
+    const [textValue, setTextValue] = useState<string>('');
 
     return (
         <div className={className}>
@@ -57,11 +57,12 @@ export function MultiSelectAutocomplete(props: IOwnProps) {
                 multiple
                 filterSelectedOptions
                 options={options}
+                inputValue={textValue}
                 getOptionLabel={(option) => option.label}
                 onChange={(event, value: IAutocompleteMultiSelectOptionType[]) => {
                     props.onChange(value ? value.slice(0, max ?? value.length) : value);
                     setTouchFlag(true);
-                    setTextValue(' ');
+                    setTextValue('');
                 }}
                 value={selectedValues}
                 renderTags={(value, getTagProps) =>
@@ -80,12 +81,13 @@ export function MultiSelectAutocomplete(props: IOwnProps) {
                         {...params}
                         required={required}
                         label={label}
+                        onChange={(event) => setTextValue(event.target.value)}
                         helperText={
                             touchFlag && required && props.selectedValues.length === 0
                                 ? label + ' is a required field'
                                 : ''
                         }
-                        inputProps={{ ...params.inputProps, value: textValue }}
+                        inputProps={{ ...params.inputProps }}
                         error={touchFlag && required && props.selectedValues.length === 0}
                         placeholder={placeholder}
                         fullWidth

--- a/packages/origin-ui-core/src/components/exchange/Market.tsx
+++ b/packages/origin-ui-core/src/components/exchange/Market.tsx
@@ -89,11 +89,12 @@ export function Market(props: IProps) {
                 onSubmit={null}
             >
                 {(formikProps) => {
-                    const { isValid, isSubmitting, setFieldValue, errors, values } = formikProps;
+                    const { isSubmitting, setFieldValue, errors, values } = formikProps;
 
-                    const totalPrice = isValid
-                        ? calculateTotalPrice(values.price, values.energy)
-                        : 0;
+                    const totalPrice =
+                        values.price && values.energy
+                            ? calculateTotalPrice(values.price, values.energy)
+                            : 0;
 
                     const fieldDisabled = isSubmitting;
 


### PR DESCRIPTION
This Pull Request fixes 2 issues: 

- No way to deselect generation time.
Now you can remove the generation start and end time by clicking on the clear icon.

- Regions autocomplete misbehaves on keyboard input
Several bugs fixed connected with filtering the options, typing the filter word, and showing the typed words.