### PR TITLE
fix/i18next alias

### DIFF
--- a/packages/apps/origin-ui/src/components/AppContainer.tsx
+++ b/packages/apps/origin-ui/src/components/AppContainer.tsx
@@ -2,7 +2,6 @@ import React, { useContext, useEffect } from 'react';
 import { useSelector, useStore } from 'react-redux';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import { History } from 'history';
-import { i18n } from 'i18next';
 import { LinearProgress, makeStyles, createStyles, useTheme } from '@material-ui/core';
 import { UserStatus, isRole, Role } from '@energyweb/origin-backend-core';
 import { OriginFeature, allOriginFeatures } from '@energyweb/utils-general';
@@ -31,7 +30,6 @@ import { IRecCoreAdapter, IRecApp } from '@energyweb/origin-ui-irec-core';
 
 interface IProps {
     history: History;
-    i18nInstance: i18n;
 }
 
 export function AppContainer(props: IProps) {
@@ -66,7 +64,6 @@ export function AppContainer(props: IProps) {
             configuration={config}
             history={props.history}
             component={component}
-            i18nInstance={props.i18nInstance}
         />
     );
 
@@ -83,7 +80,6 @@ export function AppContainer(props: IProps) {
             configuration={config}
             history={props.history}
             component={component}
-            i18nInstance={props.i18nInstance}
         />
     );
     const exchangeRoute = shareContextExchange(<ExchangeApp />);
@@ -94,7 +90,6 @@ export function AppContainer(props: IProps) {
             configuration={config}
             history={props.history}
             component={component}
-            i18nInstance={props.i18nInstance}
         />
     );
     const iRecDeviceRoute = shareContextIRec(<IRecApp />);

--- a/packages/apps/origin-ui/src/components/Origin.tsx
+++ b/packages/apps/origin-ui/src/components/Origin.tsx
@@ -14,7 +14,6 @@ import { Route } from 'react-router-dom';
 import { routerMiddleware, ConnectedRouter } from 'connected-react-router';
 import { createBrowserHistory, History } from 'history';
 import MomentUtils from '@date-io/moment';
-import { i18n } from 'i18next';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import { sagas } from '../features/sagas';
@@ -27,7 +26,6 @@ export function Origin() {
     const originConfiguration = useContext(OriginConfigurationContext);
     const [store, setStore] = useState<Store<CombinedState<IStoreState>, AnyAction>>(null);
     const [history, setHistory] = useState<History>(null);
-    const [i18next, seti18next] = useState<i18n>(null);
 
     useEffect(() => {
         if (store) {
@@ -59,8 +57,7 @@ export function Origin() {
             sagaMiddleware.run(sagas[saga]);
         });
 
-        const i18nInstance = initializeI18N(originConfiguration.language);
-        seti18next(i18nInstance);
+        initializeI18N(originConfiguration.language);
     });
 
     if (!originConfiguration) {
@@ -79,7 +76,7 @@ export function Origin() {
                 <Provider store={store}>
                     <ConnectedRouter history={history}>
                         <Route path="/">
-                            <AppContainer history={history} i18nInstance={i18next} />
+                            <AppContainer history={history} />
                         </Route>
                     </ConnectedRouter>
                 </Provider>

--- a/packages/apps/origin-ui/webpack/base.config.js
+++ b/packages/apps/origin-ui/webpack/base.config.js
@@ -14,7 +14,8 @@ module.exports = {
         // Add '.ts' and '.tsx' as resolvable extensions.
         extensions: ['.ts', '.tsx', '.js', '.json'],
         alias: {
-            'react-redux': require.resolve('react-redux')
+            'react-redux': require.resolve('react-redux'),
+            'react-i18next': require.resolve('../node_modules/react-i18next')
         },
         fallback: {
             stream: require.resolve('stream-browserify'),

--- a/packages/ui/exchange-ui-core/src/ExchangeAdapter.tsx
+++ b/packages/ui/exchange-ui-core/src/ExchangeAdapter.tsx
@@ -5,8 +5,6 @@ import MomentUtils from '@date-io/moment';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router';
 import { History } from 'history';
-import { I18nextProvider } from 'react-i18next';
-import { i18n } from 'i18next';
 import { OriginConfigurationProvider, IOriginConfiguration } from '@energyweb/origin-ui-core';
 import { Store, CombinedState, AnyAction } from 'redux';
 import { IExchangeState } from './types';
@@ -16,7 +14,6 @@ interface IProps {
     configuration: IOriginConfiguration;
     history: History;
     component: React.ReactElement;
-    i18nInstance: i18n;
 }
 
 export function ExchangeAdapter(props: IProps) {
@@ -31,9 +28,7 @@ export function ExchangeAdapter(props: IProps) {
                         >
                             <Provider store={props.store}>
                                 <ConnectedRouter history={props.history}>
-                                    <I18nextProvider i18n={props.i18nInstance}>
-                                        {props.component}
-                                    </I18nextProvider>
+                                    {props.component}
                                 </ConnectedRouter>
                             </Provider>
                         </MuiPickersUtilsProvider>

--- a/packages/ui/origin-ui-core/src/UiCoreAdapter.tsx
+++ b/packages/ui/origin-ui-core/src/UiCoreAdapter.tsx
@@ -3,8 +3,6 @@ import { Store, CombinedState, AnyAction } from 'redux';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router';
 import { History } from 'history';
-import { I18nextProvider } from 'react-i18next';
-import { i18n } from 'i18next';
 import { MuiThemeProvider } from '@material-ui/core';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import MomentUtils from '@date-io/moment';
@@ -16,7 +14,6 @@ interface IProps {
     configuration: IOriginConfiguration;
     history: History;
     component: React.ReactElement;
-    i18nInstance: i18n;
 }
 
 export function UiCoreAdapter(props: IProps) {
@@ -31,9 +28,7 @@ export function UiCoreAdapter(props: IProps) {
                         >
                             <Provider store={props.store}>
                                 <ConnectedRouter history={props.history}>
-                                    <I18nextProvider i18n={props.i18nInstance}>
-                                        {props.component}
-                                    </I18nextProvider>
+                                    {props.component}
                                 </ConnectedRouter>
                             </Provider>
                         </MuiPickersUtilsProvider>

--- a/packages/ui/origin-ui-irec-core/src/IRecCoreAdapter.tsx
+++ b/packages/ui/origin-ui-irec-core/src/IRecCoreAdapter.tsx
@@ -6,8 +6,6 @@ import { Provider } from 'react-redux';
 import { Store, CombinedState, AnyAction } from 'redux';
 import { ConnectedRouter } from 'connected-react-router';
 import { History } from 'history';
-import { I18nextProvider } from 'react-i18next';
-import { i18n } from 'i18next';
 import { OriginConfigurationProvider, IOriginConfiguration } from '@energyweb/origin-ui-core';
 import { IIRecAppState } from './types';
 
@@ -16,7 +14,6 @@ interface IProps {
     configuration: IOriginConfiguration;
     history: History;
     component: React.ReactElement;
-    i18nInstance: i18n;
 }
 
 export function IRecCoreAdapter(props: IProps) {
@@ -31,9 +28,7 @@ export function IRecCoreAdapter(props: IProps) {
                         >
                             <Provider store={props.store}>
                                 <ConnectedRouter history={props.history}>
-                                    <I18nextProvider i18n={props.i18nInstance}>
-                                        {props.component}
-                                    </I18nextProvider>
+                                    {props.component}
                                 </ConnectedRouter>
                             </Provider>
                         </MuiPickersUtilsProvider>


### PR DESCRIPTION
In this PR removed i18nextProviders from UI packages adapters. Instead used a webpack alias for react-i18next