### PR TITLE
fix: rush prettier command parallel execution

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -33,6 +33,7 @@
             "name": "prettier",
             "commandKind": "global",
             "summary": "Used by the pre-commit Git hook. This command invokes Prettier to reformat staged changes.",
+            "safeForSimultaneousRushProcesses": true,
             "autoinstallerName": "rush-prettier",
             // This will invoke common/autoinstallers/rush-prettier/node_modules/.bin/pretty-quick
             "shellCommand": "pretty-quick --staged"


### PR DESCRIPTION
Fixes `rush prettier` command can't be executed while `rush run:origin` is running, that blocks git commit hook.