### PR TITLE
fix: Claim data number overflow

### DIFF
--- a/packages/traceability/issuer-api/src/pods/certificate/dto/claim.dto.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/dto/claim.dto.ts
@@ -1,7 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IClaim } from '@energyweb/issuer';
-import { IsInt, IsPositive, IsString, ValidateNested } from 'class-validator';
+import { Validate, IsInt, IsPositive, IsString, ValidateNested } from 'class-validator';
 import { ClaimDataDTO } from '../commands/claim-data.dto';
+import { IntUnitsOfEnergy } from '@energyweb/origin-backend-utils';
 
 export class ClaimDTO implements IClaim {
     @ApiProperty({ type: Number })
@@ -17,15 +18,13 @@ export class ClaimDTO implements IClaim {
     @IsString()
     to: string;
 
-    @ApiProperty({ type: Number })
-    @IsInt()
-    @IsPositive()
-    topic: number;
+    @ApiProperty({ type: String })
+    @IsString()
+    topic: string;
 
-    @ApiProperty({ type: Number })
-    @IsInt()
-    @IsPositive()
-    value: number;
+    @ApiProperty({ type: String })
+    @Validate(IntUnitsOfEnergy)
+    value: string;
 
     @ApiProperty({ type: ClaimDataDTO })
     @ValidateNested()

--- a/packages/traceability/issuer-api/test/certificate.e2e-spec.ts
+++ b/packages/traceability/issuer-api/test/certificate.e2e-spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-expressions */
-import { IClaim, IClaimData } from '@energyweb/issuer';
+import { IClaimData } from '@energyweb/issuer';
 import { DatabaseService } from '@energyweb/origin-backend-utils';
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import { expect } from 'chai';
@@ -17,6 +17,7 @@ import {
     TestUser,
     testUsers
 } from './issuer-api';
+import { ClaimDTO } from '../src';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -198,11 +199,11 @@ describe('Certificate tests', () => {
         expect(energy.claimedVolume).to.equal(certificateTestData.energy);
         expect(
             myClaims.some(
-                (claim: IClaim) =>
+                (claim: ClaimDTO) =>
                     claim.to === deviceManager.address &&
                     claim.from === deviceManager.address &&
                     JSON.stringify(claim.claimData) === JSON.stringify(claimData) &&
-                    claim.value === parseInt(certificateTestData.energy, 10)
+                    claim.value === certificateTestData.energy
             )
         ).to.be.true;
         expect(claims).to.deep.equal(myClaims);
@@ -234,11 +235,11 @@ describe('Certificate tests', () => {
         expect(energy.claimedVolume).to.equal(amountToClaim);
         expect(
             myClaims.some(
-                (claim: IClaim) =>
+                (claim: ClaimDTO) =>
                     claim.to === deviceManager.address &&
                     claim.from === deviceManager.address &&
                     JSON.stringify(claim.claimData) === JSON.stringify(claimData) &&
-                    claim.value === parseInt(amountToClaim, 10)
+                    claim.value === amountToClaim
             )
         ).to.be.true;
     });
@@ -246,7 +247,7 @@ describe('Certificate tests', () => {
     it('should return all claiming information', async () => {
         const { id: certificateId } = await createCertificate();
 
-        const amount = parseInt(certificateTestData.energy, 10) / 2;
+        const amount = BigNumber.from(certificateTestData.energy).div(2).toString();
 
         await request(app.getHttpServer())
             .put(`/certificate/${certificateId}/transfer`)
@@ -278,20 +279,20 @@ describe('Certificate tests', () => {
         expect(claims).to.have.length(2);
         expect(
             claims.some(
-                (claim: IClaim) =>
+                (claim: ClaimDTO) =>
                     claim.to === deviceManager.address &&
                     claim.from === deviceManager.address &&
                     JSON.stringify(claim.claimData) === JSON.stringify(claimData) &&
-                    claim.value === amount
+                    claim.value === amount.toString()
             )
         ).to.be.true;
         expect(
             claims.some(
-                (claim: IClaim) =>
+                (claim: ClaimDTO) =>
                     claim.to === otherDeviceManager.address &&
                     claim.from === otherDeviceManager.address &&
                     JSON.stringify(claim.claimData) === JSON.stringify(claimData) &&
-                    claim.value === amount
+                    claim.value === amount.toString()
             )
         ).to.be.true;
     });
@@ -325,11 +326,11 @@ describe('Certificate tests', () => {
         expect(certificate1.energy.claimedVolume).to.equal(certificateTestData.energy);
         expect(
             certificate1.myClaims.some(
-                (claim: IClaim) =>
+                (claim: ClaimDTO) =>
                     claim.to === deviceManager.address &&
                     claim.from === deviceManager.address &&
                     JSON.stringify(claim.claimData) === JSON.stringify(claimData) &&
-                    claim.value === parseInt(certificateTestData.energy, 10)
+                    claim.value === certificateTestData.energy
             )
         ).to.be.true;
 
@@ -344,11 +345,11 @@ describe('Certificate tests', () => {
         expect(certificate2.energy.claimedVolume).to.equal(certificateTestData.energy);
         expect(
             certificate2.myClaims.some(
-                (claim: IClaim) =>
+                (claim: ClaimDTO) =>
                     claim.to === deviceManager.address &&
                     claim.from === deviceManager.address &&
                     JSON.stringify(claim.claimData) === JSON.stringify(claimData) &&
-                    claim.value === parseInt(certificateTestData.energy, 10)
+                    claim.value === certificateTestData.energy
             )
         ).to.be.true;
     });
@@ -599,11 +600,11 @@ describe('Certificate tests', () => {
                 expect(energy.claimedVolume).to.equal(value);
                 expect(
                     myClaims.some(
-                        (claim: IClaim) =>
+                        (claim: ClaimDTO) =>
                             claim.to === deviceManager.address &&
                             claim.from === deviceManager.address &&
                             JSON.stringify(claim.claimData) === JSON.stringify(claimData) &&
-                            claim.value === parseInt(value, 10)
+                            claim.value === value
                     )
                 ).to.be.true;
                 expect(latestCommitment.commitment[deviceManager.address]).to.equal('0');

--- a/packages/traceability/issuer/src/blockchain-facade/Certificate.ts
+++ b/packages/traceability/issuer/src/blockchain-facade/Certificate.ts
@@ -41,8 +41,8 @@ export interface IClaim {
     id: number;
     from: string;
     to: string;
-    topic: number;
-    value: number;
+    topic: string; // BigNumber string
+    value: string; // BigNumber string
     claimData: IClaimData;
 }
 
@@ -315,8 +315,8 @@ export class Certificate implements ICertificate {
                     id: _id.toNumber(),
                     from: _claimIssuer,
                     to: _claimSubject,
-                    topic: _topic.toNumber(),
-                    value: _value.toNumber(),
+                    topic: _topic.toString(),
+                    value: _value.toString(),
                     claimData
                 });
             }
@@ -342,8 +342,8 @@ export class Certificate implements ICertificate {
                     id: _ids[index].toNumber(),
                     from: _claimIssuer,
                     to: _claimSubject,
-                    topic: _topics[index]?.toNumber(),
-                    value: _values[index].toNumber(),
+                    topic: _topics[index]?.toString(),
+                    value: _values[index].toString(),
                     claimData
                 });
             }


### PR DESCRIPTION
Casting claim data `toNumber()` caused some big number overflows. Cast to string instead.

Merging into https://github.com/energywebfoundation/origin/pull/2518 to automatically work with batch claims.