### PR TITLE
fix(origin-ui-core): table date filtering bug

### DIFF
--- a/packages/origin-ui-core/src/components/Table/PaginatedLoaderHooks.tsx
+++ b/packages/origin-ui-core/src/components/Table/PaginatedLoaderHooks.tsx
@@ -282,12 +282,18 @@ export function checkRecordPassesFilters(
                                 }
                                 break;
                             case FilterRules.FROM:
-                                if (recordDate.year() < year || recordDate.month() < month) {
+                                if (
+                                    recordDate.year() < year ||
+                                    (recordDate.year() === year && recordDate.month() < month)
+                                ) {
                                     return false;
                                 }
                                 break;
                             case FilterRules.TO:
-                                if (recordDate.year() > year || recordDate.month() > month) {
+                                if (
+                                    recordDate.year() > year ||
+                                    (recordDate.year() === year && recordDate.month() > month)
+                                ) {
                                     return false;
                                 }
                                 break;


### PR DESCRIPTION
Fixed the issue with Table date filtering.
Steps to reproduce:
**Filtering the Bids Table in My Orders**

1. You bid has 
- Generation Start: May 2020, 
- Generation End: July 2020.
2. You start filtering. 
Generation Start Filter is set: April 2019. 
Everything works fine.
3. Select Generation Start Filter August 2019. 
Your bid disappear, but the actual generation time start of the bid is higher than filter's one.
So expected behavior is that your bid should be displayed. 

*Generation End Time filter is having the same issue. 