### PR TITLE
fix/multiselect and demand summary

### DIFF
--- a/packages/exchange-ui-core/src/utils/exchange/math.ts
+++ b/packages/exchange-ui-core/src/utils/exchange/math.ts
@@ -28,7 +28,7 @@ export async function calculateTotalVolume(
             ).toString(),
             periodTimeFrame: period,
             start: start.toISOString(),
-            end: start.toISOString(),
+            end: end.toISOString(),
             product: {},
             boundToGenerationTime: false,
             excludeEnd: false

--- a/packages/origin-ui-core/src/components/Modal/ChangeRoleModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/ChangeRoleModal.tsx
@@ -84,9 +84,9 @@ export function ChangeRoleModal(props: IProps) {
                         variant="filled"
                         input={<FilledInput />}
                     >
-                        {Object.keys(roleNames).map((role) => (
-                            <MenuItem key={role} value={role}>
-                                {t(roleNames[role])}
+                        {roleNames.map((role) => (
+                            <MenuItem key={role.label} value={role.value}>
+                                {t(role.label)}
                             </MenuItem>
                         ))}
                     </Select>

--- a/packages/origin-ui-core/src/components/Modal/PendingInvitationsModal.tsx
+++ b/packages/origin-ui-core/src/components/Modal/PendingInvitationsModal.tsx
@@ -181,7 +181,10 @@ export const PendingInvitationsModal = (props: IProps) => {
                                     i18nKey="organization.invitations.dialog.invitationMessage"
                                     values={{
                                         admin,
-                                        role: t(roleNames[role]),
+                                        role: t(
+                                            roleNames.filter((roleObj) => roleObj.value === role)[0]
+                                                ?.label
+                                        ),
                                         orgName: name
                                     }}
                                 />

--- a/packages/origin-ui-core/src/components/MultiSelectAutocomplete.tsx
+++ b/packages/origin-ui-core/src/components/MultiSelectAutocomplete.tsx
@@ -62,7 +62,7 @@ export function MultiSelectAutocomplete(props: IOwnProps) {
         if (selectedValues.length > 0) {
             setRequiredState(false);
         } else {
-            setRequiredState(true);
+            setRequiredState(required);
         }
     }, [selectedValues]);
 


### PR DESCRIPTION
In this PR 
- Custom validation in multiselect is improved 
- Fixed the bug, when the total volume in Repeated Purchase tab will calculate the wrong amount.
- Fixed the bug with wrongly displaying the Organization member roles in modals as [object Object]