### PR TITLE
chore: install @microsoft/rush for CI deployment

### DIFF
--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -50,6 +50,10 @@ jobs:
       run: |
         sh scripts/restore-original-timestamps.sh
 
+    - name: Install rush
+      run: |
+        npm install -g @microsoft/rush
+
     - name: Install application
       # lerna doesn't work without additional fetch
       run: |


### PR DESCRIPTION
CI deployment fails because in [Makefile](https://github.com/energywebfoundation/origin/blob/master/packages/apps/origin-backend-app/Makefile#L15)s we are using the `rush` command, which is not installed.