### PR TITLE
feat(origin-ui-core): MetaMask transfers and claims

### DIFF
--- a/packages/issuer-api/src/pods/blockchain/blockchain-properties.controller.ts
+++ b/packages/issuer-api/src/pods/blockchain/blockchain-properties.controller.ts
@@ -1,0 +1,23 @@
+import { ActiveUserGuard } from '@energyweb/origin-backend-utils';
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiResponse, ApiTags } from '@nestjs/swagger';
+import { BlockchainPropertiesDTO } from './blockchain-properties.dto';
+import { BlockchainPropertiesService } from './blockchain-properties.service';
+
+@ApiTags('blockchain-properties')
+@Controller('blockchain-properties')
+export class BlockchainPropertiesController {
+    constructor(private readonly blockchainPropertiesService: BlockchainPropertiesService) {}
+
+    @Get()
+    @UseGuards(AuthGuard(), ActiveUserGuard)
+    @ApiResponse({
+        status: 200,
+        type: BlockchainPropertiesDTO,
+        description: 'Returns blockchain properties'
+    })
+    public async get(): Promise<BlockchainPropertiesDTO> {
+        return this.blockchainPropertiesService.dto();
+    }
+}

--- a/packages/issuer-api/src/pods/blockchain/blockchain-properties.dto.ts
+++ b/packages/issuer-api/src/pods/blockchain/blockchain-properties.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+
+export class BlockchainPropertiesDTO {
+    @ApiProperty({ type: Number })
+    @IsNotEmpty()
+    @IsInt()
+    netId: number;
+
+    @ApiProperty({ type: String })
+    @IsNotEmpty()
+    @IsString()
+    registry: string;
+
+    @ApiProperty({ type: String })
+    @IsNotEmpty()
+    @IsString()
+    issuer: string;
+
+    @ApiProperty({ type: String })
+    @IsNotEmpty()
+    @IsString()
+    rpcNode: string;
+
+    @ApiProperty({ type: String })
+    @IsNotEmpty()
+    @IsString()
+    rpcNodeFallback: string;
+}

--- a/packages/issuer-api/src/pods/blockchain/blockchain-properties.module.ts
+++ b/packages/issuer-api/src/pods/blockchain/blockchain-properties.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { BlockchainPropertiesController } from './blockchain-properties.controller';
 import { BlockchainProperties } from './blockchain-properties.entity';
 import { BlockchainPropertiesService } from './blockchain-properties.service';
 
 @Module({
     imports: [TypeOrmModule.forFeature([BlockchainProperties])],
+    controllers: [BlockchainPropertiesController],
     providers: [BlockchainPropertiesService],
     exports: [BlockchainPropertiesService]
 })

