### PR TITLE
fix(issuer-api): Certificate events syncing

### DIFF
--- a/packages/traceability/issuer-api/src/pods/certificate/certificate.entity.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/certificate.entity.ts
@@ -1,5 +1,5 @@
 import { ExtendedBaseEntity } from '@energyweb/origin-backend-utils';
-import { Column, Entity, PrimaryGeneratedColumn, ManyToOne, Unique, getRepository } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn, ManyToOne, Unique } from 'typeorm';
 import { IsBoolean, IsInt, IsPositive, IsString, Min } from 'class-validator';
 import { CertificateUtils, IClaim, IOwnershipCommitmentProof } from '@energyweb/issuer';
 import { BlockchainProperties } from '../blockchain/blockchain-properties.entity';

--- a/packages/traceability/issuer-api/src/pods/certificate/certificate.entity.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/certificate.entity.ts
@@ -1,14 +1,8 @@
 import { ExtendedBaseEntity } from '@energyweb/origin-backend-utils';
 import { Column, Entity, PrimaryGeneratedColumn, ManyToOne, Unique, getRepository } from 'typeorm';
 import { IsBoolean, IsInt, IsPositive, IsString, Min } from 'class-validator';
-import {
-    CertificateUtils,
-    IClaim,
-    IOwnershipCommitmentProof,
-    Certificate as OnChainCertificate
-} from '@energyweb/issuer';
+import { CertificateUtils, IClaim, IOwnershipCommitmentProof } from '@energyweb/issuer';
 import { BlockchainProperties } from '../blockchain/blockchain-properties.entity';
-import { ISuccessResponse, ResponseFailure, ResponseSuccess } from '@energyweb/origin-backend-core';
 
 export const CERTIFICATES_TABLE_NAME = 'issuer_certificate';
 
@@ -68,37 +62,4 @@ export class Certificate extends ExtendedBaseEntity {
     @Column()
     @IsBoolean()
     issuedPrivately: boolean;
-
-    /*
-        Syncs the db certificate with it's on-chain counterpart.
-    */
-    async sync(): Promise<ISuccessResponse> {
-        if (!this.blockchain || !this.tokenId) {
-            throw new Error(
-                `Certificate ${this.id} is missing either blockchain (${this.blockchain}) or tokenId (${this.tokenId}) properties.`
-            );
-        }
-
-        const onChainCert = await new OnChainCertificate(
-            this.tokenId,
-            this.blockchain.wrap()
-        ).sync();
-
-        const certificateRepository = getRepository(Certificate);
-
-        const updateResult = await certificateRepository.update(this.id, {
-            owners: onChainCert.owners,
-            claimers: onChainCert.claimers,
-            claims: await onChainCert.getClaimedData()
-        });
-
-        if (updateResult.affected < 1) {
-            return ResponseFailure(
-                `Unable to perform update on certificate ${this.id}: ${updateResult.raw}`,
-                500
-            );
-        }
-
-        return ResponseSuccess();
-    }
 }

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/bulk-claim-certificates.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/bulk-claim-certificates.handler.ts
@@ -45,7 +45,7 @@ export class BulkClaimCertificatesHandler implements ICommandHandler<BulkClaimCe
                 forAddress
             );
 
-            const receipt = await bulkClaimTx.wait(1);
+            const receipt = await bulkClaimTx.wait();
 
             if (receipt.status === 0) {
                 throw new Error(

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/claim-certificate.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/claim-certificate.handler.ts
@@ -92,17 +92,23 @@ export class ClaimCertificateHandler implements ICommandHandler<ClaimCertificate
         }
 
         try {
-            await cert.claim(
+            const claimTx = await cert.claim(
                 claimData,
                 BigNumber.from(amountToClaim),
                 checksummedForAddress,
                 checksummedForAddress
             );
+
+            const receipt = await claimTx.wait(1);
+
+            if (receipt.status === 0) {
+                throw new Error(
+                    `Transfer tx ${receipt.transactionHash} on certificate with tokenId ${cert.id} failed.`
+                );
+            }
         } catch (error) {
             return ResponseFailure(JSON.stringify(error), HttpStatus.INTERNAL_SERVER_ERROR);
         }
-
-        await certificate.sync();
 
         return ResponseSuccess();
     }

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/claim-certificate.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/claim-certificate.handler.ts
@@ -99,7 +99,7 @@ export class ClaimCertificateHandler implements ICommandHandler<ClaimCertificate
                 checksummedForAddress
             );
 
