### PR TITLE
fix(exchange-ui-core): fix cancelling orders from the UI

### DIFF
--- a/packages/exchange-ui-core/src/features/orders/sagas.ts
+++ b/packages/exchange-ui-core/src/features/orders/sagas.ts
@@ -84,11 +84,14 @@ function* createBid(): SagaIterator {
 
 function* cancelOrder(): SagaIterator {
     while (true) {
-        const { payload } = yield take(OrdersActionsType.CANCEL_ORDER);
+        const {
+            payload: { id: orderId }
+        } = yield take(OrdersActionsType.CANCEL_ORDER);
+
         const { ordersClient }: ExchangeClient = yield select(getExchangeClient);
         const i18n = getI18n();
         try {
-            yield apply(ordersClient, ordersClient.cancelOrder, [payload]);
+            yield apply(ordersClient, ordersClient.cancelOrder, [orderId]);
             yield put(reloadCertificates());
             showNotification(i18n.t('order.feedback.orderCanceled'), NotificationType.Success);
             yield put(fetchOrders());


### PR DESCRIPTION
Fix an issue where the UI would send the whole `Order` object in a POST request instead of the just Order ID when cancelling orders.
This would cause the order cancellation to fail.

Should be merged before https://github.com/energywebfoundation/origin/pull/1763.