### PR TITLE
UI fixes and improvements

### DIFF
--- a/packages/localization/src/languages/en.json
+++ b/packages/localization/src/languages/en.json
@@ -71,20 +71,27 @@
                 "constructed": "Constructed",
                 "vintageCod": "Vintage / (Commercial Operation Date)",
                 "gridOperator": "Grid operator",
-                "price": "Price"
+                "price": "Price",
+                "active": "Active",
+                "paused": "Paused"
             },
             "actions": {
                 "requestCertificates": "Request certificates",
                 "approve": "Approve",
                 "registerDevice": "Register device",
                 "register": "Register",
-                "viewDetails": "View details"
+                "viewDetails": "View details",
+                "updateSupply": "Update Supply",
+                "cancel": "Cancel",
+                "update": "Update"
             },
             "feedback": {
                 "imagesUploaded": "Images have been uploaded.",
                 "deviceCreated": "Device successfully created.",
                 "pleaseSelectUpToXImages": "Please select up to {limit} images. You've selected {actual}.",
-                "unexpectedErrorWhenUploadingImages": "Unexpected error occurred when uploading images."
+                "unexpectedErrorWhenUploadingImages": "Unexpected error occurred when uploading images.",
+                "supplyUpdatedSuccess": "Supply updated successfully",
+                "supplyUpdateError": "Supply updating failed"
             },
             "info": {
                 "general": "General",

--- a/packages/localization/src/languages/pl.json
+++ b/packages/localization/src/languages/pl.json
@@ -56,14 +56,42 @@
                 "projectStory": "Opis projektu",
                 "images": "Zdjęcia",
                 "capacity": "Pojemność",
-                "address": "Adres"
+                "address": "Adres",
+                "constructed": "Zbudowana",
+                "vintageCod": "Vintage / (data operacji handlowej)",
+                "gridOperator": "Operator sieci",
+                "price": "Cena",
+                "active": "Aktywny",
+                "paused": "Wstrzymano"
             },
             "actions": {
                 "requestCertificates": "Zażądaj certyfikatów",
                 "approve": "Zaakceptuj",
                 "registerDevice": "Zarejestruj urządzenie",
                 "register": "Zarejestruj",
-                "viewDetails": "Pokaż szczegóły"
+                "viewDetails": "Pokaż szczegóły",
+                "updateSupply": "Zaktualizuj zaopatrzenie",
+                "cancel": "Anulować",
+                "update": "Aktualizacja"
+            },
+            "feedback": {
+                "imagesUploaded": "Obrazy zostały przesłane.",
+                "deviceCreated": "Urządzenie zostało pomyślnie utworzone.",
+                "pleaseSelectUpToXImages": "Wybierz maksymalnie {limit} obrazów. Wybrałeś {current}.",
+                "unexpectedErrorWhenUploadingImages": "Wystąpił nieoczekiwany błąd podczas przesyłania zdjęć.",
+                "supplyUpdatedSuccess": "Dostawa zaktualizowana pomyślnie",
+                "supplyUpdateError": "Aktualizacja materiałów eksploatacyjnych nie powiodła się"
+            },
+            "info": {
+                "general": "Generał",
+                "selectDeviceType": "Wybierz typ urządzenia",
+                "supported": "Utrzymany",
+                "pleaseFillOtherFields": "Wypełnij inne pola formularza i kontynuuj klikając \"Zarejestruj\".",
+                "uploadUpToXImages": "Prześlij do {amount} obrazów",
+                "selectRegion": "Wybierz region",
+                "selectProvince": "Wybierz prowincję",
+                "selectGridOperator": "Wybierz operatora sieci",
+                "toRegisterADevice": "Aby zarejestrować urządzenie, musisz spełnić następujące kryteria:"
             }
         },
         "certificate": {

--- a/packages/origin-ui-core/src/components/Account/Account.tsx
+++ b/packages/origin-ui-core/src/components/Account/Account.tsx
@@ -107,10 +107,6 @@ export function Account() {
                 render={() => <Redirect to={{ pathname: `${getAccountLink()}/${Menu[0].key}` }} />}
             />
             <Route
-                path={`${getAccountLink()}`}
-                render={() => <Redirect to={{ pathname: `${getAccountLink()}/${Menu[0].key}` }} />}
-            />
-            <Route
                 exact={true}
                 path={`${baseURL}/`}
                 render={() => <Redirect to={{ pathname: `${getAccountLink()}/${Menu[0].key}` }} />}

--- a/packages/origin-ui-core/src/components/Modal/PendingInvitationsModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/PendingInvitationsModal.tsx
@@ -155,7 +155,7 @@ export const PendingInvitationsModal = (props: IProps) => {
     };
 
     return (
-        <Dialog open={showModal} onClose={() => setShowModal(false)}>
+        <Dialog open={showModal}>
             <DialogTitle>
                 <Grid container>
                     <Grid item xs={2}>

--- a/packages/origin-ui-core/src/components/Modal/UpdateSupplyModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/UpdateSupplyModal.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    TextField,
+    DialogActions,
+    Button,
+    MenuItem
+} from '@material-ui/core';
+import { IDevice } from '@energyweb/origin-backend-core';
+import { BackendClient, showNotification, NotificationType, useTranslation } from '../../utils';
+import { getBackendClient } from '../../features';
+import { KeyStatus } from '../devices/AutoSupplyDeviceTable';
+
+interface IProps {
+    showModal: boolean;
+    setShowModal: (value: React.SetStateAction<boolean>) => void;
+    entity: IDevice;
+    setEntity: (value: React.SetStateAction<IDevice>) => void;
+    loadPage: (page: number) => void;
+}
+
+export function UpdateSupplyModal(props: IProps) {
+    const { showModal, setShowModal, entity, setEntity, loadPage } = props;
+    const backendClient: BackendClient = useSelector(getBackendClient);
+    const deviceClient = backendClient?.deviceClient;
+    const { t } = useTranslation();
+
+    async function requestAutoSupply() {
+        try {
+            await deviceClient.updateDeviceSettings(entity.id.toString(), {
+                automaticPostForSale: entity.automaticPostForSale,
+                defaultAskPrice: entity.defaultAskPrice * 100
+            });
+            setShowModal(false);
+            loadPage(1);
+            showNotification(t('device.feedback.supplyUpdatedSuccess'), NotificationType.Success);
+        } catch (error) {
+            showNotification(t('device.feedback.supplyUpdatedError'), NotificationType.Error);
+        }
+    }
+
+    return (
+        <Dialog open={showModal}>
+            <DialogTitle>{t('device.actions.updateSupply')}</DialogTitle>
+            <DialogContent>
+                <TextField
+                    label={t('device.properties.type')}
+                    value={entity?.deviceType}
+                    className="mt-4"
+                    disabled={true}
+                    fullWidth
+                />
+
+                <TextField
+                    label={t('device.properties.facility')}
+                    value={entity?.facilityName}
+                    className="mt-4"
+                    disabled={true}
+                    fullWidth
+                />
+
+                <TextField
+                    label={t('device.properties.price')}
+                    value={entity?.defaultAskPrice}
+                    className="mt-4"
+                    type="number"
+                    onChange={(e) =>
+                        setEntity({
+                            ...entity,
+                            defaultAskPrice: Number(e.target.value)
+                        })
+                    }
+                    fullWidth
+                />
+
+                <TextField
+                    label={t('device.properties.status')}
+                    value={entity?.automaticPostForSale ? KeyStatus[1] : KeyStatus[2]}
+                    className="mt-4"
+                    fullWidth
+                    onChange={(e) =>
+                        setEntity({
+                            ...entity,
+                            automaticPostForSale: e.target.value !== KeyStatus[2]
+                        })
+                    }
+                    select
+                >
+                    <MenuItem value={KeyStatus[1]}>{t('device.properties.active')}</MenuItem>
+                    <MenuItem value={KeyStatus[2]}>{t('device.properties.paused')}</MenuItem>
+                </TextField>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={() => setShowModal(false)} color="secondary">
+                    {t('device.actions.cancel')}
+                </Button>
+                <Button onClick={requestAutoSupply} color="primary">
+                    {t('device.actions.update')}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/packages/origin-ui-core/src/components/MultiSelectAutocomplete.tsx
+++ b/packages/origin-ui-core/src/components/MultiSelectAutocomplete.tsx
@@ -64,11 +64,7 @@ export function MultiSelectAutocomplete(props: IOwnProps) {
                 onChange={(event, value: IAutocompleteMultiSelectOptionType[]) => {
                     props.onChange(value ? value.slice(0, max ?? value.length) : value);
                     setTouchFlag(true);
-                    if (singleChoice) {
-                        setTextValue(' ');
-                    } else {
-                        setTextValue('');
-                    }
+                    setTextValue('');
                 }}
                 value={selectedValues}
                 renderTags={(value, getTagProps) =>
@@ -95,7 +91,7 @@ export function MultiSelectAutocomplete(props: IOwnProps) {
                         }
                         inputProps={{ ...params.inputProps }}
                         error={touchFlag && required && props.selectedValues.length === 0}
-                        placeholder={placeholder}
+                        placeholder={singleChoice && touchFlag ? '' : placeholder}
                         fullWidth
                         variant="filled"
                     />

--- a/packages/origin-ui-core/src/components/Organization/Organization.tsx
+++ b/packages/origin-ui-core/src/components/Organization/Organization.tsx
@@ -16,11 +16,20 @@ import { OrganizationUsersTable } from './OrganizationUsersTable';
 import { OrganizationForm } from './OrganizationForm';
 import { IRECRegisterForm } from './IRECRegisterForm';
 
-export const roleNames = {
-    [Role.OrganizationUser]: 'organization.invitations.roles.member',
-    [Role.OrganizationDeviceManager]: 'organization.invitations.roles.deviceManager',
-    [Role.OrganizationAdmin]: 'organization.invitations.roles.admin'
-};
+export const roleNames = [
+    {
+        value: Role.OrganizationAdmin,
+        label: 'organization.invitations.roles.admin'
+    },
+    {
+        value: Role.OrganizationDeviceManager,
+        label: 'organization.invitations.roles.deviceManager'
+    },
+    {
+        value: Role.OrganizationUser,
+        label: 'organization.invitations.roles.member'
+    }
+];
 
 export function Organization() {
     const user = useSelector(getUserOffchain);

--- a/packages/origin-ui-core/src/components/Organization/OrganizationInvite.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationInvite.tsx
@@ -132,9 +132,9 @@ export function OrganizationInvite() {
                                             variant="filled"
                                             input={<FilledInput />}
                                         >
-                                            {Object.keys(roleNames).map((role) => (
-                                                <MenuItem key={role} value={role}>
-                                                    {t(roleNames[role])}
+                                            {roleNames.map((role) => (
+                                                <MenuItem key={role.label} value={role.value}>
+                                                    {t(role.label)}
                                                 </MenuItem>
                                             ))}
                                         </Select>

--- a/packages/origin-ui-core/src/components/Organization/OrganizationUsersTable.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationUsersTable.tsx
@@ -156,7 +156,7 @@ export function OrganizationUsersTable() {
             lastName: user.lastName,
             email: user.email,
             role: getRolesFromRights(user.rights)
-                .map((roleValue) => t(roleNames[roleValue]))
+                .map((role) => t(roleNames.filter((roleName) => roleName.value === role)[0].label))
                 .join(', ')
         };
     });

--- a/packages/origin-ui-core/src/components/devices/AutoSupplyDeviceTable.tsx
+++ b/packages/origin-ui-core/src/components/devices/AutoSupplyDeviceTable.tsx
@@ -1,30 +1,21 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { IDevice } from '@energyweb/origin-backend-core';
-import {
-    Button,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogTitle,
-    MenuItem,
-    TextField
-} from '@material-ui/core';
-import { Edit } from '@material-ui/icons';
-import { text } from '@storybook/addon-knobs';
-import { BigNumber } from 'ethers';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { BigNumber } from 'ethers';
+import { Edit } from '@material-ui/icons';
+import { text } from '@storybook/addon-knobs';
+import { IDevice } from '@energyweb/origin-backend-core';
 import { getBackendClient } from '../../features/general/selectors';
 import { getUserOffchain } from '../../features/users/selectors';
 import { BackendClient, formatCurrencyComplete, moment, useTranslation } from '../../utils';
 import { EnergyFormatter } from '../../utils/EnergyFormatter';
-import { NotificationType, showNotification } from '../../utils/notifications';
 import {
     IPaginatedLoaderHooksFetchDataParameters,
     TableMaterial,
     usePaginatedLoaderFiltered
 } from '../Table';
 import { CustomFilterInputType, ICustomFilterDefinition } from '../Table/FiltersHeader';
+import { UpdateSupplyModal } from '../Modal/UpdateSupplyModal';
 
 interface IRecord {
     device: IDevice;
@@ -36,7 +27,8 @@ export const KeyStatus = {
 };
 
 export function AutoSupplyDeviceTable() {
-    const { deviceClient }: BackendClient = useSelector(getBackendClient);
+    const backendClient: BackendClient = useSelector(getBackendClient);
+    const deviceClient = backendClient?.deviceClient;
     const userOffchain = useSelector(getUserOffchain);
     const { t } = useTranslation();
 
@@ -156,24 +148,6 @@ export function AutoSupplyDeviceTable() {
         }
     ];
 
-    function hideModal() {
-        setShowModal(false);
-    }
-
-    async function reqAutoSupply() {
-        try {
-            await deviceClient.updateDeviceSettings(entity.id.toString(), {
-                automaticPostForSale: entity.automaticPostForSale,
-                defaultAskPrice: entity.defaultAskPrice * 100
-            });
-            hideModal();
-            loadPage(1);
-            showNotification('Supply updated.', NotificationType.Success);
-        } catch (error) {
-            showNotification('Error to update Supply', NotificationType.Error);
-        }
-    }
-
     return (
         <>
             <TableMaterial
@@ -185,65 +159,13 @@ export function AutoSupplyDeviceTable() {
                 actions={actions}
                 filters={filters}
             />
-            <Dialog open={showModal}>
-                <DialogTitle>{'Update Supply'}</DialogTitle>
-                <DialogContent>
-                    <TextField
-                        label={'Type'}
-                        value={entity?.deviceType}
-                        className="mt-4"
-                        disabled={true}
-                        fullWidth
-                    />
-
-                    <TextField
-                        label={'Facility'}
-                        value={entity?.facilityName}
-                        className="mt-4"
-                        disabled={true}
-                        fullWidth
-                    />
-
-                    <TextField
-                        label={'Price'}
-                        value={entity?.defaultAskPrice}
-                        className="mt-4"
-                        type="number"
-                        onChange={(e) =>
-                            setEntity({
-                                ...entity,
-                                defaultAskPrice: Number(e.target.value)
-                            })
-                        }
-                        fullWidth
-                    />
-
-                    <TextField
-                        label={'Status'}
-                        value={entity?.automaticPostForSale ? KeyStatus[1] : KeyStatus[2]}
-                        className="mt-4"
-                        fullWidth
-                        onChange={(e) =>
-                            setEntity({
-                                ...entity,
-                                automaticPostForSale: e.target.value !== 'Paused'
-                            })
-                        }
-                        select
-                    >
-                        <MenuItem value={'Active'}>Active</MenuItem>
-                        <MenuItem value={'Paused'}>Paused</MenuItem>
-                    </TextField>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={hideModal} color="secondary">
-                        {'cancel'}
-                    </Button>
-                    <Button onClick={reqAutoSupply} color="primary">
-                        {'update'}
-                    </Button>
-                </DialogActions>
-            </Dialog>
+            <UpdateSupplyModal
+                showModal={showModal}
+                setShowModal={setShowModal}
+                entity={entity}
+                setEntity={setEntity}
+                loadPage={loadPage}
+            />
         </>
     );
 }

--- a/packages/origin-ui-core/src/features/users/sagas.ts
+++ b/packages/origin-ui-core/src/features/users/sagas.ts
@@ -229,10 +229,12 @@ function* updateBlockchainAddress(): SagaIterator {
             yield call(callback);
         } catch (error) {
             if (error?.data?.message) {
-                showNotification(error?.data?.message, NotificationType.Error);
+                showNotification(error.data.message, NotificationType.Error);
+            } else if (error?.response) {
+                showNotification(error.response.data.message, NotificationType.Error);
             } else if (error?.message) {
-                console.log(error);
-                showNotification(error?.message, NotificationType.Error);
+                console.log('here it is', error.response.data.message);
+                showNotification(error.message, NotificationType.Error);
             } else {
                 console.warn('Could not log in.', error);
                 showNotification(i18n.t('general.feedback.unknownError'), NotificationType.Error);

--- a/packages/origin-ui-core/src/features/users/sagas.ts
+++ b/packages/origin-ui-core/src/features/users/sagas.ts
@@ -233,7 +233,6 @@ function* updateBlockchainAddress(): SagaIterator {
             } else if (error?.response) {
                 showNotification(error.response.data.message, NotificationType.Error);
             } else if (error?.message) {
-                console.log('here it is', error.response.data.message);
                 showNotification(error.message, NotificationType.Error);
             } else {
                 console.warn('Could not log in.', error);


### PR DESCRIPTION
In this PR: 
- FIXED:
After selecting a device type during device registration and then removing the selection, the only device type that the user can select is hydro. All other device types cannot be selected anymore. Only after refreshing, can the user choose all device types again. 
- FIXED:
After login User can leave the `PendingInvitationsModal` by clicking on empty space on the page. He should be allowed to leave this modal window only after choosing 1 of the options: Maybe Later, Decline, Accept
- ADDED: 
Warning notification if the User tries to connect the blockchain address which is currently in use by the other User.
- IMPROVED:
Created a separate component for `UpdateSupplyModal`, which previously was a part of `AutoSupplyDeviceTable`.
- FIXED: 
When clicking register on the login page, the link leads to the settings page, not the register user page.
When clicking “connect blockchain address” after the onboarding flow, it leads to the settings page, not the user profile page.
- FIXED:
When selecting the user role in Organization Invitation it would send a string instead of number and it made impossible to create an invite for user. 