### PR TITLE
fix/getting meter reads after vital device data

### DIFF
--- a/packages/ui/origin-ui-core/src/components/devices/Table/DeviceTable.tsx
+++ b/packages/ui/origin-ui-core/src/components/devices/Table/DeviceTable.tsx
@@ -102,7 +102,7 @@ export function DeviceTable(props: IOwnProps) {
 
     useEffect(() => {
         loadPage(1);
-    }, [user]);
+    }, [user, props.devices]);
 
     function viewDevice(rowIndex: number) {
         const device = paginatedData[rowIndex];
@@ -183,8 +183,14 @@ export function DeviceTable(props: IOwnProps) {
         deviceLocation: device.locationText,
         type: configuration?.deviceTypeService?.getDisplayText(device.deviceType) ?? '',
         capacity: PowerFormatter.format(device.capacityInW),
-        readCertified: EnergyFormatter.format(device.meterStats?.certified ?? 0),
-        readToBeCertified: EnergyFormatter.format(device.meterStats?.uncertified ?? 0),
+        readCertified:
+            device.meterStats === null
+                ? 'Loading...'
+                : EnergyFormatter.format(device.meterStats?.certified ?? 0),
+        readToBeCertified:
+            device.meterStats === null
+                ? 'Loading...'
+                : EnergyFormatter.format(device.meterStats?.uncertified ?? 0),
         status: device.status,
         gridOperator: device.gridOperator
     }));