-            const receipt = await claimTx.wait(1);
+            const receipt = await claimTx.wait();
 
             if (receipt.status === 0) {
                 throw new Error(

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/transfer-certificate.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/transfer-certificate.handler.ts
@@ -64,16 +64,22 @@ export class TransferCertificateHandler implements ICommandHandler<TransferCerti
         }
 
         try {
-            await onChainCert.transfer(
+            const transferTx = await onChainCert.transfer(
                 to,
                 BigNumber.from(amount ?? onChainCert.owners[from]),
                 from
             );
+
+            const receipt = await transferTx.wait(1);
+
+            if (receipt.status === 0) {
+                throw new Error(
+                    `Transfer tx ${receipt.transactionHash} on certificate with tokenId ${onChainCert.id} failed.`
+                );
+            }
         } catch (error) {
             return ResponseFailure(JSON.stringify(error), HttpStatus.INTERNAL_SERVER_ERROR);
         }
-
-        await certificate.sync();
 
         return ResponseSuccess();
     }

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/transfer-certificate.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/transfer-certificate.handler.ts
@@ -70,7 +70,7 @@ export class TransferCertificateHandler implements ICommandHandler<TransferCerti
                 from
             );
 
-            const receipt = await transferTx.wait(1);
+            const receipt = await transferTx.wait();
 
             if (receipt.status === 0) {
                 throw new Error(

--- a/packages/traceability/issuer-api/src/pods/certificate/listeners/on-chain-certificates.listener.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/listeners/on-chain-certificates.listener.ts
@@ -55,12 +55,12 @@ export class OnChainCertificateWatcher implements OnModuleInit {
 
         this.provider.on(
             this.registry.filters.TransferBatch(null, null, null, null, null),
-            (event: providers.Log) => this.processEvent(EventType.TransferSingle, event)
+            (event: providers.Log) => this.processEvent(EventType.TransferBatch, event)
         );
 
         this.provider.on(
             this.registry.filters.ClaimBatch(null, null, null, null, null, null),
-            (event: providers.Log) => this.processEvent(EventType.ClaimSingle, event)
+            (event: providers.Log) => this.processEvent(EventType.ClaimBatch, event)
         );
     }
 

--- a/packages/traceability/issuer-api/test/certificate.e2e-spec.ts
+++ b/packages/traceability/issuer-api/test/certificate.e2e-spec.ts
@@ -234,7 +234,7 @@ describe('Certificate tests', () => {
             .put(`/certificate/${id}/claim`)
             .set({ 'test-user': TestUser.OrganizationDeviceManager })
             .send({ claimData })
-            .expect(console.log);
+            .expect(HttpStatus.OK);
 
         await request(app.getHttpServer())
             .put(`/certificate/${id}/claim`)

--- a/packages/traceability/issuer-api/test/certificate.e2e-spec.ts
+++ b/packages/traceability/issuer-api/test/certificate.e2e-spec.ts
@@ -148,6 +148,8 @@ describe('Certificate tests', () => {
                 expect(transferResponse.body.success).to.be.true;
             });
 
+        await sleep(5000);
+
         await request(app.getHttpServer())
             .get(`/certificate/${certificateId}`)
             .set({ 'test-user': TestUser.OrganizationDeviceManager })
@@ -179,6 +181,8 @@ describe('Certificate tests', () => {
             .expect((claimResponse) => {
                 expect(claimResponse.body.success).to.be.true;
             });
+
+        await sleep(10000);
 
         await request(app.getHttpServer())
             .get(`/certificate/${certificateId}`)
@@ -224,17 +228,21 @@ describe('Certificate tests', () => {
             })
             .expect(HttpStatus.OK);
 
+        await sleep(5000);
+
         await request(app.getHttpServer())
             .put(`/certificate/${id}/claim`)
             .set({ 'test-user': TestUser.OrganizationDeviceManager })
             .send({ claimData })
-            .expect(HttpStatus.OK);
+            .expect(console.log);
 
         await request(app.getHttpServer())
             .put(`/certificate/${id}/claim`)
             .set({ 'test-user': TestUser.OtherOrganizationDeviceManager })
             .send({ claimData })
             .expect(HttpStatus.OK);
+
+        await sleep(10000);
 
         await request(app.getHttpServer())
             .get(`/certificate/${id}`)


### PR DESCRIPTION
Fixes:
1. `TransferBatch` and `ClaimBatch` was listening to the wrong on-chain event
2. Remove double syncing certificates - only sync certificates when a blockchain event is detected
3. Sync certificates from an event instead of an internal `sync()` function
4. Wait for transactions to be mined before sending a confirmation