### PR TITLE
User blockchain account connection

### DIFF
--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -349,6 +349,8 @@
                 "status": "Status",
                 "kycStatus": "KYC Status",
                 "blockchainAddress": "Blockchain Address",
+                "blockchainAddresses": "Blockchain Addresses",
+                "userBlockchainAddress": "User Blockchain Address",
                 "emailConfirmed": "Email Confirmed"
             },
             "actions": {
@@ -357,7 +359,14 @@
                 "login": "Login",
                 "save": "Save",
                 "resendConfirmationEmail": "Re-send confirmation email",
-                "forgotPasswordAsk": "Forgot password?"
+                "forgotPasswordAsk": "Forgot password?",
+                "connectBlockchain": "Connect Blockchain Address",
+                "connectNewBlockchain": "Connect New Blockchain Address"
+            },
+            "popover": {
+                "blockchainWhatIs": "This address is separate from the exchange deposit address. You need it if you want to manage the platform with your own blockchain address.",
+                "blockchainWhatFor": "A connected user blockchain address is required to withdraw certificates from the exchange and retire certificates.",
+                "blockchainHowTo": "Select the right blockchain account in your MetaMask browser wallet and click “Connect Blockchain Address” to connect. Visit metamask.io to set up your own blockchain wallet."
             },
             "feedback": {
                 "userRegistered": "User registered.",

--- a/packages/localization/src/languages/pl.json
+++ b/packages/localization/src/languages/pl.json
@@ -247,14 +247,27 @@
                 "lastName": "Nazwisko",
                 "telephone": "Telefon",
                 "email": "Email",
-                "password": "Hasło"
+                "password": "Hasło",
+                "status": "Status",
+                "kycStatus": "Status KYC",
+                "blockchainAddress": "Adres Blockchain",
+                "blockchainAddresses": "Adresy Blockchain",
+                "userBlockchainAddress": "Adres użytkownika Blockchain",
+                "emailConfirmed": "E-mail potwierdzony"
             },
             "actions": {
                 "register": "Zarejestruj",
                 "registerNow": "Zarejestruj się teraz",
                 "login": "Zaloguj się",
                 "save": "Zapisać",
-                "forgotPasswordAsk": "Zapomniałeś hasła?"
+                "forgotPasswordAsk": "Zapomniałeś hasła?",
+                "connectBlockchain": "Połącz adres Blockchain",
+                "connectNewBlockchain": "Połącz nowy adres Blockchain"
+            },
+            "popover": {
+                "blockchainWhatIs": "Ten adres jest inny niż adres depozytu wymiany. Potrzebujesz tego, jeśli chcesz zarządzać platformą za pomocą własnego adresu blockchain.",
+                "blockchainWhatFor": "Adres blockchain podłączonego użytkownika jest wymagany do wycofania certyfikatów z giełdy i wycofania certyfikatów.",
+                "blockchainHowTo": "Wybierz odpowiednie konto blockchain w portfelu przeglądarki MetaMask i kliknij „Połącz adres Blockchain”, aby się połączyć. Odwiedź metamask.io, aby założyć własny portfel blockchain."
             },
             "feedback": {
                 "userRegistered": "Użytkownik zarejestrowany.",

--- a/packages/origin-ui-core/src/components/Account/Account.tsx
+++ b/packages/origin-ui-core/src/components/Account/Account.tsx
@@ -107,6 +107,10 @@ export function Account() {
                 render={() => <Redirect to={{ pathname: `${getAccountLink()}/${Menu[0].key}` }} />}
             />
             <Route
+                path={`${getAccountLink()}`}
+                render={() => <Redirect to={{ pathname: `${getAccountLink()}/${Menu[0].key}` }} />}
+            />
+            <Route
                 exact={true}
                 path={`${baseURL}/`}
                 render={() => <Redirect to={{ pathname: `${getAccountLink()}/${Menu[0].key}` }} />}

--- a/packages/origin-ui-core/src/components/IconPopover.tsx
+++ b/packages/origin-ui-core/src/components/IconPopover.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import Popover from '@material-ui/core/Popover';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+    popover: {
+        pointerEvents: 'none'
+    },
+    paper: {
+        padding: theme.spacing(1)
+    },
+    popoverTextBlock: {
+        padding: '10px'
+    }
+}));
+
+interface IProps {
+    icon: React.ReactType;
+    popoverText: string[];
+    classObj?: string;
+}
+
+export function IconPopover(props: IProps) {
+    const { popoverText, classObj, icon: Icon } = props;
+    const classes = useStyles();
+    const [anchorEl, setAnchorEl] = useState(null);
+
+    const handlePopoverOpen = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handlePopoverClose = () => {
+        setAnchorEl(null);
+    };
+
+    const open = Boolean(anchorEl);
+    const textWithLineBreaks = popoverText.map((text) => (
+        <span key={text.length}>
+            {text}
+            <br />
+            <br />
+        </span>
+    ));
+
+    return (
+        <div className={classObj}>
+            <Icon
+                aria-owns={open ? 'mouse-over-popover' : undefined}
+                aria-haspopup="true"
+                onMouseEnter={handlePopoverOpen}
+                onMouseLeave={handlePopoverClose}
+                fontSize="large"
+            />
+            <Popover
+                id="mouse-over-popover"
+                className={classes.popover}
+                classes={{
+                    paper: classes.paper
+                }}
+                open={open}
+                anchorEl={anchorEl}
+                anchorOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left'
+                }}
+                transformOrigin={{
+                    vertical: 'bottom',
+                    horizontal: 'left'
+                }}
+                onClose={handlePopoverClose}
+                PaperProps={{
+                    style: { width: '30%' }
+                }}
+                disableRestoreFocus
+            >
+                <Typography className={classes.popoverTextBlock}>{textWithLineBreaks}</Typography>
+            </Popover>
+        </div>
+    );
+}

