### PR TITLE
chore(origin-backend): don't require grid operator on DTO level

### DIFF
--- a/packages/origin-backend/src/pods/device/dto/create-device.dto.ts
+++ b/packages/origin-backend/src/pods/device/dto/create-device.dto.ts
@@ -101,7 +101,6 @@ export class CreateDeviceDTO implements DeviceCreateData {
 
     @ApiProperty({ type: String })
     @IsString()
-    @IsNotEmpty()
     gridOperator: string;
 
     @ApiProperty({ type: [SmartMeterReadDTO], required: false })


### PR DESCRIPTION
Device group creation fails because we require a grid operator to be set.

Should be merged before https://github.com/energywebfoundation/origin/pull/1763.