### PR TITLE
feat: feature flags to env

### DIFF
--- a/packages/apps/origin-ui/src/components/OriginConfigurationContext.tsx
+++ b/packages/apps/origin-ui/src/components/OriginConfigurationContext.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import React, { createContext, ReactNode } from 'react';
+import React, { createContext, ReactNode, useState, SetStateAction, Dispatch } from 'react';
 import { initReactI18next } from 'react-i18next';
 import i18n from 'i18next';
 import ICU from 'i18next-icu';
@@ -250,6 +250,7 @@ export interface IOriginConfiguration {
     defaultLanguage: ORIGIN_LANGUAGE;
     language: ORIGIN_LANGUAGE;
     enabledFeatures: OriginFeature[];
+    changeContext: Dispatch<SetStateAction<IOriginConfiguration>>;
 }
 
 export function createStyleConfigFromSCSSVariables(scssVariables: any): IOriginStyleConfig {
@@ -286,7 +287,7 @@ export function setOriginLanguage(language: ORIGIN_LANGUAGE) {
     location.reload();
 }
 
-export function createOriginConfiguration(configuration: Partial<IOriginConfiguration> = {}) {
+export function useConfigurationCreation(configuration: Partial<IOriginConfiguration> = {}) {
     const DEFAULT_STYLE_CONFIG = createStyleConfigFromSCSSVariables(variables);
 
     const storedLanguage = getOriginLanguage();
@@ -306,7 +307,8 @@ export function createOriginConfiguration(configuration: Partial<IOriginConfigur
                 OriginFeature.IRecUIApp,
                 OriginFeature.CertificatesImport
             ].includes(feature);
-        })
+        }),
+        changeContext: null
     };
 
     const newConfiguration: IOriginConfiguration = {
@@ -346,8 +348,10 @@ interface IProps {
 }
 
 export function OriginConfigurationProvider(props: IProps) {
+    const [context, setContext] = useState<IOriginConfiguration>(props.value);
+    const value = { ...context, changeContext: setContext };
     return (
-        <OriginConfigurationContext.Provider value={props.value}>
+        <OriginConfigurationContext.Provider value={value}>
             {props.children}
         </OriginConfigurationContext.Provider>
     );

--- a/packages/apps/origin-ui/src/index.tsx
+++ b/packages/apps/origin-ui/src/index.tsx
@@ -4,10 +4,10 @@ import './styles/app.scss';
 import { Origin } from './components/Origin';
 import {
     OriginConfigurationProvider,
-    createOriginConfiguration
+    useConfigurationCreation
 } from './components/OriginConfigurationContext';
 
-const originConfiguration = createOriginConfiguration();
+const originConfiguration = useConfigurationCreation();
 
 render(
     <OriginConfigurationProvider value={originConfiguration}>

--- a/packages/ui/origin-ui-core/src/features/general/actions.ts
+++ b/packages/ui/origin-ui-core/src/features/general/actions.ts
@@ -30,6 +30,7 @@ export interface IEnvironment {
     EXCHANGE_WALLET_PUB: string;
     GOOGLE_MAPS_API_KEY: string;
     MARKET_UTC_OFFSET: number;
+    DISABLED_UI_FEATURES: string;
 }
 
 export interface ISetLoadingAction {


### PR DESCRIPTION
This PR provides a new way to change disabled UI features. 
By default there is a predefined list of disabled features in `OriginConfigurationContext` as it was previously.
But now disabled UI features are also a part of .env file.
We are getting them via request alongside with other Environment properties required for UI.
So on environment initialization - we check if the received from response features are different than the predefined ones, and if they differ - update the Context and change displayed UI features.