### PR TITLE
chore(issuer-api): Queries should return pure Certificate entities in…

### DIFF
--- a/packages/traceability/issuer-api/src/pods/certificate/certificate.controller.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/certificate.controller.ts
@@ -44,6 +44,8 @@ import { CertificateEvent } from '../../types';
 import { GetAllCertificateEventsQuery } from './queries/get-all-certificate-events.query';
 import { CertificateDTO } from './certificate.dto';
 import { SuccessResponseDTO } from '../../utils/success-response.dto';
+import { certificateToDto } from './utils';
+import { Certificate } from './certificate.entity';
 
 @ApiTags('certificates')
 @ApiBearerAuth('access-token')
@@ -64,7 +66,11 @@ export class CertificateController {
         @Param('id', new ParseIntPipe()) id: number,
         @BlockchainAccountDecorator() blockchainAddress: string
     ): Promise<CertificateDTO> {
-        return this.queryBus.execute(new GetCertificateQuery(id, blockchainAddress));
+        const certificate = await this.queryBus.execute<GetCertificateQuery, Certificate>(
+            new GetCertificateQuery(id)
+        );
+
+        return certificateToDto(certificate, blockchainAddress);
     }
 
     @Get('/token-id/:tokenId')
@@ -78,7 +84,11 @@ export class CertificateController {
         @Param('tokenId', new ParseIntPipe()) tokenId: number,
         @BlockchainAccountDecorator() blockchainAddress: string
     ): Promise<CertificateDTO> {
-        return this.queryBus.execute(new GetCertificateByTokenIdQuery(tokenId, blockchainAddress));
+        const certificate = await this.queryBus.execute<GetCertificateByTokenIdQuery, Certificate>(
+            new GetCertificateByTokenIdQuery(tokenId)
+        );
+
+        return certificateToDto(certificate, blockchainAddress);
     }
 
     @Get()
@@ -91,7 +101,12 @@ export class CertificateController {
     public async getAll(
         @BlockchainAccountDecorator() blockchainAddress: string
     ): Promise<CertificateDTO[]> {
-        return this.queryBus.execute(new GetAllCertificatesQuery(blockchainAddress));
+        const certificates = await this.queryBus.execute<GetAllCertificatesQuery, Certificate[]>(
+            new GetAllCertificatesQuery()
+        );
+        return Promise.all(
+            certificates.map((certificate) => certificateToDto(certificate, blockchainAddress))
+        );
     }
 
     @Get('/issuer/certified/:deviceId')

--- a/packages/traceability/issuer-api/src/pods/certificate/events/certificate-created-event.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/events/certificate-created-event.ts
@@ -5,7 +5,7 @@ interface IPrivateCertificateInfo {
 
 export class CertificateCreatedEvent {
     constructor(
-        public readonly certificateId: number,
+        public readonly tokenId: number,
         public readonly privateInfo?: IPrivateCertificateInfo
     ) {}
 }

--- a/packages/traceability/issuer-api/src/pods/certificate/events/certificate-persisted.event.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/events/certificate-persisted.event.ts
@@ -1,0 +1,3 @@
+export class CertificatePersistedEvent {
+    constructor(public readonly certificateId: number) {}
+}

--- a/packages/traceability/issuer-api/src/pods/certificate/events/index.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/events/index.ts
@@ -1,2 +1,3 @@
 export * from './certificate-created-event';
 export * from './sync-certificate-event';
+export * from './certificate-persisted.event';

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/get-all-certificates.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/get-all-certificates.handler.ts
@@ -3,8 +3,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { GetAllCertificatesQuery } from '../queries/get-all-certificates.query';
 import { Certificate } from '../certificate.entity';
-import { CertificateDTO } from '../certificate.dto';
-import { certificateToDto } from '../utils';
 
 @QueryHandler(GetAllCertificatesQuery)
 export class GetAllCertificatesHandler implements IQueryHandler<GetAllCertificatesQuery> {
@@ -13,11 +11,7 @@ export class GetAllCertificatesHandler implements IQueryHandler<GetAllCertificat
         private readonly repository: Repository<Certificate>
     ) {}
 
-    async execute({ userId }: GetAllCertificatesQuery): Promise<CertificateDTO[]> {
-        const certificates = await this.repository.find();
-
-        return Promise.all(
-            certificates.map((certificate) => certificateToDto(certificate, userId))
-        );
+    async execute(): Promise<Certificate[]> {
+        return this.repository.find();
     }
 }

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/get-certificate-by-token.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/get-certificate-by-token.handler.ts
@@ -1,10 +1,8 @@
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { CertificateDTO } from '../certificate.dto';
 import { Certificate } from '../certificate.entity';
 import { GetCertificateByTokenIdQuery } from '../queries/get-certificate-by-token.query';
-import { certificateToDto } from '../utils';
 
 @QueryHandler(GetCertificateByTokenIdQuery)
 export class GetCertificateByTokenIdHandler implements IQueryHandler<GetCertificateByTokenIdQuery> {
@@ -13,9 +11,7 @@ export class GetCertificateByTokenIdHandler implements IQueryHandler<GetCertific
         private readonly repository: Repository<Certificate>
     ) {}
 
-    async execute({ userId, tokenId }: GetCertificateByTokenIdQuery): Promise<CertificateDTO> {
-        const certificate = await this.repository.findOne({ tokenId });
-
-        return certificateToDto(certificate, userId);
+    async execute({ tokenId }: GetCertificateByTokenIdQuery): Promise<Certificate> {
+        return this.repository.findOne({ tokenId });
     }
 }

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/get-certificate.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/get-certificate.handler.ts
@@ -1,10 +1,8 @@
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { CertificateDTO } from '../certificate.dto';
 import { Certificate } from '../certificate.entity';
 import { GetCertificateQuery } from '../queries/get-certificate.query';
-import { certificateToDto } from '../utils';
 
 @QueryHandler(GetCertificateQuery)
 export class GetCertificateHandler implements IQueryHandler<GetCertificateQuery> {
@@ -13,9 +11,7 @@ export class GetCertificateHandler implements IQueryHandler<GetCertificateQuery>
         private readonly repository: Repository<Certificate>
     ) {}
 
-    async execute({ id, userId }: GetCertificateQuery): Promise<CertificateDTO> {
-        const certificate = await this.repository.findOne(id);
-
-        return certificateToDto(certificate, userId);
+    async execute({ id }: GetCertificateQuery): Promise<Certificate> {
+        return this.repository.findOne(id);
     }
 }

--- a/packages/traceability/issuer-api/src/pods/certificate/queries/get-all-certificates.query.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/queries/get-all-certificates.query.ts
@@ -1,3 +1,1 @@
-export class GetAllCertificatesQuery {
-    constructor(public readonly userId: string) {}
-}
+export class GetAllCertificatesQuery {}

--- a/packages/traceability/issuer-api/src/pods/certificate/queries/get-certificate-by-token.query.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/queries/get-certificate-by-token.query.ts
@@ -1,3 +1,3 @@
 export class GetCertificateByTokenIdQuery {
-    constructor(public readonly tokenId: number, public readonly userId: string) {}
+    constructor(public readonly tokenId: number) {}
 }

--- a/packages/traceability/issuer-api/src/pods/certificate/queries/get-certificate.query.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/queries/get-certificate.query.ts
@@ -1,3 +1,3 @@
 export class GetCertificateQuery {
-    constructor(public readonly id: number, public readonly userId: string) {}
+    constructor(public readonly id: number) {}
 }


### PR DESCRIPTION
- Queries should return pure Certificate entities internally instead of DTOs
- Emit an event when a certificate is persisted