### PR TITLE
chore: distinguish between device services

### DIFF
--- a/packages/origin-backend-app/src/integration/external-device.service.ts
+++ b/packages/origin-backend-app/src/integration/external-device.service.ts
@@ -1,12 +1,12 @@
 import { IDeviceSettings, IExternalDeviceService, IProductInfo } from '@energyweb/exchange';
-import { DeviceService } from '@energyweb/origin-backend';
+import { IDeviceService } from '@energyweb/origin-backend';
 import { IExternalDeviceId } from '@energyweb/origin-backend-core';
 import { Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 
 @Injectable()
 export class ExternalDeviceService implements IExternalDeviceService {
-    private _deviceService: DeviceService;
+    private _deviceService: IDeviceService;
 
     constructor(private readonly moduleRef: ModuleRef) {}
 
@@ -15,7 +15,7 @@ export class ExternalDeviceService implements IExternalDeviceService {
             return this._deviceService;
         }
 
-        this._deviceService = this.moduleRef.get<DeviceService>(DeviceService, {
+        this._deviceService = this.moduleRef.get<IDeviceService>(IDeviceService, {
             strict: false
         });
 

--- a/packages/origin-backend-app/src/notification/handlers/certificate-request-approved.handler.ts
+++ b/packages/origin-backend-app/src/notification/handlers/certificate-request-approved.handler.ts
@@ -1,7 +1,7 @@
 import { EventsHandler, IEventHandler, QueryBus } from '@nestjs/cqrs';
 import { Logger } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
-import { DeviceService, UserService } from '@energyweb/origin-backend';
+import { UserService, IDeviceService } from '@energyweb/origin-backend';
 import { Role } from '@energyweb/origin-backend-core';
 import {
     CertificateRequestApprovedEvent,
@@ -18,7 +18,7 @@ export class CertificateRequestApprovedHandler
 
     private readonly issuerTypeId: string;
 
-    private _deviceService: DeviceService;
+    private _deviceService: IDeviceService;
 
     constructor(
         private readonly mailService: MailService,
@@ -36,7 +36,7 @@ export class CertificateRequestApprovedHandler
             return this._deviceService;
         }
 
-        this._deviceService = this.moduleRef.get<DeviceService>(DeviceService, {
+        this._deviceService = this.moduleRef.get<IDeviceService>(IDeviceService, {
             strict: false
         });
 

--- a/packages/origin-backend/src/index.ts
+++ b/packages/origin-backend/src/index.ts
@@ -29,6 +29,7 @@ export * from './pods/email-confirmation/events';
 export * from './pods/invitation/events';
 export * from './pods/device/events';
 export * from './pods/user';
+export * from './pods/device/device.service';
 
 export const entities = [
     Device,

--- a/packages/origin-backend/src/pods/device/device.module.ts
+++ b/packages/origin-backend/src/pods/device/device.module.ts
@@ -7,7 +7,12 @@ import { SM_READS_ADAPTER } from '../../const';
 import { ConfigurationModule } from '../configuration';
 import { DeviceController } from './device.controller';
 import { Device } from './device.entity';
-import { DeviceService } from './device.service';
+import { DeviceService, IDeviceService } from './device.service';
+
+const deviceService = {
+    provide: IDeviceService,
+    useClass: DeviceService
+};
 
 @Module({})
 export class DeviceModule {
@@ -20,10 +25,11 @@ export class DeviceModule {
                     provide: SM_READS_ADAPTER,
                     useValue: smartMeterReadingsAdapter
                 },
-                DeviceService
+                DeviceService,
+                deviceService
             ],
             controllers: [DeviceController],
-            exports: [DeviceService]
+            exports: [DeviceService, deviceService]
         };
     }
 }

--- a/packages/origin-backend/src/pods/device/device.service.ts
+++ b/packages/origin-backend/src/pods/device/device.service.ts
@@ -35,8 +35,15 @@ import { Device } from './device.entity';
 import { DeviceStatusChangedEvent } from './events';
 import { DeviceCreatedEvent } from './events/device-created.event';
 
+export const IDeviceService = Symbol('IDeviceService');
+export interface IDeviceService {
+    create(data: DeviceCreateData, loggedUser: ILoggedInUser): Promise<IDevice>;
+    findByExternalId(externalId: IExternalDeviceId): Promise<IDevice>;
+    findDeviceProductInfo(externalId: IExternalDeviceId): Promise<IDeviceProductInfo>;
+}
+
 @Injectable()
-export class DeviceService {
+export class DeviceService implements IDeviceService {
     constructor(
         @InjectRepository(Device)
         private readonly repository: Repository<Device>,

--- a/packages/origin-backend/test/device.e2e-spec.ts
+++ b/packages/origin-backend/test/device.e2e-spec.ts
@@ -17,7 +17,7 @@ import dotenv from 'dotenv';
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { DatabaseService } from '@energyweb/origin-backend-utils';
 import { bootstrapTestInstance, registerAndLogin } from './origin-backend';
-import { DeviceService } from '../src/pods/device/device.service';
+import { IDeviceService } from '../src/pods/device/device.service';
 import { OrganizationService } from '../src/pods/organization/organization.service';
 import { UserService } from '../src/pods/user/user.service';
 
@@ -27,7 +27,7 @@ describe('Device e2e tests', () => {
     });
 
     let app: INestApplication;
-    let deviceService: DeviceService;
+    let deviceService: IDeviceService;
     let organizationService: OrganizationService;
     let userService: UserService;
     let databaseService: DatabaseService;

--- a/packages/origin-device-registry-irec-local-api/src/device/device.module.ts
+++ b/packages/origin-device-registry-irec-local-api/src/device/device.module.ts
@@ -4,13 +4,18 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { DeviceController } from './device.controller';
 import { Device } from './device.entity';
-import { DeviceService } from './device.service';
+import { DeviceService, IDeviceServiceIREC } from './device.service';
 import { ValidateDeviceOwnershipCommandHandler } from './handlers/validate-device-ownership.handler';
+
+const deviceService = {
+    provide: IDeviceServiceIREC,
+    useClass: DeviceService
+};
 
 @Module({
     imports: [TypeOrmModule.forFeature([Device]), CqrsModule],
-    providers: [DeviceService, ValidateDeviceOwnershipCommandHandler],
-    exports: [DeviceService],
+    providers: [DeviceService, deviceService, ValidateDeviceOwnershipCommandHandler],
+    exports: [DeviceService, deviceService],
     controllers: [DeviceController]
 })
 export class DeviceModule {}

--- a/packages/origin-device-registry-irec-local-api/src/device/device.service.ts
+++ b/packages/origin-device-registry-irec-local-api/src/device/device.service.ts
@@ -8,8 +8,16 @@ import { Device } from './device.entity';
 import { CreateDeviceDTO } from './dto/create-device.dto';
 import { DeviceStatusChangedEvent, DeviceCreatedEvent } from './events';
 
+export const IDeviceServiceIREC = Symbol('IDeviceServiceIREC');
+export interface IDeviceServiceIREC {
+    findOne(id: string): Promise<Device>;
+    create(user: ILoggedInUser, newDevice: CreateDeviceDTO): Promise<Device>;
+    findAll(options?: FindManyOptions<Device>): Promise<Device[]>;
+    updateStatus(id: string, status: DeviceStatus): Promise<Device>;
+}
+
 @Injectable()
-export class DeviceService {
+export class DeviceService implements IDeviceServiceIREC {
     constructor(
         @InjectRepository(Device)
         private readonly repository: Repository<Device>,


### PR DESCRIPTION
We have a DeviceService defined in both `@energyweb/origin-backend` and `@energyweb/origin-device-registry-irec-local-api-client`

Getting `DeviceService` from NestJS's moduleRef would sometimes returns the incorrect DeviceService due to a naming collision.

Solution:
- Distinguish the two existing `DeviceService` using interfaces and symbols