### PR TITLE
fix/blockchain error notifications 

### DIFF
--- a/packages/origin-ui-core/src/components/Account/UserProfile.tsx
+++ b/packages/origin-ui-core/src/components/Account/UserProfile.tsx
@@ -139,9 +139,13 @@ export function UserProfile() {
 
     async function signAndSend(blockchainAccountAddress: string): Promise<boolean> {
         try {
-            if (blockchainAccountAddress === activeBlockchainAccountAddress.toLowerCase())
+            if (activeBlockchainAccountAddress === null) {
+                throw Error(
+                    'MetaMask Error: Please enable the Metamask extension in your browser, be logged-in, have the page connected and try to refresh.'
+                );
+            } else if (blockchainAccountAddress === activeBlockchainAccountAddress.toLowerCase()) {
                 throw Error('User has blockchain account already linked.');
-
+            }
             const signedMessage = await signTypedMessage(
                 activeBlockchainAccountAddress,
                 environment.REGISTRATION_MESSAGE_TO_SIGN,
@@ -162,7 +166,11 @@ export function UserProfile() {
                 showNotification(error?.data?.message, NotificationType.Error);
             } else if (error?.message) {
                 console.log(error);
-                showNotification(error?.message, NotificationType.Error);
+                const message =
+                    error?.message === 'u is null'
+                        ? 'No blockchain connection detected, please visit <a href="https://metamask.io/" target="_blank">metamask.io</a> and follow the instructions.'
+                        : error?.message;
+                showNotification(message, NotificationType.Error);
             } else {
                 console.warn('Could not log in.', error);
                 showNotification(t('general.feedback.unknownError'), NotificationType.Error);


### PR DESCRIPTION
When User is trying to add the Blockchain Account, but has no success - the Notification window appears: 
1. MetaMask extension exists, but not active - “Cannot read the property of to-Lower-Case of null”.
2. MetaMask extension is not installed  - "u is null".