### PR TITLE
feat(issuer-api): added validation to "to" address

### DIFF
--- a/packages/issuer-api/src/pods/certification-request/commands/create-certification-request.dto.ts
+++ b/packages/issuer-api/src/pods/certification-request/commands/create-certification-request.dto.ts
@@ -4,6 +4,7 @@ import {
     IsArray,
     IsBoolean,
     IsInt,
+    IsNotEmpty,
     IsPositive,
     IsString,
     Validate,
@@ -13,6 +14,7 @@ import {
 export class CreateCertificationRequestDTO {
     @ApiProperty({ type: String })
     @IsString()
+    @IsNotEmpty()
     to: string;
 
     @ApiProperty({ type: String })


### PR DESCRIPTION
Certification request creation "to" address

Certificate request has weak validation and when you send to: "" then it passes but mints to a caller instead of the user account. Since we want to support different send destination types like strings, eth addresses, etc, we should not add @IsEthereumAddress to the validation.

Instead, we should add an @IsNotEmpty() check to the to field in CreateCertificationRequestDTO .

In the CreateCertificationRequestHandler we should then check if this string is an Ethereum address before proceeding with the creation.