### PR TITLE
chore(issuer-api): use correct type for Registry contract

### DIFF
--- a/packages/issuer-api/src/pods/certificate/listeners/on-chain-certificates.listener.ts
+++ b/packages/issuer-api/src/pods/certificate/listeners/on-chain-certificates.listener.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { Contract, providers } from 'ethers';
-import { CertificateUtils } from '@energyweb/issuer';
+import { providers } from 'ethers';
+import { CertificateUtils, IBlockchainProperties } from '@energyweb/issuer';
 import { EventBus } from '@nestjs/cqrs';
 import { BlockchainPropertiesService } from '../../blockchain/blockchain-properties.service';
 import { CertificateCreatedEvent } from '../events/certificate-created-event';
@@ -22,7 +22,7 @@ export class OnChainCertificateWatcher implements OnModuleInit {
 
     public provider: providers.FallbackProvider | providers.JsonRpcProvider;
 
-    public registry: Contract;
+    public registry: IBlockchainProperties['registry'];
 
     constructor(
         private readonly blockchainPropertiesService: BlockchainPropertiesService,


### PR DESCRIPTION
Incorrect type error breaks deployments to canary.
This should fix the type error.