### PR TITLE
fix(exchange-io-erc1888): deposit watcher amount to string

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "test:utils-general": "lerna run test --scope @energyweb/utils-general --stream",
         "test:ci:contracts": "lerna run --scope @energyweb/issuer --scope @energyweb/utils-general test:concurrent --since master --parallel --stream",
         "test:ci:apps": "lerna run --scope @energyweb/exchange --scope @energyweb/origin-backend test:concurrent --since master --parallel --stream",
-        "test:ci:e2e": "lerna run test:e2e --stream --ignore @energyweb/exchange-* && lerna run test:e2e --stream --scope @energyweb/exchange-irec",
+        "test:ci:e2e": "lerna run test:e2e --stream --ignore @energyweb/exchange-irec && lerna run test:e2e --stream --scope @energyweb/exchange-irec",
         "publish:canary": "lerna publish --yes --skip-git --exact --cd-version=prerelease --pre-dist-tag canary --preid=alpha.$TRAVIS_BUILD_NUMBER",
         "publish:release": "lerna version --create-release github --conventional-commits --exact --yes --message \"chore(release): publish /skip-deploy\" && lerna publish from-git --yes",
         "build:containers:canary": "lerna run build:container:canary --stream",

--- a/packages/exchange-io-erc1888/src/deposit-watcher/deposit-watcher.service.ts
+++ b/packages/exchange-io-erc1888/src/deposit-watcher/deposit-watcher.service.ts
@@ -92,6 +92,12 @@ export class DepositWatcherService implements OnModuleInit {
 
         const { _from: from, _to: to, _value: value, _id: id } = log;
 
+        if (!value || !from || !to) {
+            this.logger.error(`Received an incorrect even: ${JSON.stringify(event)}`);
+
+            return;
+        }
+
         if (to !== this.walletAddress) {
             this.logger.debug(
                 `This transfer is to other address ${to} than wallet address ${this.walletAddress}`

--- a/packages/exchange-io-erc1888/src/deposit-watcher/deposit-watcher.service.ts
+++ b/packages/exchange-io-erc1888/src/deposit-watcher/deposit-watcher.service.ts
@@ -93,7 +93,7 @@ export class DepositWatcherService implements OnModuleInit {
         const { _from: from, _to: to, _value: value, _id: id } = log;
 
         if (!value || !from || !to) {
-            this.logger.error(`Received an incorrect even: ${JSON.stringify(event)}`);
+            this.logger.error(`Received an incorrect event: ${JSON.stringify(event)}`);
 
             return;
         }

--- a/packages/exchange-io-erc1888/src/deposit-watcher/deposit-watcher.service.ts
+++ b/packages/exchange-io-erc1888/src/deposit-watcher/deposit-watcher.service.ts
@@ -107,8 +107,8 @@ export class DepositWatcherService implements OnModuleInit {
 
         const deposit: CreateDepositDTO = {
             transactionHash,
-            address: from as string,
-            amount: value as string,
+            address: from,
+            amount: value.toString(),
             blockNumber: receipt.blockNumber,
             asset: {
                 address: this.registryAddress,

--- a/packages/exchange-io-erc1888/test/deposits-auto-post-for-sale.e2e-spec.ts
+++ b/packages/exchange-io-erc1888/test/deposits-auto-post-for-sale.e2e-spec.ts
@@ -13,6 +13,7 @@ import {
     IProductInfo,
     testUtils
 } from '@energyweb/exchange';
+import { getProviderWithFallback } from '@energyweb/utils-general';
 import { ExchangeErc1888Module } from '../src';
 
 const web3 = 'http://localhost:8590';
@@ -22,7 +23,6 @@ const {
     createDepositAddress,
     depositToken,
     issueToken,
-    provider,
     bootstrapTestInstance
 } = testUtils;
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -76,7 +76,7 @@ describe('Deposits automatic posting for sale', () => {
 
     const tokenReceiverPrivateKey =
         '0xca77c9b06fde68bcbcc09f603c958620613f4be79f3abb4b2032131d0229462e';
-    const tokenReceiver = new ethers.Wallet(tokenReceiverPrivateKey, provider);
+    const tokenReceiver = new ethers.Wallet(tokenReceiverPrivateKey, getProviderWithFallback(web3));
 
     const generationFrom = moment('2020-01-01').unix();
     const generationTo = moment('2020-01-31').unix();

--- a/packages/exchange-io-erc1888/test/deposits-withdrawals.e2e-spec.ts
+++ b/packages/exchange-io-erc1888/test/deposits-withdrawals.e2e-spec.ts
@@ -18,6 +18,7 @@ import {
     testUtils
 } from '@energyweb/exchange';
 import { TestProduct } from '@energyweb/exchange/test/product/get-product.handler';
+import { getProviderWithFallback } from '@energyweb/utils-general';
 import { ExchangeErc1888Module } from '../src';
 
 const web3 = 'http://localhost:8590';
@@ -27,7 +28,6 @@ const {
     createDepositAddress,
     depositToken,
     issueToken,
-    provider,
     bootstrapTestInstance,
     MWh
 } = testUtils;
@@ -50,7 +50,7 @@ describe('Deposits using deployed registry', () => {
 
     const tokenReceiverPrivateKey =
         '0xca77c9b06fde68bcbcc09f603c958620613f4be79f3abb4b2032131d0229462e';
-    const tokenReceiver = new ethers.Wallet(tokenReceiverPrivateKey, provider);
+    const tokenReceiver = new ethers.Wallet(tokenReceiverPrivateKey, getProviderWithFallback(web3));
 
     const generationFrom = moment('2020-01-01').unix();
     const generationTo = moment('2020-01-31').unix();

--- a/packages/exchange/src/app.module.ts
+++ b/packages/exchange/src/app.module.ts
@@ -11,6 +11,7 @@ import { BundleAccountingModule, BundleModule } from './pods/bundle';
 import { DemandModule } from './pods/demand/demand.module';
 import { MatchingEngineModule } from './pods/matching-engine/matching-engine.module';
 import { OrderAccountingModule, OrderModule } from './pods/order';
+import { PostForSaleModule } from './pods/post-for-sale/post-for-sale.module';
 import { TradeModule, TradeAccountingModule } from './pods/trade';
 import { TransferAccountingModule, TransferModule } from './pods/transfer';
 
@@ -31,7 +32,8 @@ import { TransferAccountingModule, TransferModule } from './pods/transfer';
         BundleModule,
         BundleAccountingModule,
         OrderModule,
-        OrderAccountingModule
+        OrderAccountingModule,
+        PostForSaleModule
     ],
     providers: [IntUnitsOfEnergy]
 })

--- a/packages/exchange/test/utils.ts
+++ b/packages/exchange/test/utils.ts
@@ -1,12 +1,9 @@
 import { Contracts } from '@energyweb/issuer';
-import { getProviderWithFallback } from '@energyweb/utils-general';
 import { Contract, ContractTransaction, ethers } from 'ethers';
 import polly from 'polly-js';
 import { AccountService } from '../src/pods/account/account.service';
 
 const registryInterface = new ethers.utils.Interface(Contracts.IssuerJSON.abi);
-
-const web3 = 'http://localhost:8580';
 
 export const issueToken = async (
     issuer: Contract,
@@ -54,14 +51,15 @@ export const depositToken = async (
 ) => {
     const registryWithUserAsSigner = registry.connect(sender);
 
-    await registryWithUserAsSigner.safeTransferFrom(sender.address, to, id, amount, '0x00');
+    return registryWithUserAsSigner.safeTransferFrom(sender.address, to, id, amount, '0x00');
 };
-
-export const provider = getProviderWithFallback(web3);
 
 export const MWh = 10 ** 6;
 
-export const createDepositAddress = async (accountService: AccountService, userId: string) => {
+export const createDepositAddress = async (
+    accountService: AccountService,
+    userId: string
+): Promise<string> => {
     const account = await accountService.getAccount(userId);
 
     if (account) {


### PR DESCRIPTION
Fixes an error when depositing.

```
[TransferService] invalid input syntax for type bigint: "{"type":"BigNumber","hex":"0x3b9aca00"}" +12ms
```

Additionally:
- Enables `exchange-io-erc1888` tests
- Fixes an error where `post-for-sale` module was not even imported into the main app