### PR TITLE
fix(exchange-core-irec): show bids with no type filter when type filter specified

### DIFF
--- a/packages/exchange-core-irec/src/BidProduct.ts
+++ b/packages/exchange-core-irec/src/BidProduct.ts
@@ -75,7 +75,7 @@ export class BidProduct implements IMatchableProduct<IRECProduct, IRECProductFil
         }
 
         if (!this.product.location?.length) {
-            return false;
+            return true;
         }
 
         return (
@@ -93,7 +93,7 @@ export class BidProduct implements IMatchableProduct<IRECProduct, IRECProductFil
         }
 
         if (!this.product.deviceType?.length) {
-            return false;
+            return true;
         }
 
         return (
@@ -147,7 +147,7 @@ export class BidProduct implements IMatchableProduct<IRECProduct, IRECProductFil
         }
 
         if (!this.product.gridOperator?.length) {
-            return false;
+            return true;
         }
 
         return this.product.gridOperator.some((bidGridOperator) =>


### PR DESCRIPTION
Now bids list display bids without specified type even when market filter has.
@JonathanWfels take a look please. Is it ok?
![1](https://user-images.githubusercontent.com/97810/103634504-975f6c00-4f60-11eb-82ad-071ae597b1f9.gif)
