### PR TITLE
Exchange / Origin Backend decoupling

### DIFF
--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json && nest build -p tsconfig.json --tsc && cp migrations/initial.sql dist/js/migrations/",
+        "build:ts": "tsc -b tsconfig.json && cp migrations/initial.sql dist/js/migrations/",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\"",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --fix",
@@ -41,7 +41,6 @@
         "@energyweb/exchange-core": "3.1.6",
         "@energyweb/exchange-token-account": "0.1.17",
         "@energyweb/issuer": "2.4.6",
-        "@energyweb/origin-backend": "8.0.0",
         "@energyweb/origin-backend-core": "6.0.0",
         "@energyweb/origin-backend-utils": "1.3.0",
         "@energyweb/utils-general": "9.3.0",

--- a/packages/exchange/src/index.ts
+++ b/packages/exchange/src/index.ts
@@ -27,6 +27,8 @@ import { BundleModule } from './pods/bundle/bundle.module';
 export { BulkTradeExecutedEvent } from './pods/matching-engine/bulk-trade-executed.event';
 export { TradePersistedEvent } from './pods/trade/trade-persisted.event';
 
+export * from './interfaces';
+
 export { AppModule } from './app.module';
 
 export const entities = [

--- a/packages/exchange/src/interfaces/IExchangeConfigurationService.ts
+++ b/packages/exchange/src/interfaces/IExchangeConfigurationService.ts
@@ -1,0 +1,9 @@
+import { IDeviceType } from '@energyweb/origin-backend-core';
+
+export const IExchangeConfigurationService = Symbol('IExchangeConfigurationService');
+export interface IExchangeConfigurationService {
+    getDeviceTypes(): Promise<IDeviceType[]>;
+    getGridOperators(): Promise<string[]>;
+    getRegistryAddress(): Promise<string>;
+    getIssuerAddress(): Promise<string>;
+}

--- a/packages/exchange/src/interfaces/IExternalDeviceService.ts
+++ b/packages/exchange/src/interfaces/IExternalDeviceService.ts
@@ -1,0 +1,21 @@
+import { IExternalDeviceId } from '@energyweb/origin-backend-core';
+
+export interface IProductInfo {
+    deviceType: string;
+    region: string;
+    province: string;
+    country: string;
+    operationalSince: number;
+    gridOperator: string;
+}
+
+export interface IDeviceSettings {
+    postForSale: boolean;
+    postForSalePrice: number;
+}
+
+export const IExternalDeviceService = Symbol('IExternalDeviceService');
+export interface IExternalDeviceService {
+    getDeviceProductInfo(id: IExternalDeviceId): Promise<IProductInfo>;
+    getDeviceSettings(id: IExternalDeviceId): Promise<IDeviceSettings>;
+}

--- a/packages/exchange/src/interfaces/index.ts
+++ b/packages/exchange/src/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './IExchangeConfigurationService';
+export * from './IExternalDeviceService';

--- a/packages/exchange/src/pods/product/product.service.ts
+++ b/packages/exchange/src/pods/product/product.service.ts
@@ -1,8 +1,8 @@
-import { DeviceService } from '@energyweb/origin-backend';
-import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ModuleRef } from '@nestjs/core';
 
+import { IExternalDeviceService } from '../../interfaces';
 import { AssetService } from '../asset/asset.service';
 import { ProductDTO } from '../order/product.dto';
 
