### PR TITLE
Fix/gen time range

### DIFF
--- a/packages/trade/exchange-core-irec/src/AskProduct.ts
+++ b/packages/trade/exchange-core-irec/src/AskProduct.ts
@@ -149,12 +149,13 @@ export class AskProduct implements IMatchableProduct<IRECProduct, IRECProductFil
     }
 
     private matchesGenerationTimes(product: IRECProduct) {
-        const range = moment.range(
+        const askRange = moment.range(
             this.product.generationTime.from,
             this.product.generationTime.to
         );
-        const askRange = moment.range(product.generationTime.from, product.generationTime.to);
 
-        return range.contains(askRange);
+        const range = moment.range(product.generationTime.from, product.generationTime.to);
+
+        return range.contains(askRange) || askRange.contains(range);
     }
 }

--- a/packages/trade/exchange-irec/test/orderbook.e2e-spec.ts
+++ b/packages/trade/exchange-irec/test/orderbook.e2e-spec.ts
@@ -422,6 +422,40 @@ describe('orderbook tests', () => {
         expect(bids[0].product.deviceType).to.deep.equal(['Wind']);
     });
 
+    it('should return asks filtered by generation date if filter is included in asks', async () => {
+        const {
+            body: { asks }
+        }: { body: OrderBook } = await request(app.getHttpServer())
+            .post('/orderbook/search')
+            .send({
+                ...defaultAllFilter,
+                generationTimeFilter: Filter.Specific,
+                generationFrom: new Date('2020-01-02').toISOString(),
+                generationTo: new Date('2020-01-05').toISOString()
+            })
+            .expect('Content-Type', /application\/json/)
+            .expect(HttpStatus.OK);
+
+        expect(asks).to.have.length(2);
+    });
+
+    it('should return asks filtered by generation date if filter is broader than asks', async () => {
+        const {
+            body: { asks }
+        }: { body: OrderBook } = await request(app.getHttpServer())
+            .post('/orderbook/search')
+            .send({
+                ...defaultAllFilter,
+                generationTimeFilter: Filter.Specific,
+                generationFrom: new Date('2019-01-01').toISOString(),
+                generationTo: new Date('2021-01-31').toISOString()
+            })
+            .expect('Content-Type', /application\/json/)
+            .expect(HttpStatus.OK);
+
+        expect(asks).to.have.length(2);
+    });
+
     it('should return empty orders list if time mismatch', async () => {
         const {
             body: { asks, bids }


### PR DESCRIPTION
This PR changes the way generation time is matched and filtered. 

Previously:
`Certificate: Dec2018 + Filter Dec2018->Jan2019 ` won't return Certificate, because certificate range is < than filter range
Currently:
`Certificate: Dec2018 + Filter Dec2018->Jan2019 ` will return Certificate