--- a/packages/ui/origin-ui-core/src/features/devices/actions.ts
+++ b/packages/ui/origin-ui-core/src/features/devices/actions.ts
@@ -3,7 +3,9 @@ import {
     IStoreAllDevicesAction,
     IStoreMyDevicesAction,
     IDeviceActions,
-    IApproveDeviceAction
+    IApproveDeviceAction,
+    IAddReadsAllDevices,
+    IAddReadsMyDevices
 } from './types';
 
 export enum DevicesActions {
@@ -14,7 +16,9 @@ export enum DevicesActions {
     CREATE_DEVICE = 'CREATE_DEVICE',
     STORE_ALL_DEVICES = 'STORE_ALL_DEVICES',
     STORE_MY_DEVICES = 'STORE_MY_DEVICES',
-    APPROVE_DEVICE = 'APPROVE_DEVICE'
+    APPROVE_DEVICE = 'APPROVE_DEVICE',
+    ADD_READS_ALL_DEVICES = 'ADD_READS_ALL_DEVICES',
+    ADD_READS_MY_DEVICES = 'ADD_READS_MY_DEVICES'
 }
 
 export const fetchAllDevices = (): IDeviceActions => ({
@@ -54,5 +58,17 @@ export const createDevice = (payload: ICreateDeviceAction['payload']): ICreateDe
 
 export const approveDevice = (payload: IApproveDeviceAction['payload']): IApproveDeviceAction => ({
     type: DevicesActions.APPROVE_DEVICE,
+    payload
+});
+
+export const addReadsAllDevices = (
+    payload: IAddReadsAllDevices['payload']
+): IAddReadsAllDevices => ({
+    type: DevicesActions.ADD_READS_ALL_DEVICES,
+    payload
+});
+
+export const addReadsMyDevices = (payload: IAddReadsMyDevices['payload']): IAddReadsMyDevices => ({
+    type: DevicesActions.ADD_READS_MY_DEVICES,
     payload
 });

--- a/packages/ui/origin-ui-core/src/features/devices/reducer.ts
+++ b/packages/ui/origin-ui-core/src/features/devices/reducer.ts
@@ -1,5 +1,7 @@
 import { IDeviceState, IDeviceActions } from './types';
 import { DevicesActions } from './actions';
+import { DeviceDTO } from '@energyweb/origin-device-registry-irec-form-api-client';
+import { fillDevicesWithReads } from '../../utils/device';
 
 const defaultState: IDeviceState = {
     allDevices: null,
@@ -16,10 +18,24 @@ export function devicesState(
                 ...state,
                 allDevices: payload
             };
+        case DevicesActions.ADD_READS_ALL_DEVICES:
+            const allDevicesWithReads: DeviceDTO[] = payload;
+            const updatedAllDevices = fillDevicesWithReads(state.allDevices, allDevicesWithReads);
+            return {
+                ...state,
+                allDevices: updatedAllDevices
+            };
         case DevicesActions.STORE_MY_DEVICES:
             return {
                 ...state,
                 myDevices: payload
+            };
+        case DevicesActions.ADD_READS_MY_DEVICES:
+            const myDevicesWithReads: DeviceDTO[] = payload;
+            const updatedMyDevices = fillDevicesWithReads(state.myDevices, myDevicesWithReads);
+            return {
+                ...state,
+                myDevices: updatedMyDevices
             };
         case DevicesActions.CLEAR_ALL_DEVICES:
             return {

--- a/packages/ui/origin-ui-core/src/features/devices/sagas.ts
+++ b/packages/ui/origin-ui-core/src/features/devices/sagas.ts
@@ -54,7 +54,8 @@ function* fetchAndFormatAllDevices(): SagaIterator {
             const devicesWithOrg: IOriginDevice[] = allDevices.map((device) => ({
                 ...device,
                 organizationName: orgNames.get(device.organizationId),
-                locationText: getDeviceLocationText(device)
+                locationText: getDeviceLocationText(device),
+                meterStats: null
             }));
             yield put(clearAllDevices());
             yield put(storeAllDevices(devicesWithOrg));
@@ -101,7 +102,8 @@ function* fetchAndFormatMyDevices(): SagaIterator {
             const devicesWithOrg: IOriginDevice[] = myDevices.map((device) => ({
                 ...device,
                 organizationName: ownOrgName,
-                locationText: getDeviceLocationText(device)
+                locationText: getDeviceLocationText(device),
+                meterStats: null
             }));
 
             yield put(clearMyDevices());

--- a/packages/ui/origin-ui-core/src/features/devices/sagas.ts
+++ b/packages/ui/origin-ui-core/src/features/devices/sagas.ts
@@ -18,7 +18,9 @@ import {
     fetchMyDevices,
     clearAllDevices,
     clearMyDevices,
-    fetchAllDevices
+    fetchAllDevices,
+    addReadsAllDevices,
+    addReadsMyDevices
 } from './actions';
 import { ICreateDeviceAction, IApproveDeviceAction } from './types';
 
@@ -42,7 +44,6 @@ function* fetchAndFormatAllDevices(): SagaIterator {
             );
 
             allDevices.forEach((device) => allOrgIds.add(device.organizationId));
-
             for (const id of allOrgIds) {
                 const {
                     data: { name }
@@ -57,6 +58,13 @@ function* fetchAndFormatAllDevices(): SagaIterator {
             }));
             yield put(clearAllDevices());
             yield put(storeAllDevices(devicesWithOrg));
+
+            const { data: allDevicesWithReads }: { data: DeviceDTO[] } = yield apply(
+                deviceClient,
+                deviceClient.getAll,
+                [true]
+            );
+            yield put(addReadsAllDevices(allDevicesWithReads));
         } catch (error) {
             showNotification(i18n.t('device.feedback.errorGettingDevices'), NotificationType.Error);
             console.log(error);
@@ -98,6 +106,13 @@ function* fetchAndFormatMyDevices(): SagaIterator {
 
             yield put(clearMyDevices());
             yield put(storeMyDevices(devicesWithOrg));
+
+            const { data: myDevicesWithReads }: { data: DeviceDTO[] } = yield apply(
+                deviceClient,
+                deviceClient.getMyDevices,
+                [true]
+            );
+            yield put(addReadsMyDevices(myDevicesWithReads));
         } catch (error) {
             showNotification(i18n.t('device.feedback.errorGettingDevices'), NotificationType.Error);
             console.log(error);

--- a/packages/ui/origin-ui-core/src/features/devices/types.ts
+++ b/packages/ui/origin-ui-core/src/features/devices/types.ts
@@ -1,4 +1,4 @@
-import { CreateDeviceDTO } from '@energyweb/origin-device-registry-irec-form-api-client';
+import { CreateDeviceDTO, DeviceDTO } from '@energyweb/origin-device-registry-irec-form-api-client';
 import { IOriginDevice } from '../../types';
 import { DevicesActions } from './actions';
 
@@ -30,4 +30,14 @@ export interface IStoreMyDevicesAction {
 export interface IApproveDeviceAction {
     type: DevicesActions.APPROVE_DEVICE;
     payload: number;
+}
+
+export interface IAddReadsAllDevices {
+    type: DevicesActions.ADD_READS_ALL_DEVICES;
+    payload: DeviceDTO[];
+}
+
+export interface IAddReadsMyDevices {
+    type: DevicesActions.ADD_READS_MY_DEVICES;
+    payload: DeviceDTO[];
 }

--- a/packages/ui/origin-ui-core/src/utils/device.ts
+++ b/packages/ui/origin-ui-core/src/utils/device.ts
@@ -213,3 +213,23 @@ export function getDeviceName(id: string, devices: any[], environment: IEnvironm
     const deviceName = deviceTypeChecker(device) ? device?.facilityName : (device as any)?.name;
     return deviceName ?? '-';
 }
+
+export function fillDevicesWithReads(
+    stateDevices: IOriginDevice[],
+    devicesWithReads: DeviceDTO[]
+): IOriginDevice[] {
+    const updatedDevices = stateDevices.map((stateDevice) => {
+        const sameDeviceWithReads = devicesWithReads.find((d) => d.id === stateDevice.id);
+
+        if (stateDevice.smartMeterReads.length === sameDeviceWithReads.smartMeterReads.length) {
+            return stateDevice;
+        }
+
+        return {
+            ...stateDevice,
+            smartMeterReads: sameDeviceWithReads.smartMeterReads,
+            meterStats: sameDeviceWithReads.meterStats
+        };
+    });
+    return updatedDevices;
+}

--- a/packages/ui/origin-ui-core/src/utils/device.ts
+++ b/packages/ui/origin-ui-core/src/utils/device.ts
@@ -220,11 +220,6 @@ export function fillDevicesWithReads(
 ): IOriginDevice[] {
     const updatedDevices = stateDevices.map((stateDevice) => {
         const sameDeviceWithReads = devicesWithReads.find((d) => d.id === stateDevice.id);
-
-        if (stateDevice.smartMeterReads.length === sameDeviceWithReads.smartMeterReads.length) {
-            return stateDevice;
-        }
-
         return {
             ...stateDevice,
             smartMeterReads: sameDeviceWithReads.smartMeterReads,


### PR DESCRIPTION
When getting All/My devices - at first device data is received without meterReads, allowing to display table data. 
At the same moment second request is started at the background, where devices with meter reads are received. 
After this we are merging devices with meterRead and without and update the stored data.