--- a/packages/origin-ui-core/src/features/users/actions.ts
+++ b/packages/origin-ui-core/src/features/users/actions.ts
@@ -12,7 +12,8 @@ export enum UsersActions {
     addOrganizations = 'USERS_ADD_ORGANIZATIONS',
     setInvitations = 'USERS_SET_INVITATIONS',
     setUserState = 'USERS_SET_USER_STATE',
-    setIRecAccount = 'USERS_SET_IREC_ACCOUNT'
+    setIRecAccount = 'USERS_SET_IREC_ACCOUNT',
+    updateUserBlockchain = 'UPDATE_USER_BLOCKCHAIN'
 }
 
 export interface ISetActiveBlockchainAccountAddressAction {
@@ -123,6 +124,22 @@ export interface ISetUserState {
 
 export const setUserState = (payload: ISetUserState['payload']): ISetUserState => ({
     type: UsersActions.setUserState,
+    payload
+});
+
+export interface IUpdateUserBlockchainAction {
+    type: UsersActions.updateUserBlockchain;
+    payload: {
+        user: IUser;
+        activeAccount: string;
+        callback: () => void;
+    };
+}
+
+export const updateUserBlockchain = (
+    payload: IUpdateUserBlockchainAction['payload']
+): IUpdateUserBlockchainAction => ({
+    type: UsersActions.updateUserBlockchain,
     payload
 });
 

--- a/packages/origin-ui-core/src/features/users/sagas.ts
+++ b/packages/origin-ui-core/src/features/users/sagas.ts
@@ -4,9 +4,9 @@ import {
     Configuration as ClientConfiguration,
     BlockchainPropertiesClient
 } from '@energyweb/issuer-api-client';
-import { OriginFeature } from '@energyweb/utils-general';
+import { OriginFeature, signTypedMessage } from '@energyweb/utils-general';
 import { UserClient } from '@energyweb/origin-backend-client';
-import { call, put, select, take, fork, all, getContext } from 'redux-saga/effects';
+import { call, put, select, take, fork, all, getContext, apply } from 'redux-saga/effects';
 import { SagaIterator } from 'redux-saga';
 import {
     UsersActions,
@@ -16,7 +16,8 @@ import {
     clearAuthenticationToken,
     setUserState,
     refreshUserOffchain,
-    refreshClients
+    refreshClients,
+    IUpdateUserBlockchainAction
 } from './actions';
 import { getBackendClient, getIRecClient, getEnvironment } from '../general/selectors';
 import { Registration } from '../../utils/irec/types';
@@ -25,7 +26,8 @@ import {
     IEnvironment,
     setBackendClient,
     setExchangeClient,
-    setIRecClient
+    setIRecClient,
+    setLoading
 } from '../general/actions';
 import {
     reloadCertificates,
@@ -40,6 +42,9 @@ import { IUsersState } from './reducer';
 import { BackendClient } from '../../utils/clients/BackendClient';
 import { ExchangeClient } from '../../utils/clients/ExchangeClient';
 import { IRecClient } from '../../utils/clients/IRecClient';
+import { showNotification, NotificationType } from '../..';
+import { getI18n } from 'react-i18next';
+import { getWeb3 } from '../selectors';
 
 export const LOCAL_STORAGE_KEYS = {
     AUTHENTICATION_TOKEN: 'AUTHENTICATION_TOKEN'
@@ -186,6 +191,57 @@ function* fetchOffchainUserDetails(): SagaIterator {
     }
 }
 
+function* updateBlockchainAddress(): SagaIterator {
+    while (true) {
+        const { payload }: IUpdateUserBlockchainAction = yield take(
+            UsersActions.updateUserBlockchain
+        );
+        const { user, activeAccount, callback } = payload;
+
+        yield put(setLoading(true));
+
+        const web3 = yield select(getWeb3);
+        const environment = yield select(getEnvironment);
+        const backendClient: BackendClient = yield select(getBackendClient);
+        const userClient: UserClient = backendClient.userClient;
+        const i18n = getI18n();
+
+        try {
+            const message = yield call(
+                signTypedMessage,
+                activeAccount,
+                environment.REGISTRATION_MESSAGE_TO_SIGN,
+                web3
+            );
+
+            yield apply(userClient, userClient.updateOwnBlockchainAddress, [
+                { ...user, blockchainAccountAddress: '' }
+            ]);
+            yield apply(userClient, userClient.update, [
+                { blockchainAccountSignedMessage: message }
+            ]);
+
+            showNotification(
+                i18n.t('settings.feedback.blockchainAccountLinked'),
+                NotificationType.Success
+            );
+            yield put(refreshUserOffchain());
+            yield call(callback);
+        } catch (error) {
+            if (error?.data?.message) {
+                showNotification(error?.data?.message, NotificationType.Error);
+            } else if (error?.message) {
+                console.log(error);
+                showNotification(error?.message, NotificationType.Error);
+            } else {
+                console.warn('Could not log in.', error);
+                showNotification(i18n.t('general.feedback.unknownError'), NotificationType.Error);
+            }
+        }
+        yield put(setLoading(false));
+    }
+}
+
 function* logOutSaga(): SagaIterator {
     while (true) {
         yield take(UsersActions.clearAuthenticationToken);
@@ -204,6 +260,7 @@ export function* usersSaga(): SagaIterator {
         fork(persistAuthenticationToken),
         fork(updateClients),
         fork(fetchOffchainUserDetails),
+        fork(updateBlockchainAddress),
         fork(logOutSaga)
     ]);
 }


### PR DESCRIPTION
In this PR: 
- Added default redirect for non-accessible routes inside Account-route.
- Changed the user blockchain connection form.

![first-connect](https://user-images.githubusercontent.com/69903849/100716574-8e0f3c80-33c1-11eb-8af9-3b1d184ecbdd.png)

- Created a `IconPopover` component which provides additional info for user action.

![popover-blockchain](https://user-images.githubusercontent.com/69903849/100716608-98c9d180-33c1-11eb-99a2-87bd30daaa68.png)

- Moved the functionality of updating user blockchain account from component to saga.
- Added the ability for user to set his blockchain account not once, but every time he wants to.
![connected-account](https://user-images.githubusercontent.com/69903849/100716633-a1220c80-33c1-11eb-8c4e-e0ebed9f3007.png)
