### PR TITLE
feat(issuer-api): use queuing for certificate requests deployment

### DIFF
--- a/packages/issuer-api/migrations/1605261411326-CertificationRequestStatus.ts
+++ b/packages/issuer-api/migrations/1605261411326-CertificationRequestStatus.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CertificationRequestStatus1605261411326 implements MigrationInterface {
+    name = 'CertificationRequestStatus1605261411326';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "issuer_certification_request" ADD "status" varchar NOT NULL DEFAULT 'Executed'`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "issuer_certification_request" ALTER COLUMN "requestId" DROP NOT NULL`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "issuer_certification_request" ALTER COLUMN "created" DROP NOT NULL`
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "issuer_certification_request" ALTER COLUMN "created" SET NOT NULL`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "issuer_certification_request" ALTER COLUMN "requestId" SET NOT NULL`
+        );
+        await queryRunner.query(`ALTER TABLE "issuer_certification_request" DROP COLUMN "status"`);
+    }
+}

--- a/packages/issuer-api/package.json
+++ b/packages/issuer-api/package.json
@@ -56,7 +56,8 @@
         "pg": "^8.0.0",
         "precise-proofs-js": "^1.2.0",
         "swagger-ui-express": "4.1.4",
-        "typeorm": "0.2.29"
+        "typeorm": "0.2.29",
+        "rxjs": "6.6.3"
     },
     "devDependencies": {
         "@nestjs/cli": "7.5.2",

--- a/packages/issuer-api/src/pods/certification-request/certification-request-status.enum.ts
+++ b/packages/issuer-api/src/pods/certification-request/certification-request-status.enum.ts
@@ -1,0 +1,5 @@
+export enum CertificationRequestStatus {
+    Queued = 'Queued',
+    Executed = 'Executed',
+    Error = 'Error'
+}

--- a/packages/issuer-api/src/pods/certification-request/certification-request.dto.ts
+++ b/packages/issuer-api/src/pods/certification-request/certification-request.dto.ts
@@ -11,6 +11,7 @@ import {
     Validate,
     ValidateIf
 } from 'class-validator';
+import { CertificationRequestStatus } from './certification-request-status.enum';
 
 export class CertificationRequestDTO {
     @ApiProperty({ type: Number })
@@ -79,4 +80,11 @@ export class CertificationRequestDTO {
     @IsInt()
     @Min(0)
     issuedCertificateTokenId?: number;
+
+    @ApiProperty({
+        enumName: 'CertificationRequestStatus',
+        enum: CertificationRequestStatus,
+        required: false
+    })
+    status?: CertificationRequestStatus;
 }

--- a/packages/issuer-api/src/pods/certification-request/certification-request.entity.ts
+++ b/packages/issuer-api/src/pods/certification-request/certification-request.entity.ts
@@ -2,6 +2,7 @@ import { ExtendedBaseEntity } from '@energyweb/origin-backend-utils';
 import { Column, Entity, PrimaryGeneratedColumn, Unique } from 'typeorm';
 import { IsInt, Min, IsBoolean, IsDate, IsPositive } from 'class-validator';
 import { CertificationRequestDTO } from './certification-request.dto';
+import { CertificationRequestStatus } from './certification-request-status.enum';
 
 export const CERTIFICATION_REQUESTS_TABLE_NAME = 'issuer_certification_request';
 
@@ -11,7 +12,7 @@ export class CertificationRequest extends ExtendedBaseEntity implements Certific
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Column()
+    @Column({ nullable: true })
     requestId: number;
 
     @Column('varchar')
@@ -36,7 +37,7 @@ export class CertificationRequest extends ExtendedBaseEntity implements Certific
     @Column('simple-array', { nullable: false, default: [] })
     files: string[];
 
-    @Column()
+    @Column({ nullable: true })
     @IsInt()
     @IsPositive()
     created: number;
@@ -65,4 +66,7 @@ export class CertificationRequest extends ExtendedBaseEntity implements Certific
     @Column()
     @IsBoolean()
     isPrivate: boolean;
+
+    @Column('varchar')
+    status: CertificationRequestStatus;
 }

--- a/packages/issuer-api/src/pods/certification-request/handlers/create-certification-request.handler.ts
+++ b/packages/issuer-api/src/pods/certification-request/handlers/create-certification-request.handler.ts
@@ -1,20 +1,31 @@
+import { CertificationRequest as CertificationRequestFacade } from '@energyweb/issuer';
+import { Logger } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Subject } from 'rxjs';
+import { concatMap } from 'rxjs/operators';
 import { Repository } from 'typeorm';
-import { CertificationRequest as CertificationRequestFacade } from '@energyweb/issuer';
-import { CreateCertificationRequestCommand } from '../commands/create-certification-request.command';
-import { CertificationRequest } from '../certification-request.entity';
+
 import { BlockchainPropertiesService } from '../../blockchain/blockchain-properties.service';
+import { CertificationRequestStatus } from '../certification-request-status.enum';
 import { CertificationRequestDTO } from '../certification-request.dto';
+import { CertificationRequest } from '../certification-request.entity';
+import { CreateCertificationRequestCommand } from '../commands/create-certification-request.command';
 
 @CommandHandler(CreateCertificationRequestCommand)
 export class CreateCertificationRequestHandler
     implements ICommandHandler<CreateCertificationRequestCommand> {
+    private readonly logger = new Logger(CreateCertificationRequestHandler.name);
+
+    private readonly requestQueue = new Subject<number>();
+
     constructor(
         @InjectRepository(CertificationRequest)
         private readonly repository: Repository<CertificationRequest>,
         private readonly blockchainPropertiesService: BlockchainPropertiesService
-    ) {}
+    ) {
+        this.requestQueue.pipe(concatMap((id) => this.process(id))).subscribe();
+    }
 
     async execute({
         to,
@@ -25,30 +36,72 @@ export class CreateCertificationRequestHandler
         files,
         isPrivate
     }: CreateCertificationRequestCommand): Promise<CertificationRequestDTO> {
-        const blockchainProperties = await this.blockchainPropertiesService.get();
-
-        const certReq = await CertificationRequestFacade.create(
+        const certificationRequest = this.repository.create({
+            deviceId,
+            energy,
             fromTime,
             toTime,
-            deviceId,
-            blockchainProperties.wrap(),
-            to
-        );
-
-        const certificationRequest = this.repository.create({
-            requestId: certReq.id,
-            deviceId: certReq.deviceId,
-            energy,
-            owner: certReq.owner,
-            fromTime: certReq.fromTime,
-            toTime: certReq.toTime,
-            created: certReq.created,
-            approved: certReq.approved,
-            revoked: certReq.revoked,
+            approved: false,
+            revoked: false,
             files,
-            isPrivate: isPrivate ?? false
+            isPrivate: isPrivate ?? false,
+            status: CertificationRequestStatus.Queued,
+            owner: to
         });
 
-        return this.repository.save(certificationRequest);
+        const stored = await this.repository.save(certificationRequest);
+
+        this.requestQueue.next(stored.id);
+
+        return stored;
+    }
+
+    private async process(requestId: number) {
+        this.logger.debug(`Processing certification request ${requestId}`);
+
+        const request = await this.repository.findOne(requestId);
+
+        if (!request) {
+            this.logger.error(
+                `Certification request ${requestId} not longer exists in DB...skipping`
+            );
+            return;
+        }
+
+        if (request.status !== CertificationRequestStatus.Queued) {
+            this.logger.error(
+                `Certification request ${requestId} was expected to have status ${CertificationRequestStatus.Queued} but has ${request.status}`
+            );
+            return;
+        }
+
+        const blockchainProperties = await this.blockchainPropertiesService.get();
+
+        const { fromTime, toTime, deviceId, owner } = request;
+
+        try {
+            const { created, id } = await CertificationRequestFacade.create(
+                fromTime,
+                toTime,
+                deviceId,
+                blockchainProperties.wrap(),
+                owner
+            );
+            this.logger.debug(
+                `Certification request ${requestId} has been deployed with id ${id} `
+            );
+
+            await this.repository.update(request.id, {
+                created,
+                requestId: id,
+                status: CertificationRequestStatus.Executed
+            });
+        } catch (e) {
+            this.logger.error(`Certification request ${requestId} deployment has end if error`);
+
+            await this.repository.update(request.id, {
+                status: CertificationRequestStatus.Error
+            });
+        }
     }
 }

--- a/packages/issuer-api/src/pods/certification-request/handlers/validate-certification-request.handler.ts
+++ b/packages/issuer-api/src/pods/certification-request/handlers/validate-certification-request.handler.ts
@@ -2,11 +2,12 @@ import * as Moment from 'moment';
 import { extendMoment } from 'moment-range';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Not, Repository } from 'typeorm';
 import { ISuccessResponse, ResponseFailure, ResponseSuccess } from '@energyweb/origin-backend-core';
 import { HttpStatus } from '@nestjs/common';
 import { ValidateCertificationRequestCommand } from '../commands/validate-certification-request.command';
 import { CertificationRequest } from '../certification-request.entity';
+import { CertificationRequestStatus } from '../certification-request-status.enum';
 
 @CommandHandler(ValidateCertificationRequestCommand)
 export class ValidateCertificationRequestHandler
@@ -25,7 +26,8 @@ export class ValidateCertificationRequestHandler
         const deviceCertificationRequests = await this.repository.find({
             where: {
                 revoked: false,
-                deviceId
+                deviceId,
+                status: Not(CertificationRequestStatus.Error)
             }
         });
 

--- a/packages/issuer-api/test/certification-request.e2e-spec.ts
+++ b/packages/issuer-api/test/certification-request.e2e-spec.ts
@@ -9,6 +9,7 @@ import { DatabaseService } from '@energyweb/origin-backend-utils';
 import { authenticatedUser, bootstrapTestInstance, deviceManager } from './issuer-api';
 import { CERTIFICATION_REQUESTS_TABLE_NAME } from '../src/pods/certification-request/certification-request.entity';
 import { CERTIFICATES_TABLE_NAME } from '../src/pods/certificate/certificate.entity';
+import { CertificationRequestStatus } from '../src/pods/certification-request/certification-request-status.enum';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -60,17 +61,19 @@ describe('Certification Request tests', () => {
                     approved,
                     revoked,
                     files,
-                    energy
+                    energy,
+                    status
                 } = res.body;
 
                 expect(deviceId).to.equal(certificationRequestTestData.deviceId);
                 expect(fromTime).to.equal(certificationRequestTestData.fromTime);
                 expect(toTime).to.equal(certificationRequestTestData.toTime);
-                expect(created).to.be.above(1);
-                expect(requestId).to.be.above(-1);
+                expect(created).to.be.null;
+                expect(requestId).to.be.null;
                 expect(owner).to.equal(deviceManager.address);
                 expect(approved).to.be.false;
                 expect(revoked).to.be.false;
+                expect(status).to.be.equal(CertificationRequestStatus.Queued);
                 expect(JSON.stringify(files)).to.equal(
                     JSON.stringify(certificationRequestTestData.files)
                 );
@@ -107,6 +110,9 @@ describe('Certification Request tests', () => {
             .expect((res) => {
                 certificationRequestId = res.body.id;
             });
+
+        // need to wait for item to be picked up from the queue and deployed
+        await sleep(3000);
 
         authenticatedUser.rights = Role.Issuer;
 
@@ -164,6 +170,9 @@ describe('Certification Request tests', () => {
                 certificationRequestId = res.body.id;
             });
 
+        // need to wait for item to be picked up from the queue and deployed
+        await sleep(3000);
+
         authenticatedUser.rights = Role.Issuer;
 
         await request(app.getHttpServer())
@@ -183,6 +192,9 @@ describe('Certification Request tests', () => {
             .expect((res) => {
                 certificationRequestId = res.body.id;
             });
+
+        // need to wait for item to be picked up from the queue and deployed
+        await sleep(3000);
 
         authenticatedUser.rights = Role.Issuer;
 
@@ -225,6 +237,9 @@ describe('Certification Request tests', () => {
             .expect((res) => {
                 certificationRequestId = res.body.id;
             });
+
+        // need to wait for item to be picked up from the queue and deployed
+        await sleep(3000);
 
         await request(app.getHttpServer())
             .put(`/certification-request/${certificationRequestId}/approve`)

--- a/packages/origin-backend-app/tsconfig.json
+++ b/packages/origin-backend-app/tsconfig.json
@@ -22,6 +22,9 @@
         },
         {
             "path": "../utils-general/tsconfig.json"
+        },
+        {
+            "path": "../issuer-api/tsconfig.json"
         }
     ]
 }

--- a/packages/origin-ui-core/src/components/certificates/CertificationRequestsTable.tsx
+++ b/packages/origin-ui-core/src/components/certificates/CertificationRequestsTable.tsx
@@ -28,6 +28,7 @@ import {
     requestCertificateApproval
 } from '../../features/certificates';
 import { downloadFile } from '../Organization/DownloadDocuments';
+import { CertificationRequestStatus } from '@energyweb/issuer-api-client';
 
 interface IProps {
     approved: boolean;
@@ -80,6 +81,7 @@ export function CertificationRequestsTable(props: IProps) {
 
                 if (
                     request.approved !== props.approved ||
+                    request.status !== CertificationRequestStatus.Executed ||
                     (!isIssuer && user?.organization.id !== requestDevice?.organization.id)
                 ) {
                     continue;


### PR DESCRIPTION
This PR adds the queuing functionality for certification requests deployments.

This solves the problems where multiple requests are handled at the same time by same deployer account causing nonces mismatch.