### PR TITLE
chore(exchange-ui-core): show all bids and asks by default

### DIFF
--- a/packages/exchange-ui-core/src/containers/Exchange.tsx
+++ b/packages/exchange-ui-core/src/containers/Exchange.tsx
@@ -52,12 +52,12 @@ export function Exchange() {
     const [generationDateEnd, setGenerationDateEnd] = useState<string>();
 
     const orderbookFilter: ProductFilterDTO = {
-        deviceTypeFilter: deviceType.length > 0 ? Filter.Specific : Filter.Unspecified,
-        locationFilter: location.length > 0 ? Filter.Specific : Filter.Unspecified,
-        gridOperatorFilter: gridOperator.length > 0 ? Filter.Specific : Filter.Unspecified,
+        deviceTypeFilter: deviceType.length > 0 ? Filter.Specific : Filter.All,
+        locationFilter: location.length > 0 ? Filter.Specific : Filter.All,
+        gridOperatorFilter: gridOperator.length > 0 ? Filter.Specific : Filter.All,
         generationTimeFilter:
-            generationDateStart && generationDateEnd ? Filter.Specific : Filter.Unspecified,
-        deviceVintageFilter: Filter.Unspecified,
+            generationDateStart && generationDateEnd ? Filter.Specific : Filter.All,
+        deviceVintageFilter: Filter.All,
         deviceType: deviceType.length > 0 ? deviceType : undefined,
         location: location.length > 0 ? location : undefined,
         gridOperator: gridOperator.length > 0 ? gridOperator : undefined,


### PR DESCRIPTION
Now it shows all active bids and asks in ui when no filters specified
![image](https://user-images.githubusercontent.com/97810/103080728-df40d380-45ef-11eb-971f-5a26ab9f0d58.png)
