### PR TITLE
chore(issuer-api): log errors when resyncing certificate fails

### DIFF
--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/sync-certificate.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/sync-certificate.handler.ts
@@ -27,7 +27,9 @@ export class SyncCertificateHandler implements IEventHandler<SyncCertificateEven
         try {
             await certificate.sync();
         } catch (e) {
-            this.logger.error(`Failed to resync certificate: ${JSON.stringify(e.message)}`);
+            this.logger.error(
+                `Failed to resync certificate ${tokenId}: ${JSON.stringify(e.message)}`
+            );
             this.logger.error(JSON.stringify(e));
             return ResponseFailure(e.message, HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/sync-certificate.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/sync-certificate.handler.ts
@@ -27,6 +27,8 @@ export class SyncCertificateHandler implements IEventHandler<SyncCertificateEven
         try {
             await certificate.sync();
         } catch (e) {
+            this.logger.error(`Failed to resync certificate: ${JSON.stringify(e.message)}`);
+            this.logger.error(JSON.stringify(e));
             return ResponseFailure(e.message, HttpStatus.INTERNAL_SERVER_ERROR);
         }
 


### PR DESCRIPTION
Log the error in the Logger when a certificate resync fails.