### PR TITLE
fix(origin-ui-core): Fetch exchange certificates using tokenId

### DIFF
--- a/packages/origin-ui-core/src/features/certificates/sagas.ts
+++ b/packages/origin-ui-core/src/features/certificates/sagas.ts
@@ -42,10 +42,14 @@ import { ICertificate, ICertificateViewItem } from './types';
 import { enhanceCertificate, fetchDataAfterConfigurationChange } from '../general/sagas';
 import { certificateEnergyStringToBN } from '../../utils/certificates';
 
-export function* getCertificate(id: number): any {
+export function* getCertificate(id: number, byTokenId = false): any {
     const certificatesClient: CertificatesClient = yield select(getCertificatesClient);
 
-    const certificate = yield apply(certificatesClient, certificatesClient.get, [id]);
+    const { data: certificate } = yield apply(
+        certificatesClient,
+        byTokenId ? certificatesClient.getByTokenId : certificatesClient.get,
+        [id]
+    );
 
     return {
         ...certificate,

--- a/packages/origin-ui-core/src/features/general/sagas.ts
+++ b/packages/origin-ui-core/src/features/general/sagas.ts
@@ -274,7 +274,7 @@ function* findEnhancedExchangeCertificate(
     let onChainCertificate = onChainCertificates.find((c) => c.id === certificateId);
 
     if (!onChainCertificate) {
-        onChainCertificate = yield call(getCertificate, certificateId);
+        onChainCertificate = yield call(getCertificate, certificateId, true);
     }
 
     return enhanceCertificate(onChainCertificate, userId, asset);


### PR DESCRIPTION
Fixes the issue where the canary API would crash because the exchange UI would try to fetch a certificate by its db ID instead of its blockchain token ID.