### PR TITLE
fix(issuer-api): Allow users with no blockchain address to use Issuer API

### DIFF
--- a/packages/traceability/issuer-api/src/pods/certificate/certificate.controller.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/certificate.controller.ts
@@ -51,7 +51,7 @@ export class CertificateController {
     constructor(private readonly commandBus: CommandBus, private readonly queryBus: QueryBus) {}
 
     @Get('/:id')
-    @UseGuards(AuthGuard(), ActiveUserGuard, BlockchainAccountGuard)
+    @UseGuards(AuthGuard(), ActiveUserGuard)
     @ApiResponse({
         status: HttpStatus.OK,
         type: CertificateDTO,
@@ -65,7 +65,7 @@ export class CertificateController {
     }
 
     @Get('/token-id/:tokenId')
-    @UseGuards(AuthGuard(), ActiveUserGuard, BlockchainAccountGuard)
+    @UseGuards(AuthGuard(), ActiveUserGuard)
     @ApiResponse({
         status: HttpStatus.OK,
         type: CertificateDTO,
@@ -79,7 +79,7 @@ export class CertificateController {
     }
 
     @Get()
-    @UseGuards(AuthGuard(), ActiveUserGuard, BlockchainAccountGuard)
+    @UseGuards(AuthGuard(), ActiveUserGuard)
     @ApiResponse({
         status: HttpStatus.OK,
         type: [CertificateDTO],
@@ -199,7 +199,7 @@ export class CertificateController {
     }
 
     @Get('/:id/events')
-    @UseGuards(AuthGuard(), ActiveUserGuard, BlockchainAccountGuard)
+    @UseGuards(AuthGuard(), ActiveUserGuard)
     @ApiResponse({
         status: HttpStatus.OK,
         type: [CertificateEvent],

--- a/packages/traceability/issuer-api/src/pods/certificate/certificate.dto.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/certificate.dto.ts
@@ -1,4 +1,4 @@
-import { IClaim, IOwnershipCommitmentProof } from '@energyweb/issuer';
+import { IClaim } from '@energyweb/issuer';
 import { ApiProperty } from '@nestjs/swagger';
 import {
     IsArray,
@@ -66,10 +66,6 @@ export class CertificateDTO {
     @ApiProperty({ type: String, required: false })
     @ValidateIf((dto: CertificateDTO) => !!dto.creationBlockHash)
     creationBlockHash?: string;
-
-    @ApiProperty({ required: false })
-    @ValidateIf((dto: CertificateDTO) => !!dto.latestCommitment)
-    latestCommitment?: IOwnershipCommitmentProof;
 
     @ApiProperty({ type: Boolean, required: false })
     @ValidateIf((dto: CertificateDTO) => !!dto.issuedPrivately)

--- a/packages/traceability/issuer-api/src/pods/certificate/utils/index.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/utils/index.ts
@@ -4,18 +4,22 @@ import { Certificate } from '../certificate.entity';
 
 export const certificateToDto = async (
     certificate: Certificate,
-    userId: string
+    userId?: string
 ): Promise<CertificateDTO> => {
-    const userAddress = utils.getAddress(userId);
+    let userAddress: string;
+
+    if (userId) {
+        userAddress = utils.getAddress(userId);
+    }
 
     const publicVolume = BigNumber.from(
-        certificate.issuedPrivately ? 0 : certificate.owners[userAddress] ?? 0
+        certificate.issuedPrivately || !userId ? 0 : certificate.owners[userAddress] ?? 0
     );
     const privateVolume = BigNumber.from(
-        certificate.issuedPrivately ? certificate.owners[userAddress] ?? 0 : 0
+        certificate.issuedPrivately && userId ? certificate.owners[userAddress] ?? 0 : 0
     );
     const claimedVolume = BigNumber.from(
-        certificate.claimers ? certificate.claimers[userAddress] ?? 0 : 0
+        certificate.claimers && userId ? certificate.claimers[userAddress] ?? 0 : 0
     );
 
     return {

--- a/packages/traceability/issuer-api/src/pods/certificate/utils/index.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/utils/index.ts
@@ -13,10 +13,12 @@ export const certificateToDto = async (
     }
 
     const publicVolume = BigNumber.from(
-        certificate.issuedPrivately || !userId ? 0 : certificate.owners[userAddress] ?? 0
+        !certificate.issuedPrivately && userId ? certificate.owners[userAddress] ?? 0 : 0
     );
     const privateVolume = BigNumber.from(
-        certificate.issuedPrivately && userId ? certificate.owners[userAddress] ?? 0 : 0
+        certificate.issuedPrivately && userId
+            ? certificate.latestCommitment.commitment[userAddress] ?? 0
+            : 0
     );
     const claimedVolume = BigNumber.from(
         certificate.claimers && userId ? certificate.claimers[userAddress] ?? 0 : 0
@@ -39,7 +41,6 @@ export const certificateToDto = async (
         isOwned: publicVolume.add(privateVolume).gt(0),
         myClaims:
             certificate.claims?.filter((claim) => utils.getAddress(claim.to) === userAddress) ?? [],
-        latestCommitment: certificate.latestCommitment,
         issuedPrivately: certificate.issuedPrivately
     };
 };

--- a/packages/traceability/issuer-api/src/pods/certification-request/certification-request.dto.ts
+++ b/packages/traceability/issuer-api/src/pods/certification-request/certification-request.dto.ts
@@ -87,4 +87,7 @@ export class CertificationRequestDTO {
         required: false
     })
     status?: CertificationRequestStatus;
+
+    @ApiProperty({ type: Boolean, required: false })
+    isPrivate?: boolean;
 }

--- a/packages/traceability/issuer-api/test/certificate.e2e-spec.ts
+++ b/packages/traceability/issuer-api/test/certificate.e2e-spec.ts
@@ -480,4 +480,32 @@ describe('Certificate tests', () => {
                 );
             });
     });
+
+    it('should get certificates without a blockchain account attached', async () => {
+        let certificateId: number;
+
+        setUserRole(Role.Issuer);
+
+        const blockchainAddress = authenticatedUser.blockchainAccountAddress;
+
+        await request(app.getHttpServer())
+            .post('/certificate')
+            .send(certificateTestData)
+            .expect(HttpStatus.CREATED)
+            .expect((res) => {
+                certificateId = res.body.id;
+            });
+
+        setUserRole(Role.OrganizationDeviceManager);
+
+        authenticatedUser.blockchainAccountAddress = null;
+
+        await request(app.getHttpServer())
+            .get(`/certificate/${certificateId}`)
+            .expect(HttpStatus.OK);
+
+        await request(app.getHttpServer()).get(`/certificate`).expect(HttpStatus.OK);
+
+        authenticatedUser.blockchainAccountAddress = blockchainAddress;
+    });
 });


### PR DESCRIPTION
- Allow certain endpoints of the Issuer API to be used by users with no blockchain address
- **Critical bugfix** - private transfer commitment was always revealed in all certificates