### PR TITLE
fix: Approved certification request marked as unapproved

### DIFF
--- a/packages/traceability/issuer-api/src/pods/certification-request/handlers/approve-certification-request.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certification-request/handlers/approve-certification-request.handler.ts
@@ -58,15 +58,22 @@ export class ApproveCertificationRequestHandler
 
         let newCertificateId;
 
-        try {
-            newCertificateId = await certReq.approve(BigNumber.from(isPrivate ? 0 : energy));
-        } catch (e) {
-            return ResponseFailure(e.message, HttpStatus.INTERNAL_SERVER_ERROR);
+        if (certReq.approved) {
+            this.logger.warn(
+                `Certification Request ${certReq.id} is unapproved but should be set to approved. Fixing...`
+            );
+            newCertificateId = certReq.issuedCertificateTokenId;
+        } else {
+            try {
+                newCertificateId = await certReq.approve(BigNumber.from(isPrivate ? 0 : energy));
+            } catch (e) {
+                return ResponseFailure(e.message, HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         await this.repository.update(id, {
             approved: true,
-            approvedDate: new Date(),
+            approvedDate: certReq.approvedDate ?? new Date(),
             issuedCertificateTokenId: newCertificateId
         });
 

--- a/packages/traceability/issuer/src/blockchain-facade/CertificationRequest.ts
+++ b/packages/traceability/issuer/src/blockchain-facade/CertificationRequest.ts
@@ -18,6 +18,7 @@ export interface ICertificationRequestBlockchain {
     revoked: boolean;
     approvedDate?: Date;
     revokedDate?: Date;
+    issuedCertificateTokenId?: number;
 }
 
 export class CertificationRequest implements ICertificationRequestBlockchain {
@@ -38,6 +39,8 @@ export class CertificationRequest implements ICertificationRequestBlockchain {
     public revokedDate: Date;
 
     public created: Timestamp;
+
+    public issuedCertificateTokenId: number;
 
     public initialized = false;
 
@@ -112,6 +115,13 @@ export class CertificationRequest implements ICertificationRequestBlockchain {
             issuer.filters.CertificationRequested(null, this.id, null)
         );
 
+        const certificationApprovedLogs = await getEventsFromContract(
+            issuer,
+            issuer.filters.CertificationRequestApproved(null, this.id, null)
+        );
+
+        this.issuedCertificateTokenId = certificationApprovedLogs[0]?._certificateId ?? null;
+
         const creationBlock = await issuer.provider.getBlock(
             certificationRequestedLogs[0].blockNumber
         );
@@ -123,7 +133,7 @@ export class CertificationRequest implements ICertificationRequestBlockchain {
         return this;
     }
 
-    async approve(energy: BigNumber): Promise<number> {
+    async approve(energy: BigNumber): Promise<CertificationRequest['issuedCertificateTokenId']> {
         const { issuer, activeUser } = this.blockchainProperties;
 
         const validityData = issuer.interface.encodeFunctionData('isRequestValid', [
@@ -144,6 +154,8 @@ export class CertificationRequest implements ICertificationRequestBlockchain {
             events.find((log: BlockchainEvent) => log.event === 'CertificationRequestApproved')
                 .topics[3]
         );
+
+        this.issuedCertificateTokenId = certificateId;
 
         return certificateId;
     }

--- a/packages/traceability/issuer/src/test/Issuer.test.ts
+++ b/packages/traceability/issuer/src/test/Issuer.test.ts
@@ -114,6 +114,7 @@ describe('Issuer', () => {
         certificationRequest = await certificationRequest.sync();
 
         assert.isTrue(certificationRequest.approved);
+        assert.exists(certificationRequest.issuedCertificateTokenId);
 
         const deviceOwnerBalance = await blockchainProperties.registry.balanceOf(
             deviceOwnerWallet.address,


### PR DESCRIPTION
We've encountered a case where a certification request in our database is marked as **unapproved**, while its blockchain representation (source of truth) is **approved**.

Added handlers to autocorrect these kinds of cases.