### PR TITLE
fix(origin-ui): typo on running node --max-old-space-size=8192

### DIFF
--- a/packages/origin-ui/package.json
+++ b/packages/origin-ui/package.json
@@ -3,9 +3,9 @@
     "name": "@energyweb/origin-ui",
     "version": "2.2.8",
     "scripts": {
-        "build": "yarn config-env && node --max-old-space-size=8192 ./node_modules/.bin/webpack --config webpack/prod.config.js",
+        "build": "yarn build:full",
         "build:ts": "tsc -b tsconfig.json",
-        "build:full": "yarn config-env && node --max-old-space-size=8192 && webpack --config webpack/prod.config.js",
+        "build:full": "yarn config-env && node --max-old-space-size=8192 ./node_modules/.bin/webpack --config webpack/prod.config.js",
         "build:container:canary": "yarn build:full && make build-canary push-dockerhub",
         "build:container:latest": "yarn build:full && make build-latest push-dockerhub",
         "deploy:container:heroku:canary": "make push-heroku-canary",


### PR DESCRIPTION
Attempt to fix the failing builds and deployments on https://travis-ci.com/github/energywebfoundation/origin/builds/200005734#L4608