### PR TITLE
feat(exchange-ui-core): use set instead of loop in redux

### DIFF
--- a/packages/exchange-ui-core/src/features/orders/actions.ts
+++ b/packages/exchange-ui-core/src/features/orders/actions.ts
@@ -22,8 +22,8 @@ export interface IOrderAction {
     payload?;
 }
 
-export interface IStoreOrderAction extends IOrderAction {
-    payload: Order;
+export interface IStoreOrdersAction extends IOrderAction {
+    payload: Order[];
 }
 
 export interface ICreateBidAction extends IOrderAction {
@@ -34,9 +34,9 @@ export interface ICancelOrderAction extends IOrderAction {
     payload: Order;
 }
 
-export const storeOrder = (order: IStoreOrderAction['payload']): IStoreOrderAction => ({
+export const storeOrders = (orders: IStoreOrdersAction['payload']): IStoreOrdersAction => ({
     type: OrdersActionsType.STORE_ORDERS,
-    payload: order
+    payload: orders
 });
 
 export const createBid = (bid: ICreateBidAction['payload']): ICreateBidAction => ({
@@ -81,7 +81,7 @@ export interface IDirectBuyOrderAction extends IOrderAction {
     payload: IDirectBuyDTO;
 }
 
-export const storeDemand = (demands: Demand[]): IStoreDemandAction => ({
+export const storeDemands = (demands: Demand[]): IStoreDemandAction => ({
     type: OrdersActionsType.STORE_DEMANDS,
     payload: demands
 });

--- a/packages/exchange-ui-core/src/features/orders/reducer.ts
+++ b/packages/exchange-ui-core/src/features/orders/reducer.ts
@@ -17,8 +17,12 @@ export function ordersState<T>(
 ): IOrdersState {
     switch (type) {
         case OrdersActionsType.STORE_ORDERS:
-            const orders = [...state.orders.filter((o) => o.id !== payload.id)];
-            orders.push(payload);
+            const allOrders: Order[] = [...state.orders].concat(payload);
+            const set: Set<string> = new Set();
+            allOrders.map((order) => {
+                set.add(JSON.stringify(order));
+            });
+            const orders: Order[] = Array.from(set).map((order) => JSON.parse(order));
             return {
                 ...state,
                 orders

--- a/packages/exchange-ui-core/src/features/orders/reducer.ts
+++ b/packages/exchange-ui-core/src/features/orders/reducer.ts
@@ -19,7 +19,7 @@ export function ordersState<T>(
         case OrdersActionsType.STORE_ORDERS:
             const allOrders: Order[] = [...state.orders].concat(payload);
             const set: Set<string> = new Set();
-            allOrders.map((order) => {
+            allOrders.forEach((order) => {
                 set.add(JSON.stringify(order));
             });
             const orders: Order[] = Array.from(set).map((order) => JSON.parse(order));

--- a/packages/exchange-ui-core/src/features/orders/sagas.ts
+++ b/packages/exchange-ui-core/src/features/orders/sagas.ts
@@ -13,9 +13,9 @@ import {
 import { getExchangeClient } from '../general/selectors';
 import {
     clearOrders,
-    storeOrder,
+    storeOrders,
     OrdersActionsType,
-    storeDemand,
+    storeDemands,
     clearDemands,
     fetchOrders,
     ICreateDemandAction
@@ -46,9 +46,9 @@ function* fetchOrdersAndDemands(): SagaIterator {
 
         const demands: Demand[] = demandsResponse.data;
 
-        yield put(storeDemand(demands));
+        yield put(storeDemands(demands));
         if (orders.length > 0) {
-            for (const order of orders) {
+            const ordersWithFilledInfo = orders.map((order) => {
                 const { startVolume, currentVolume } = order;
                 const filled =
                     BigNumber.from(startVolume)
@@ -56,8 +56,10 @@ function* fetchOrdersAndDemands(): SagaIterator {
                         .mul(100)
                         .div(startVolume)
                         .toNumber() / 100;
-                yield put(storeOrder({ ...order, filled }));
-            }
+                return { ...order, filled };
+            });
+
+            yield put(storeOrders(ordersWithFilledInfo));
         }
     }
 }


### PR DESCRIPTION
Used Set for filtering out duplicate orders. 
Now Orders added to Redux state as an array instead of firing an event on each order one by one. 
This adjustment was made due to poor performance of the previous order store strategy.