### PR TITLE
fix(exchange): use order isFilled getter for setting correct status

### DIFF
--- a/packages/exchange/src/pods/trade/trade.service.ts
+++ b/packages/exchange/src/pods/trade/trade.service.ts
@@ -64,11 +64,11 @@ export class TradeService<TProduct, TProductFilter> implements OnModuleInit {
                 const { ask, bid } = trade;
                 await entityManager.update<Order>(Order, ask.id, {
                     currentVolume: ask.volume,
-                    status: ask.volume.isZero() ? OrderStatus.Filled : OrderStatus.PartiallyFilled
+                    status: ask.isFilled ? OrderStatus.Filled : OrderStatus.PartiallyFilled
                 });
                 await entityManager.update<Order>(Order, bid.id, {
                     currentVolume: bid.volume,
-                    status: bid.volume.isZero() ? OrderStatus.Filled : OrderStatus.PartiallyFilled
+                    status: bid.isFilled ? OrderStatus.Filled : OrderStatus.PartiallyFilled
                 });
 
                 const tradeToStore = new TradeEntity({


### PR DESCRIPTION
This PR fixes the issue where `Order.status` stored in the DB was incorrect when using `OneTimeMatchOrder`.