@@ -10,7 +10,7 @@ import { ProductDTO } from '../order/product.dto';
 export class ProductService implements OnModuleInit {
     private readonly logger = new Logger(ProductService.name);
 
-    private deviceService: DeviceService;
+    private deviceService: IExternalDeviceService;
 
     private issuerTypeId: string;
 
@@ -23,7 +23,9 @@ export class ProductService implements OnModuleInit {
     }
 
     public async onModuleInit() {
-        this.deviceService = this.moduleRef.get(DeviceService, { strict: false });
+        this.deviceService = this.moduleRef.get<IExternalDeviceService>(IExternalDeviceService, {
+            strict: false
+        });
     }
 
     public async getProduct(assetId: string): Promise<ProductDTO> {
@@ -34,7 +36,7 @@ export class ProductService implements OnModuleInit {
             id: deviceId,
             type: this.issuerTypeId
         };
-        const deviceProductInfo = await this.deviceService.findDeviceProductInfo(externalDeviceId);
+        const deviceProductInfo = await this.deviceService.getDeviceProductInfo(externalDeviceId);
 
         if (!deviceProductInfo) {
             this.logger.error(

--- a/packages/exchange/src/pods/runner/deviceTypeServiceWrapper.ts
+++ b/packages/exchange/src/pods/runner/deviceTypeServiceWrapper.ts
@@ -1,7 +1,7 @@
-import { ConfigurationService } from '@energyweb/origin-backend';
 import { DeviceTypeService, IDeviceTypeService } from '@energyweb/utils-general';
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
+import { IExchangeConfigurationService } from '../../interfaces';
 
 @Injectable()
 export class DeviceTypeServiceWrapper implements OnModuleInit {
@@ -10,11 +10,14 @@ export class DeviceTypeServiceWrapper implements OnModuleInit {
     constructor(private readonly moduleRef: ModuleRef) {}
 
     public async onModuleInit() {
-        const configService = this.moduleRef.get(ConfigurationService, {
-            strict: false
-        });
+        const configService = this.moduleRef.get<IExchangeConfigurationService>(
+            IExchangeConfigurationService,
+            {
+                strict: false
+            }
+        );
 
-        const { deviceTypes } = await configService.get();
+        const deviceTypes = await configService.getDeviceTypes();
 
         this._deviceTypeService = new DeviceTypeService(deviceTypes);
     }

--- a/packages/exchange/src/pods/runner/grid-operator.service.ts
+++ b/packages/exchange/src/pods/runner/grid-operator.service.ts
@@ -1,6 +1,6 @@
-import { ConfigurationService } from '@energyweb/origin-backend';
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
+import { IExchangeConfigurationService } from '../../interfaces';
 
 @Injectable()
 export class GridOperatorService implements OnModuleInit {
@@ -9,13 +9,14 @@ export class GridOperatorService implements OnModuleInit {
     constructor(private readonly moduleRef: ModuleRef) {}
 
     public async onModuleInit() {
-        const configService = this.moduleRef.get(ConfigurationService, {
-            strict: false
-        });
+        const configService = this.moduleRef.get<IExchangeConfigurationService>(
+            IExchangeConfigurationService,
+            {
+                strict: false
+            }
+        );
 
-        const { gridOperators } = await configService.get();
-
-        this.gridOperators = gridOperators;
+        this.gridOperators = await configService.getGridOperators();
     }
 
     public areValid(gridOperators: string[]) {

--- a/packages/exchange/src/pods/withdrawal-processor/withdrawal-processor.service.ts
+++ b/packages/exchange/src/pods/withdrawal-processor/withdrawal-processor.service.ts
@@ -1,13 +1,13 @@
 import { Contracts } from '@energyweb/issuer';
-import { ConfigurationService } from '@energyweb/origin-backend';
 import { getProviderWithFallback } from '@energyweb/utils-general';
 import { forwardRef, Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ModuleRef } from '@nestjs/core';
-import { Contract, ContractTransaction, ethers, Wallet, ContractReceipt } from 'ethers';
+import { Contract, ContractReceipt, ContractTransaction, ethers, Wallet } from 'ethers';
 import { Subject } from 'rxjs';
 import { concatMap, tap } from 'rxjs/operators';
 
+import { IExchangeConfigurationService } from '../../interfaces';
 import { TransferDirection } from '../transfer/transfer-direction';
 import { TransferStatus } from '../transfer/transfer-status';
 import { Transfer } from '../transfer/transfer.entity';
@@ -43,14 +43,14 @@ export class WithdrawalProcessorService implements OnModuleInit {
 
         this.wallet = new Wallet(wallet, provider);
 
-        const originBackendConfigurationService = this.moduleRef.get(ConfigurationService, {
-            strict: false
-        });
+        const exchangeConfigService = this.moduleRef.get<IExchangeConfigurationService>(
+            IExchangeConfigurationService,
+            {
+                strict: false
+            }
+        );
 
-        const {
-            contractsLookup: { registry }
-        } = await originBackendConfigurationService.get();
-
+        const registry = await exchangeConfigService.getRegistryAddress();
         const { abi } = Contracts.RegistryJSON;
 
         this.registry = new Contract(registry, abi, this.wallet);

--- a/packages/exchange/test/deposits-auto-post-for-sale.e2e-spec.ts
+++ b/packages/exchange/test/deposits-auto-post-for-sale.e2e-spec.ts
@@ -1,12 +1,11 @@
 import { OrderSide, OrderStatus } from '@energyweb/exchange-core';
-import { DeviceService } from '@energyweb/origin-backend';
-import { IDeviceProductInfo, IDevice } from '@energyweb/origin-backend-core';
 import { DatabaseService } from '@energyweb/origin-backend-utils';
 import { INestApplication } from '@nestjs/common';
 import { expect } from 'chai';
 import { Contract, ethers } from 'ethers';
 import moment from 'moment';
 import request from 'supertest';
+import { IDeviceSettings, IExternalDeviceService, IProductInfo } from '../src/interfaces';
 
 import { AccountService } from '../src/pods/account/account.service';
 import { Order } from '../src/pods/order/order.entity';
@@ -30,30 +29,20 @@ describe('Deposits automatic posting for sale', () => {
 
     const defaultAskPrice = 1000;
 
-    const deviceServiceMock = ({
-        findDeviceProductInfo: async (): Promise<IDeviceProductInfo> => {
-            return {
-                deviceType: 'Solar;Photovoltaic;Classic silicon',
-                country: 'Thailand',
-                region: 'Central',
-                province: 'Nakhon Pathom',
-                operationalSince: 2016,
-                gridOperator: 'TH-PEA'
-            };
-        },
-        findByExternalId: async (): Promise<IDevice> => {
-            return {
-                deviceType: 'Solar;Photovoltaic;Classic silicon',
-                country: 'Thailand',
-                region: 'Central',
-                province: 'Nakhon Pathom',
-                operationalSince: 2016,
-                gridOperator: 'TH-PEA',
-                automaticPostForSale: true,
-                defaultAskPrice
-            } as IDevice;
-        }
-    } as unknown) as DeviceService;
+    const deviceServiceMock = {
+        getDeviceProductInfo: async (): Promise<IProductInfo> => ({
+            deviceType: 'Solar;Photovoltaic;Classic silicon',
+            country: 'Thailand',
+            region: 'Central',
+            province: 'Nakhon Pathom',
+            operationalSince: 2016,
+            gridOperator: 'TH-PEA'
+        }),
+        getDeviceSettings: async (): Promise<IDeviceSettings> => ({
+            postForSale: true,
+            postForSalePrice: defaultAskPrice
+        })
+    } as IExternalDeviceService;
 
     before(async () => {
         ({ accountService, databaseService, registry, issuer, app } = await bootstrapTestInstance(

--- a/packages/exchange/test/orderbook.e2e-spec.ts
+++ b/packages/exchange/test/orderbook.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Filter } from '@energyweb/exchange-core';
-import { DeviceService } from '@energyweb/origin-backend';
-import { IDeviceProductInfo, IExternalDeviceId } from '@energyweb/origin-backend-core';
+
+import { IExternalDeviceId } from '@energyweb/origin-backend-core';
 import { INestApplication } from '@nestjs/common';
 import { expect } from 'chai';
 import moment from 'moment';
@@ -16,6 +16,7 @@ import { OrderService } from '../src/pods/order/order.service';
 import { TradePriceInfoDTO } from '../src/pods/trade/trade-price-info.dto';
 import { TransferService } from '../src/pods/transfer/transfer.service';
 import { authenticatedUser, bootstrapTestInstance } from './exchange';
+import { IExternalDeviceService, IProductInfo } from '../src/interfaces';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -200,7 +201,7 @@ describe('orderbook tests', () => {
         await sleep(2000);
     };
 
-    const productByDeviceId = new Map<string, IDeviceProductInfo>([
+    const productByDeviceId = new Map<string, IProductInfo>([
         [
             'deviceId1',
             {
@@ -237,10 +238,10 @@ describe('orderbook tests', () => {
     ]);
 
     const deviceServiceMock = ({
-        findDeviceProductInfo: async ({ id }: IExternalDeviceId): Promise<IDeviceProductInfo> => {
+        getDeviceProductInfo: async ({ id }: IExternalDeviceId): Promise<IProductInfo> => {
             return productByDeviceId.get(id);
         }
-    } as unknown) as DeviceService;
+    } as unknown) as IExternalDeviceService;
 
     before(async () => {
         ({

--- a/packages/exchange/tsconfig.json
+++ b/packages/exchange/tsconfig.json
@@ -23,9 +23,6 @@
             "path": "../origin-backend-core/tsconfig.json"
         },
         {
-            "path": "../origin-backend/tsconfig.json"
-        },
-        {
             "path": "../issuer/tsconfig.json"
         }
     ]

--- a/packages/origin-backend-app/package.json
+++ b/packages/origin-backend-app/package.json
@@ -10,7 +10,7 @@
         "start:prod": "node dist/main",
         "prebuild": "shx rm -rf dist",
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json && nest build -p tsconfig.json --tsc",
+        "build:ts": "tsc -b tsconfig.json",
         "build:container:canary": "make build-canary push",
         "build:container:latest": "make build-latest push",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",

--- a/packages/origin-backend-app/src/index.ts
+++ b/packages/origin-backend-app/src/index.ts
@@ -1,3 +1,4 @@
 export * from './origin-app.module';
 export * from './notification/notification.module';
 export * from './mail';
+export * from './integration';

--- a/packages/origin-backend-app/src/integration/exchange-configuration.service.ts
+++ b/packages/origin-backend-app/src/integration/exchange-configuration.service.ts
@@ -1,0 +1,36 @@
+import { IExchangeConfigurationService } from '@energyweb/exchange';
+import { ConfigurationService } from '@energyweb/origin-backend';
+import { IDeviceType } from '@energyweb/origin-backend-core';
+import { Injectable } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+
+@Injectable()
+export class ExchangeConfigurationService implements IExchangeConfigurationService {
+    private configService: ConfigurationService;
+
+    constructor(private readonly moduleRef: ModuleRef) {
+        this.configService = this.moduleRef.get<ConfigurationService>(ConfigurationService, {
+            strict: false
+        });
+    }
+
+    public async getDeviceTypes(): Promise<IDeviceType[]> {
+        const { deviceTypes } = await this.configService.get();
+        return deviceTypes;
+    }
+
+    public async getGridOperators(): Promise<string[]> {
+        const { gridOperators } = await this.configService.get();
+        return gridOperators;
+    }
+
+    public async getRegistryAddress(): Promise<string> {
+        const { contractsLookup } = await this.configService.get();
+        return contractsLookup.registry;
+    }
+
+    public async getIssuerAddress(): Promise<string> {
+        const { contractsLookup } = await this.configService.get();
+        return contractsLookup.issuer;
+    }
+}

--- a/packages/origin-backend-app/src/integration/external-device.service.ts
+++ b/packages/origin-backend-app/src/integration/external-device.service.ts
@@ -1,0 +1,29 @@
+import { IDeviceSettings, IExternalDeviceService, IProductInfo } from '@energyweb/exchange';
+import { DeviceService } from '@energyweb/origin-backend';
+import { IExternalDeviceId } from '@energyweb/origin-backend-core';
+import { Injectable } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+
+@Injectable()
+export class ExternalDeviceService implements IExternalDeviceService {
+    private deviceService: DeviceService;
+
+    constructor(private readonly moduleRef: ModuleRef) {
+        this.deviceService = this.moduleRef.get<DeviceService>(DeviceService, {
+            strict: false
+        });
+    }
+
+    public async getDeviceProductInfo(id: IExternalDeviceId): Promise<IProductInfo> {
+        return this.deviceService.findDeviceProductInfo(id);
+    }
+
+    public async getDeviceSettings(id: IExternalDeviceId): Promise<IDeviceSettings> {
+        const device = await this.deviceService.findByExternalId(id);
+
+        return {
+            postForSale: device.automaticPostForSale,
+            postForSalePrice: device.defaultAskPrice
+        };
+    }
+}

--- a/packages/origin-backend-app/src/integration/index.ts
+++ b/packages/origin-backend-app/src/integration/index.ts
@@ -1,0 +1,3 @@
+export * from './exchange-configuration.service';
+export * from './external-device.service';
+export * from './integration.module';

--- a/packages/origin-backend-app/src/integration/integration.module.ts
+++ b/packages/origin-backend-app/src/integration/integration.module.ts
@@ -1,0 +1,21 @@
+import { IExchangeConfigurationService, IExternalDeviceService } from '@energyweb/exchange';
+import { Module } from '@nestjs/common';
+
+import { ExchangeConfigurationService } from './exchange-configuration.service';
+import { ExternalDeviceService } from './external-device.service';
+
+const exchangeConfigurationService = {
+    provide: IExchangeConfigurationService,
+    useClass: ExchangeConfigurationService
+};
+
+const externalDeviceService = {
+    provide: IExternalDeviceService,
+    useClass: ExternalDeviceService
+};
+
+@Module({
+    providers: [exchangeConfigurationService, externalDeviceService],
+    exports: [exchangeConfigurationService, externalDeviceService]
+})
+export class IntegrationModule {}

--- a/packages/origin-backend-app/src/origin-app.module.ts
+++ b/packages/origin-backend-app/src/origin-app.module.ts
@@ -12,6 +12,7 @@ import {
 import { DynamicModule, Module } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { IntegrationModule } from './integration/integration.module';
 
 import { MailModule } from './mail';
 import { NotificationModule } from './notification/notification.module';
@@ -49,6 +50,7 @@ export class OriginAppModule {
             imports: [
                 OriginAppTypeOrmModule(),
                 OriginBackendModule.register(smartMeterReadingsAdapter),
+                IntegrationModule,
                 ExchangeModule,
                 IRECOrganizationModule,
                 MailModule,


### PR DESCRIPTION
This PR remove the `origin-backend` dependency from the `exchange` project. This allows for more flexible exchange configuration.  