### PR TITLE
fix(db-schema): Configuration.id definition

### DIFF
--- a/packages/origin-backend/src/pods/configuration/configuration.entity.ts
+++ b/packages/origin-backend/src/pods/configuration/configuration.entity.ts
@@ -11,8 +11,8 @@ import { IsArray, IsString } from 'class-validator';
 @Entity()
 @Check(`id = 1`)
 export class Configuration extends ExtendedBaseEntity implements IOriginConfiguration {
-    @PrimaryColumn({ type: 'int', default: () => `1`, nullable: false })
-    id: 1;
+    @PrimaryColumn({ type: 'int', default: 1, nullable: false })
+    id: number;
 
     @Column('varchar', { nullable: true })
     @IsString()


### PR DESCRIPTION
current Configuration.id field definition causes the following changes added on every typeorm generated migration:
```
    public async up(queryRunner: QueryRunner): Promise<void> {   
        await queryRunner.query(`ALTER TABLE "configuration" ALTER COLUMN "id" SET DEFAULT 1`);
    }

    public async down(queryRunner: QueryRunner): Promise<void> {
        await queryRunner.query(`ALTER TABLE "configuration" ALTER COLUMN "id" SET DEFAULT '1'`);
    }
```