--- a/packages/issuer-api/src/pods/blockchain/blockchain-properties.service.ts
+++ b/packages/issuer-api/src/pods/blockchain/blockchain-properties.service.ts
@@ -1,6 +1,7 @@
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { BlockchainProperties } from './blockchain-properties.entity';
+import { BlockchainPropertiesDTO } from './blockchain-properties.dto';
 
 export class BlockchainPropertiesService {
     constructor(
@@ -32,5 +33,17 @@ export class BlockchainPropertiesService {
         const [blockchainProperties] = await this.repository.find();
 
         return blockchainProperties;
+    }
+
+    public async dto(): Promise<BlockchainPropertiesDTO> {
+        const [blockchainProperties] = await this.repository.find();
+
+        return {
+            netId: blockchainProperties.netId,
+            registry: blockchainProperties.registry,
+            issuer: blockchainProperties.issuer,
+            rpcNode: blockchainProperties.rpcNode,
+            rpcNodeFallback: blockchainProperties.rpcNodeFallback
+        };
     }
 }

--- a/packages/issuer-api/test/blockchain-properties.e2e-spec.ts
+++ b/packages/issuer-api/test/blockchain-properties.e2e-spec.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-unused-expressions */
+import { INestApplication } from '@nestjs/common';
+import { expect } from 'chai';
+import request from 'supertest';
+import { DatabaseService } from '@energyweb/origin-backend-utils';
+
+import { bootstrapTestInstance } from './issuer-api';
+import { BlockchainPropertiesDTO } from '../src/pods/blockchain/blockchain-properties.dto';
+
+describe('BlockchainProperties tests', () => {
+    let app: INestApplication;
+    let databaseService: DatabaseService;
+
+    before(async () => {
+        ({ databaseService, app } = await bootstrapTestInstance());
+
+        await app.init();
+    });
+
+    after(async () => {
+        await databaseService.cleanUp();
+        await app.close();
+    });
+
+    it('should be able to get blockchain properties', async () => {
+        await request(app.getHttpServer())
+            .get('/blockchain-properties')
+            .expect(200)
+            .expect((res) => {
+                const { netId, registry, issuer, rpcNode }: BlockchainPropertiesDTO = res.body;
+
+                expect(netId).to.be.above(0);
+                expect(registry).to.not.be.empty;
+                expect(issuer).to.not.be.empty;
+                expect(rpcNode).to.not.be.empty;
+            });
+    });
+});

--- a/packages/issuer/src/blockchain-facade/Certificate.ts
+++ b/packages/issuer/src/blockchain-facade/Certificate.ts
@@ -1,4 +1,10 @@
-import { Event as BlockchainEvent, ContractTransaction, ethers, BigNumber } from 'ethers';
+import {
+    Event as BlockchainEvent,
+    ContractTransaction,
+    ethers,
+    BigNumber,
+    ContractReceipt
+} from 'ethers';
 
 import { Timestamp } from '@energyweb/utils-general';
 
@@ -207,7 +213,7 @@ export class Certificate implements ICertificate {
         amount?: BigNumber,
         from?: string,
         to?: string
-    ): Promise<ContractTransaction> {
+    ): Promise<ContractReceipt> {
         const { activeUser, registry } = this.blockchainProperties;
         const registryWithSigner = registry.connect(activeUser);
 
@@ -231,9 +237,9 @@ export class Certificate implements ICertificate {
             encodedClaimData
         );
 
-        await claimTx.wait();
+        const txReceipt = await claimTx.wait();
 
-        return claimTx;
+        return txReceipt;
     }
 
     async transfer(to: string, amount?: BigNumber, from?: string): Promise<ContractTransaction> {

--- a/packages/origin-ui-core/src/features/certificates/actions.ts
+++ b/packages/origin-ui-core/src/features/certificates/actions.ts
@@ -1,6 +1,10 @@
 import { ProducingDevice } from '@energyweb/device-registry';
 import { Certificate, IClaimData } from '@energyweb/issuer';
-import { CertificatesClient, CertificationRequestsClient } from '@energyweb/issuer-api-client';
+import {
+    BlockchainPropertiesClient,
+    CertificatesClient,
+    CertificationRequestsClient
+} from '@energyweb/issuer-api-client';
 import { BigNumber } from 'ethers';
 import { CertificateSource, ICertificateViewItem, ICertificationRequest } from './types';
 
@@ -21,6 +25,7 @@ export enum CertificatesActions {
     requestDepositCertificate = 'CERTIFICATES_REQUEST_CERTIFICATE_DEPOSIT',
     clearCertificates = 'CERTIFICATES_CLEAR_CERTIFICATES',
     reloadCertificates = 'CERTIFICATES_RELOAD_CERTIFICATES',
+    setBlockchainPropertiesClient = 'CERTIFICATES_SET_BLOCKCHAIN_PROPERTIES_CLIENT',
     setCertificatesClient = 'CERTIFICATES_SET_CERTIFICATES_CLIENT',
     setCertificationRequestsClient = 'CERTIFICATES_SET_CERTIFICATION_REQUESTS_CLIENT'
 }
@@ -251,6 +256,20 @@ export const reloadCertificates = () => ({
     type: CertificatesActions.reloadCertificates
 });
 
+export interface ISetBlockchainPropertiesClientAction {
+    type: CertificatesActions.setBlockchainPropertiesClient;
+    payload: BlockchainPropertiesClient;
+}
+
+export const setBlockchainPropertiesClient = (
+    payload: ISetBlockchainPropertiesClientAction['payload']
+) => ({
+    type: CertificatesActions.setBlockchainPropertiesClient,
+    payload
+});
+
+export type TSetBlockchainPropertiesClientAction = typeof setBlockchainPropertiesClient;
+
 export interface ISetCertificatesClientAction {
     type: CertificatesActions.setCertificatesClient;
     payload: CertificatesClient;
@@ -293,5 +312,6 @@ export type ICertificatesAction =
     | IClearCertificatesAction
     | IReloadCertificatesAction
     | IRequestWithdrawCertificateAction
+    | ISetBlockchainPropertiesClientAction
     | ISetCertificatesClientAction
     | ISetCertificationRequestsClientAction;

--- a/packages/origin-ui-core/src/features/certificates/reducer.ts
+++ b/packages/origin-ui-core/src/features/certificates/reducer.ts
@@ -1,6 +1,10 @@
 import { CertificatesActions, ICertificatesAction } from './actions';
 import { ProducingDevice } from '@energyweb/device-registry';
-import { CertificatesClient, CertificationRequestsClient } from '@energyweb/issuer-api-client';
+import {
+    CertificatesClient,
+    CertificationRequestsClient,
+    BlockchainPropertiesClient
+} from '@energyweb/issuer-api-client';
 import { ICertificateViewItem } from '.';
 
 export interface ICertificatesState {
@@ -9,6 +13,7 @@ export interface ICertificatesState {
         visible: boolean;
         producingDevice: ProducingDevice.Entity;
     };
+    blockchainPropertiesClient: BlockchainPropertiesClient;
     certificatesClient: CertificatesClient;
     certificationRequestsClient: CertificationRequestsClient;
 }
@@ -19,6 +24,7 @@ const defaultState: ICertificatesState = {
         visible: false,
         producingDevice: null
     },
+    blockchainPropertiesClient: null,
     certificatesClient: null,
     certificationRequestsClient: null
 };
@@ -88,6 +94,12 @@ export function certificatesState(
 
         case CertificatesActions.clearCertificates:
             return { ...state, certificates: [] };
+
+        case CertificatesActions.setBlockchainPropertiesClient:
+            return {
+                ...state,
+                blockchainPropertiesClient: action.payload
+            };
 
         case CertificatesActions.setCertificatesClient:
             return {

--- a/packages/origin-ui-core/src/features/certificates/selectors.ts
+++ b/packages/origin-ui-core/src/features/certificates/selectors.ts
@@ -20,6 +20,9 @@ export const getCertificateById = (
     return certificates.find((i) => i.id === id);
 };
 
+export const getBlockchainPropertiesClient = (state: ICoreState) =>
+    state.certificatesState.blockchainPropertiesClient;
+
 export const getCertificatesClient = (state: ICoreState) =>
     state.certificatesState.certificatesClient;
 

--- a/packages/origin-ui-core/src/features/general/sagas.ts
+++ b/packages/origin-ui-core/src/features/general/sagas.ts
@@ -36,7 +36,8 @@ import { BigNumber, ethers } from 'ethers';
 import {
     CertificationRequestsClient,
     Configuration as ClientConfiguration,
-    CertificatesClient
+    CertificatesClient,
+    BlockchainPropertiesClient
 } from '@energyweb/issuer-api-client';
 
 import { setActiveBlockchainAccountAddress } from '../users/actions';
@@ -57,7 +58,8 @@ import {
     updateCertificate,
     addCertificate,
     setCertificatesClient,
-    setCertificationRequestsClient
+    setCertificationRequestsClient,
+    setBlockchainPropertiesClient
 } from '../certificates';
 import { getCertificate } from '../certificates/sagas';
 import { getUserOffchain } from '../users/selectors';
@@ -219,6 +221,11 @@ function* initializeOffChainDataSource(): SagaIterator {
         });
         const backendUrl = `${environment.BACKEND_URL}:${environment.BACKEND_PORT}`;
 
+        yield put(
+            setBlockchainPropertiesClient(
+                new BlockchainPropertiesClient(clientConfiguration, backendUrl)
+            )
+        );
         yield put(setCertificatesClient(new CertificatesClient(clientConfiguration, backendUrl)));
         yield put(
             setCertificationRequestsClient(

--- a/packages/origin-ui-core/src/features/users/sagas.ts
+++ b/packages/origin-ui-core/src/features/users/sagas.ts
@@ -23,11 +23,13 @@ import {
     reloadCertificates,
     clearCertificates,
     setCertificatesClient,
-    setCertificationRequestsClient
+    setCertificationRequestsClient,
+    setBlockchainPropertiesClient
 } from '../certificates';
 import { getUserState } from './selectors';
 import { IUsersState } from './reducer';
 import {
+    BlockchainPropertiesClient,
     CertificatesClient,
     CertificationRequestsClient,
     Configuration as ClientConfiguration
@@ -95,6 +97,11 @@ function* updateClients(): SagaIterator {
         });
         const backendUrl = `${environment.BACKEND_URL}:${environment.BACKEND_PORT}`;
 
+        yield put(
+            setBlockchainPropertiesClient(
+                new BlockchainPropertiesClient(clientConfiguration, backendUrl)
+            )
+        );
         yield put(setCertificatesClient(new CertificatesClient(clientConfiguration, backendUrl)));
         yield put(
             setCertificationRequestsClient(
@@ -191,6 +198,11 @@ function* logOutSaga(): SagaIterator {
         requestClient.authenticationToken = null;
 
         const backendUrl = `${environment.BACKEND_URL}:${environment.BACKEND_PORT}`;
+        yield put(
+            setBlockchainPropertiesClient(
+                new BlockchainPropertiesClient(new ClientConfiguration(), backendUrl)
+            )
+        );
         yield put(
             setCertificatesClient(new CertificatesClient(new ClientConfiguration(), backendUrl))
         );


### PR DESCRIPTION
Enables doing transfers and claims directly through MetaMask, i.e. without using the Issuer API `/transfer` and `/claim` endpoints. + Expose the blockchain properties that the backend is using
