### PR TITLE
chore: prettier ignore docs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ package-lock.json
 shrinkwrap.json
 
 .github/workflows/*.yml
+docs/

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -242,7 +242,7 @@ dependencies:
   url-loader: 4.1.1_file-loader@6.2.0+webpack@5.40.0
   uuid: 8.3.2
   vm-browserify: 1.1.2
-  wait-on: 5.2.1
+  wait-on: 6.0.0
   webpack: 5.40.0_webpack-cli@4.7.2
   webpack-cli: 4.7.2_9ea8c6fb2d6dba249f7224b7196a0699
   webpack-dev-server: 3.11.2_webpack-cli@4.7.2+webpack@5.40.0
@@ -30880,19 +30880,19 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
-  /wait-on/5.2.1:
+  /wait-on/6.0.0:
     dependencies:
       axios: 0.21.1
       joi: 17.4.0
       lodash: 4.17.21
       minimist: 1.2.5
-      rxjs: 6.6.7
+      rxjs: 7.1.0
     dev: false
     engines:
-      node: '>=8.9.0'
+      node: '>=10.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-H2F986kNWMU9hKlI9l/ppO6tN8ZSJd35yBljMLa1/vjzWP++Qh6aXyt77/u7ySJFZQqBtQxnvm/xgG48AObXcw==
+      integrity: sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==
   /walker/1.0.7:
     dependencies:
       makeerror: 1.0.11
@@ -33613,7 +33613,7 @@ packages:
       ts-node: 9.1.1_typescript@4.3.4
       typeorm: 0.2.34
       typescript: 4.3.4
-      wait-on: 5.2.1
+      wait-on: 6.0.0
     dev: false
     id: file:projects/exchange.tgz
     name: '@rush-temp/exchange'
@@ -33622,7 +33622,7 @@ packages:
       passport: '*'
       webpack-cli: '*'
     resolution:
-      integrity: sha512-1ZrW3c1OqUeng8sWSuDLqHrZCDrRe7qf5XJ+mDGDNICrMzn7PAZKEErv3ZZoW/SC+jUhEyAar0y6laCl6XhqEw==
+      integrity: sha512-k/io7WCrfCK3pbMbGMamu9jH82Q/x87KKGCxyAC8Bt1/g+m7IE92D3WgyNCUVashWBxFaEC8QbXUfyVeWmAziw==
       tarball: file:projects/exchange.tgz
     version: 0.0.0
   file:projects/issuer-api-client.tgz_22c1a38c599279d324ff82b55ef0a6c8:
@@ -35075,7 +35075,7 @@ specifiers:
   url-loader: 4.1.1
   uuid: 8.3.2
   vm-browserify: 1.1.2
-  wait-on: 5.2.1
+  wait-on: 6.0.0
   webpack: 5.40.0
   webpack-cli: 4.7.2
   webpack-dev-server: 3.11.2

--- a/docs/traceability/contracts/ERC1888/ERC1888.md
+++ b/docs/traceability/contracts/ERC1888/ERC1888.md
@@ -1,23 +1,74 @@
 ## `ERC1888`
 
+
+
+
+
+
 ### `issue(address _to, bytes _validityData, uint256 _topic, uint256 _value, bytes _data) → uint256 id` (external)
+
+
+
+
 
 ### `batchIssue(address _to, bytes[] _validityData, uint256[] _topics, uint256[] _values, bytes[] _data) → uint256[] ids` (external)
 
+
+
+
+
 ### `safeTransferAndClaimFrom(address _from, address _to, uint256 _id, uint256 _value, bytes _data, bytes _claimData)` (external)
+
+
+
+
 
 ### `safeBatchTransferAndClaimFrom(address _from, address _to, uint256[] _ids, uint256[] _values, bytes _data, bytes[] _claimData)` (external)
 
+
+
+
+
 ### `getCertificate(uint256 _id) → address issuer, uint256 topic, bytes validityCall, bytes data` (external)
+
+
+
+
 
 ### `claimedBalanceOf(address _owner, uint256 _id) → uint256` (external)
 
+
+
+
+
 ### `claimedBalanceOfBatch(address[] _owners, uint256[] _ids) → uint256[]` (external)
+
+
+
+
+
 
 ### `IssuanceSingle(address _issuer, uint256 _topic, uint256 _id, uint256 _value)`
 
+
+
+
+
 ### `IssuanceBatch(address _issuer, uint256[] _topics, uint256[] _ids, uint256[] _values)`
+
+
+
+
 
 ### `ClaimSingle(address _claimIssuer, address _claimSubject, uint256 _topic, uint256 _id, uint256 _value, bytes _claimData)`
 
+
+
+
+
 ### `ClaimBatch(address _claimIssuer, address _claimSubject, uint256[] _topics, uint256[] _ids, uint256[] _values, bytes[] _claimData)`
+
+
+
+
+

--- a/docs/traceability/contracts/Issuer.md
+++ b/docs/traceability/contracts/Issuer.md
@@ -2,9 +2,13 @@
 
 Used to manage the request/approve workflow for issuing ERC-1888 certificates.
 
+
+
+
 ### `initialize(uint256 _certificateTopic, address _registry)` (public)
 
 Contructor.
+
 
 Uses the OpenZeppelin `initializer` for upgradeability.
 `_registry` cannot be the zero address.
@@ -13,61 +17,142 @@ Uses the OpenZeppelin `initializer` for upgradeability.
 
 Attaches a private issuance contract to this issuance contract.
 
+
 `_privateIssuer` cannot be the zero address.
 
 ### `getCertificationRequest(uint256 _requestId) → struct Issuer.CertificationRequest` (public)
 
+
+
+
+
 ### `requestCertificationFor(bytes _data, address _owner) → uint256` (public)
+
+
+
+
 
 ### `requestCertificationForBatch(bytes[] _data, address[] _owners) → uint256[]` (public)
 
+
+
+
+
 ### `requestCertification(bytes _data) → uint256` (external)
+
+
+
+
 
 ### `revokeRequest(uint256 _requestId)` (external)
 
+
+
+
+
 ### `revokeCertificate(uint256 _certificateId)` (external)
+
+
+
+
 
 ### `approveCertificationRequest(uint256 _requestId, uint256 _value) → uint256` (public)
 
+
+
+
+
 ### `approveCertificationRequestBatch(uint256[] _requestIds, uint256[] _values) → uint256[]` (public)
+
+
+
+
 
 ### `issue(address _to, uint256 _value, bytes _data) → uint256` (public)
 
 Directly issue a certificate without going through the request/approve procedure manually.
 
+
+
 ### `issueBatch(address[] _to, uint256[] _values, bytes[] _data) → uint256[]` (public)
 
 Directly issue a batch of certificates without going through the request/approve procedure manually.
 
+
+
 ### `isRequestValid(uint256 _requestId) → bool` (external)
 
 Validation for certification requests.
+
 
 Used by other contracts to validate the token.
 `_requestId` has to be an existing ID.
 
 ### `getRegistryAddress() → address` (external)
 
+
+
+
+
 ### `getPrivateIssuerAddress() → address` (external)
+
+
+
+
 
 ### `version() → string` (external)
 
+
+
+
+
 ### `_requestNotApprovedOrRevoked(uint256 _requestId) → bool` (internal)
+
+
+
+
 
 ### `_authorizeUpgrade(address)` (internal)
 
 Needed for OpenZeppelin contract upgradeability.
 
+
 Allow only to the owner of the contract.
+
 
 ### `CertificationRequested(address _owner, uint256 _id)`
 
+
+
+
+
 ### `CertificationRequestedBatch(address[] _owners, uint256[] _id)`
+
+
+
+
 
 ### `CertificationRequestApproved(address _owner, uint256 _id, uint256 _certificateId)`
 
+
+
+
+
 ### `CertificationRequestBatchApproved(address[] _owners, uint256[] _ids, uint256[] _certificateIds)`
+
+
+
+
 
 ### `CertificationRequestRevoked(address _owner, uint256 _id)`
 
+
+
+
+
 ### `CertificateRevoked(uint256 _certificateId)`
+
+
+
+
+

--- a/docs/traceability/contracts/Migrations.md
+++ b/docs/traceability/contracts/Migrations.md
@@ -1,7 +1,26 @@
 ## `Migrations`
 
+
+
+
+
 ### `restricted()`
+
+
+
+
+
 
 ### `setCompleted(uint256 completed)` (public)
 
+
+
+
+
 ### `upgrade(address new_address)` (public)
+
+
+
+
+
+

--- a/docs/traceability/contracts/PrivateIssuer.md
+++ b/docs/traceability/contracts/PrivateIssuer.md
@@ -4,9 +4,12 @@ A privately issued certificate can later be migrated to be public.
 
 Private certificate issuance differ from the public ones in a way that the fungible volumes that are being transferred/claimed are stored off-chain.
 
+
+
 ### `initialize(address _issuer)` (public)
 
 Constructor.
+
 
 Uses the OpenZeppelin `initializer` for upgradeability.
 `_issuer` cannot be the zero address.
@@ -15,56 +18,118 @@ Uses the OpenZeppelin `initializer` for upgradeability.
 
 Get the commitment (proof) for a specific certificate.
 
+
+
 ### `approveCertificationRequestPrivate(uint256 _requestId, bytes32 _commitment) → uint256` (public)
+
+
+
+
 
 ### `issuePrivate(address _to, bytes32 _commitment, bytes _data) → uint256` (public)
 
 Directly issue a private certificate.
 
+
+
 ### `requestPrivateTransfer(uint256 _certificateId, bytes32 _ownerAddressLeafHash)` (external)
 
 Request transferring a certain amount of tokens.
+
+
+
 
 ### `approvePrivateTransfer(uint256 _certificateId, struct PrivateIssuer.Proof[] _proof, bytes32 _previousCommitment, bytes32 _commitment) → bool` (external)
 
 Approve a private transfer of certificates.
 
+
+
 ### `requestMigrateToPublic(uint256 _certificateId, bytes32 _ownerAddressLeafHash) → uint256 _migrationRequestId` (external)
 
 Request the certificate volumes to be migrated from private to public.
+
+
+
 
 ### `requestMigrateToPublicFor(uint256 _certificateId, bytes32 _ownerAddressLeafHash, address _forAddress) → uint256 _migrationRequestId` (external)
 
 Request the certificate volumes to be migrated from private to public for someone else.
 
+
+
+
 ### `getPrivateTransferRequest(uint256 _certificateId) → struct PrivateIssuer.PrivateTransferRequest` (external)
 
 Get the private transfer request that is currently active for a specific certificate.
+
+
 
 ### `getMigrationRequest(uint256 _requestId) → struct PrivateIssuer.RequestStateChange` (external)
 
 Get the migration request.
 
+
+
 ### `getMigrationRequestId(uint256 _certificateId) → uint256 _migrationRequestId` (external)
 
 Get the migration request ID for a specific certificate.
+
+
 
 ### `migrateToPublic(uint256 _requestId, uint256 _volume, string _salt, struct PrivateIssuer.Proof[] _proof)` (external)
 
 Migrate a private certificate to be public.
 
+
+
+
 ### `_authorizeUpgrade(address)` (internal)
+
+
+
+
 
 ### `getIssuerAddress() → address` (external)
 
+
+
+
+
 ### `version() → string` (external)
+
+
+
+
+
 
 ### `PrivateCertificationRequestApproved(address _owner, uint256 _id, uint256 _certificateId)`
 
+
+
+
+
 ### `CommitmentUpdated(address _owner, uint256 _id, bytes32 _commitment)`
+
+
+
+
 
 ### `MigrateToPublicRequested(address _owner, uint256 _id)`
 
+
+
+
+
 ### `PrivateTransferRequested(address _owner, uint256 _certificateId)`
 
+
+
+
+
 ### `CertificateMigratedToPublic(uint256 _certificateId, address _owner, uint256 _amount)`
+
+
+
+
+

--- a/docs/traceability/contracts/Registry.md
+++ b/docs/traceability/contracts/Registry.md
@@ -1,19 +1,28 @@
 ## `Registry`
 
+
+
 Also complies to ERC-1155: https://eips.ethereum.org/EIPS/eip-1155.
-\*\* Data set to 0 because there is no meaningful check yet to be done on the data
+** Data set to 0 because there is no meaningful check yet to be done on the data
+
 
 ### `constructor(string _uri)` (public)
+
+
+
+
 
 ### `issue(address _to, bytes _validityData, uint256 _topic, uint256 _value, bytes _data) → uint256 id` (external)
 
 See {IERC1888-issue}.
+
 
 `_to` cannot be the zero address.
 
 ### `batchIssue(address _to, bytes[] _validityData, uint256[] _topics, uint256[] _values, bytes[] _data) → uint256[] ids` (external)
 
 See {IERC1888-batchIssue}.
+
 
 `_to` cannot be the zero address.
 `_data`, `_values` and `_validityData` must have the same length.
@@ -22,7 +31,8 @@ See {IERC1888-batchIssue}.
 
 Similar to {IERC1888-batchIssue}, but not a part of the ERC-1888 standard.
 
-Allows batch issuing to an array of \_to addresses.
+
+Allows batch issuing to an array of _to addresses.
 `_to` cannot be the zero addresses.
 `_to`, `_data`, `_values`, `_topics` and `_validityData` must have the same length.
 
@@ -30,12 +40,14 @@ Allows batch issuing to an array of \_to addresses.
 
 Allows the issuer to mint more fungible tokens for existing ERC-188 certificates.
 
-Allows batch issuing to an array of \_to addresses.
+
+Allows batch issuing to an array of _to addresses.
 `_to` cannot be the zero address.
 
 ### `safeTransferAndClaimFrom(address _from, address _to, uint256 _id, uint256 _value, bytes _data, bytes _claimData)` (external)
 
 See {IERC1888-safeTransferAndClaimFrom}.
+
 
 `_to` cannot be the zero address.
 `_from` has to have a balance above or equal `_value`.
@@ -44,6 +56,7 @@ See {IERC1888-safeTransferAndClaimFrom}.
 
 See {IERC1888-safeBatchTransferAndClaimFrom}.
 
+
 `_to` and `_from` cannot be the zero addresses.
 `_from` has to have a balance above 0.
 
@@ -51,18 +64,30 @@ See {IERC1888-safeBatchTransferAndClaimFrom}.
 
 See {IERC1888-getCertificate}.
 
+
+
 ### `claimedBalanceOf(address _owner, uint256 _id) → uint256` (external)
 
 See {IERC1888-claimedBalanceOf}.
+
+
 
 ### `claimedBalanceOfBatch(address[] _owners, uint256[] _ids) → uint256[]` (external)
 
 See {IERC1888-claimedBalanceOfBatch}.
 
+
+
 ### `_burn(address _from, uint256 _id, uint256 _value)` (internal)
 
 Burn certificates after they've been claimed, and increase the claimed balance.
 
+
+
 ### `_validate(address _verifier, bytes _validityData)` (internal)
 
 Validate if the certificate is valid against an external `_verifier` contract.
+
+
+
+


### PR DESCRIPTION
Prettier keeps re-formatting the docs generated by `solidity-docgen` (removes blank rows) and then generates changes on each branch.
This should stop it from happening on every branch build.