### PR TITLE
feat(origin-device-registry-irec-local-api): added postalCode, country, region, subregion fields to irec devices

### DIFF
--- a/packages/devices/origin-device-registry-irec-local-api/migrations/1622016360883-RegionSubregion.ts
+++ b/packages/devices/origin-device-registry-irec-local-api/migrations/1622016360883-RegionSubregion.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RegionSubregion1622016360883 implements MigrationInterface {
+    name = 'RegionSubregion1622016360883';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "irec_device_registry_device" ADD "postalCode" character varying NOT NULL`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "irec_device_registry_device" ADD "country" character varying NOT NULL`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "irec_device_registry_device" ADD "region" character varying NOT NULL`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "irec_device_registry_device" ADD "subregion" character varying NOT NULL`
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "irec_device_registry_device" DROP COLUMN "subregion"`
+        );
+        await queryRunner.query(`ALTER TABLE "irec_device_registry_device" DROP COLUMN "region"`);
+        await queryRunner.query(`ALTER TABLE "irec_device_registry_device" DROP COLUMN "country"`);
+        await queryRunner.query(
+            `ALTER TABLE "irec_device_registry_device" DROP COLUMN "postalCode"`
+        );
+    }
+}

--- a/packages/devices/origin-device-registry-irec-local-api/src/device/device.entity.ts
+++ b/packages/devices/origin-device-registry-irec-local-api/src/device/device.entity.ts
@@ -1,9 +1,12 @@
 import { DeviceState } from '@energyweb/issuer-irec-api-wrapper';
 import { ExtendedBaseEntity } from '@energyweb/origin-backend-utils';
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { IsString } from 'class-validator';
+
+import { DeviceDTO } from './dto';
 
 @Entity({ name: 'irec_device_registry_device' })
-export class Device extends ExtendedBaseEntity {
+export class Device extends ExtendedBaseEntity implements DeviceDTO {
     constructor(device: Partial<Device>) {
         super();
         Object.assign(this, device);
@@ -68,4 +71,20 @@ export class Device extends ExtendedBaseEntity {
 
     @Column({ nullable: true })
     gridOperator: string;
+
+    @Column()
+    @IsString()
+    postalCode: string;
+
+    @Column()
+    @IsString()
+    country: string;
+
+    @Column()
+    @IsString()
+    region: string;
+
+    @Column({ default: '' })
+    @IsString()
+    subregion: string;
 }

--- a/packages/devices/origin-device-registry-irec-local-api/src/device/dto/create-device.dto.ts
+++ b/packages/devices/origin-device-registry-irec-local-api/src/device/dto/create-device.dto.ts
@@ -93,6 +93,28 @@ export class CreateDeviceDTO {
     @Expose()
     gridOperator: string;
 
+    @ApiProperty({ type: String })
+    @IsString()
+    @Expose()
+    postalCode: string;
+
+    @ApiProperty({ type: String })
+    @IsString()
+    @IsISO31661Alpha2()
+    @Expose()
+    country: string;
+
+    @ApiProperty({ type: String })
+    @IsString()
+    @Expose()
+    region: string;
+
+    @ApiProperty({ type: String })
+    @IsString()
+    @IsOptional()
+    @Expose()
+    subregion: string;
+
     public static sanitize(device: CreateDeviceDTO): CreateDeviceDTO {
         return plainToClass(CreateDeviceDTO, device, { excludeExtraneousValues: true });
     }

--- a/packages/devices/origin-device-registry-irec-local-api/src/device/dto/device.dto.ts
+++ b/packages/devices/origin-device-registry-irec-local-api/src/device/dto/device.dto.ts
@@ -18,4 +18,20 @@ export class DeviceDTO extends IrecDeviceDTO {
     @ApiProperty({ type: String })
     @Expose()
     gridOperator: string;
+
+    @ApiProperty({ type: String })
+    @Expose()
+    postalCode: string;
+
+    @ApiProperty({ type: String })
+    @Expose()
+    country: string;
+
+    @ApiProperty({ type: String })
+    @Expose()
+    region: string;
+
+    @ApiProperty({ type: String })
+    @Expose()
+    subregion: string;
 }

--- a/packages/devices/origin-device-registry-irec-local-api/src/device/dto/import-irec-device.dto.ts
+++ b/packages/devices/origin-device-registry-irec-local-api/src/device/dto/import-irec-device.dto.ts
@@ -13,4 +13,20 @@ export class ImportIrecDeviceDTO {
     @ApiProperty({ type: String })
     @Expose()
     gridOperator: string;
+
+    @ApiProperty({ type: String })
+    @Expose()
+    postalCode: string;
+
+    @ApiProperty({ type: String })
+    @Expose()
+    country: string;
+
+    @ApiProperty({ type: String })
+    @Expose()
+    region: string;
+
+    @ApiProperty({ type: String })
+    @Expose()
+    subregion: string;
 }

--- a/packages/devices/origin-device-registry-irec-local-api/test/device.e2e-spec.ts
+++ b/packages/devices/origin-device-registry-irec-local-api/test/device.e2e-spec.ts
@@ -32,7 +32,11 @@ describe('Device e2e tests', () => {
         latitude: '10',
         longitude: '10',
         gridOperator: 'OP',
-        timezone: 'Asia/Bangkok'
+        timezone: 'Asia/Bangkok',
+        postalCode: '12345',
+        country: 'TH',
+        region: 'Some place',
+        subregion: 'Another place'
     };
 
     before(async () => {
@@ -162,7 +166,15 @@ describe('Device e2e tests', () => {
 
         const { body: createdDevice } = await test
             .post('/irec/device-registry/import-irec-device')
-            .send({ code: deviceToImport.code, timezone: 'some', gridOperator: 'some' })
+            .send({
+                code: deviceToImport.code,
+                timezone: 'some',
+                gridOperator: 'some',
+                country: 'TH',
+                postalCode: '12345',
+                region: 'Shire',
+                subregion: 'Hobbiton'
+            })
             .set({ 'test-user': TestUser.OrganizationAdmin });
 
         expect(createdDevice.id).to.be.a('string');

--- a/packages/ui/origin-ui-irec-core/src/components/Modal/ImportDeviceModal.tsx
+++ b/packages/ui/origin-ui-irec-core/src/components/Modal/ImportDeviceModal.tsx
@@ -21,7 +21,11 @@ const INITIAL_VALUES = {
     timezone: '',
     gridOperator: '',
     smartMeterId: '',
-    description: ''
+    description: '',
+    country: '',
+    postalCode: '',
+    region: '',
+    subregion: ''
 };
 
 export function ImportDeviceModal(props: {
@@ -85,7 +89,11 @@ export function ImportDeviceModal(props: {
         description: device?.description ?? '',
         smartMeterId: device?.smartMeterId ?? '',
         gridOperator: device?.gridOperator ?? '',
-        timezone: device?.timezone ?? ''
+        timezone: device?.timezone ?? '',
+        country: device?.country ?? '',
+        postalCode: device?.postalCode ?? '',
+        region: device?.region ?? '',
+        subregion: device?.subregion ?? ''
     };
 
     async function submitForm(
@@ -100,7 +108,11 @@ export function ImportDeviceModal(props: {
                 const irecResponse = await iRecClient.importIrecDevice({
                     code: device.code,
                     timezone: values.timezone,
-                    gridOperator: values.gridOperator
+                    gridOperator: values.gridOperator,
+                    country: values.country,
+                    postalCode: values.postalCode,
+                    region: values.region,
+                    subregion: values.subregion
                 });
 
                 localIrecDevice = irecResponse.data;

--- a/packages/ui/origin-ui-irec-core/src/containers/Device/RegisterDevice.tsx
+++ b/packages/ui/origin-ui-irec-core/src/containers/Device/RegisterDevice.tsx
@@ -47,6 +47,10 @@ interface IFormValues {
     longitude: string;
     supported: boolean;
     projectStory: string;
+    country: string;
+    postalCode: string;
+    region: string;
+    subregion: string;
 }
 
 const INITIAL_FORM_VALUES: IFormValues = {
@@ -58,7 +62,11 @@ const INITIAL_FORM_VALUES: IFormValues = {
     latitude: '',
     longitude: '',
     supported: false,
-    projectStory: ''
+    projectStory: '',
+    country: '',
+    postalCode: '',
+    region: '',
+    subregion: ''
 };
 
 const useStyles = makeStyles(() =>
@@ -180,7 +188,11 @@ export const RegisterDevice = () => {
                 smartMeterId: '',
                 description: values.projectStory,
                 externalDeviceIds,
-                imageIds: ['']
+                imageIds: [''],
+                country: values.country,
+                postalCode: values.postalCode,
+                region: values.region,
+                subregion: values.subregion
             })
         );
         formikActions.setSubmitting(false);

--- a/packages/ui/origin-ui-irec-core/src/types/ComposedDevice.ts
+++ b/packages/ui/origin-ui-irec-core/src/types/ComposedDevice.ts
@@ -27,6 +27,10 @@ export type ComposedDevice = {
     description: string;
     externalDeviceIds?: IExternalDeviceId[];
     imageIds?: string[];
+    country: string;
+    postalCode: string;
+    region: string;
+    subregion: string;
 };
 
 export type ComposedPublicDevice = Omit<ComposedDevice, 'defaultAccount'>;

--- a/packages/ui/origin-ui-irec-core/src/types/CreateDevice.ts
+++ b/packages/ui/origin-ui-irec-core/src/types/CreateDevice.ts
@@ -20,4 +20,8 @@ export type CreateDeviceData = {
     description: string;
     externalDeviceIds?: IExternalDeviceId[];
     imageIds: string[];
+    country: string;
+    postalCode: string;
+    region: string;
+    subregion: string;
 };

--- a/packages/ui/origin-ui-irec-core/src/utils/compose.ts
+++ b/packages/ui/origin-ui-irec-core/src/utils/compose.ts
@@ -56,7 +56,11 @@ export function composeImportedDevices(
                 id: '',
                 ownerId: '',
                 timezone: '',
-                gridOperator: ''
+                gridOperator: '',
+                country: '',
+                postalCode: '',
+                region: '',
+                subregion: ''
             };
         })
     ];


### PR DESCRIPTION
This PR contains only schema changes. Frontend inputs in create device and import device forms are still required