### PR TITLE
feat(issuer): Allow the Issuer contract to mint more tokens

### DIFF
--- a/docs/traceability/contracts/Issuer.md
+++ b/docs/traceability/contracts/Issuer.md
@@ -80,6 +80,13 @@ Directly issue a batch of certificates without going through the request/approve
 
 
 
+### `mint(address _to, uint256 _certificateId, uint256 _volume)` (external)
+
+Mint more volume to existing certificates
+
+
+
+
 ### `isRequestValid(uint256 _requestId) → bool` (external)
 
 Validation for certification requests.
@@ -151,6 +158,12 @@ Allow only to the owner of the contract.
 
 
 ### `CertificateRevoked(uint256 _certificateId)`
+
+
+
+
+
+### `CertificateVolumeMinted(address _owner, uint256 _certificateId, uint256 _volume)`
 
 
 

--- a/packages/traceability/issuer/contracts/Issuer.sol
+++ b/packages/traceability/issuer/contracts/Issuer.sol
@@ -17,6 +17,7 @@ contract Issuer is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     event CertificationRequestRevoked(address indexed _owner, uint256 indexed _id);
 
     event CertificateRevoked(uint256 indexed _certificateId);
+    event CertificateVolumeMinted(address indexed _owner, uint256 indexed _certificateId, uint256 indexed _volume);
 
     // Certificate topic - check ERC-1888 topic description
     uint256 public certificateTopic;
@@ -230,6 +231,16 @@ contract Issuer is Initializable, OwnableUpgradeable, UUPSUpgradeable {
             _values
         );
     }
+
+	/// @notice Mint more volume to existing certificates
+    /// @param _to To whom the volume should be minted.
+	/// @param _certificateId The ID of the certificate.
+	/// @param _volume Volume that should be minted.
+	function mint(address _to, uint256 _certificateId, uint256 _volume) external onlyOwner {
+        registry.mint(_certificateId, _to, _volume);
+
+        emit CertificateVolumeMinted(_to, _certificateId, _volume);
+	}
 
     /// @notice Validation for certification requests.
     /// @dev Used by other contracts to validate the token.

--- a/packages/traceability/issuer/src/blockchain-facade/Certificate.ts
+++ b/packages/traceability/issuer/src/blockchain-facade/Certificate.ts
@@ -278,6 +278,15 @@ export class Certificate implements ICertificate {
         );
     }
 
+    async mint(to: string, volume: BigNumber): Promise<ContractTransaction> {
+        const toAddress = ethers.utils.getAddress(to);
+
+        const { issuer } = this.blockchainProperties;
+        const issuerWithSigner = issuer.connect(this.blockchainProperties.activeUser);
+
+        return issuerWithSigner.mint(toAddress, this.id, volume);
+    }
+
     async revoke(): Promise<ContractTransaction> {
         const { issuer } = this.blockchainProperties;
         const issuerWithSigner = issuer.connect(this.blockchainProperties.activeUser);

--- a/packages/traceability/issuer/test/Issuer.test.ts
+++ b/packages/traceability/issuer/test/Issuer.test.ts
@@ -7,7 +7,7 @@ import { getProviderWithFallback } from '@energyweb/utils-general';
 
 import { Wallet, BigNumber } from 'ethers';
 import { migrateIssuer, migratePrivateIssuer, migrateRegistry } from '../src/migrate';
-import { CertificationRequest, IBlockchainProperties } from '../src';
+import { CertificationRequest, IBlockchainProperties, Certificate } from '../src';
 import { decodeData, encodeData } from '../src/blockchain-facade/CertificateUtils';
 
 describe('Issuer', () => {
@@ -173,6 +173,35 @@ describe('Issuer', () => {
 
         certificationRequest = await certificationRequest.sync();
         assert.isTrue(certificationRequest.revoked);
+    });
+
+    it('issuer should be able to mint more volume to an existing certificate', async () => {
+        setActiveUser(deviceOwnerWallet);
+
+        const volume = BigNumber.from(1e9);
+        let certificationRequest = await createCertificationRequest();
+
+        setActiveUser(issuerWallet);
+        certificationRequest = await certificationRequest.sync();
+
+        const certificateId = await certificationRequest.approve(volume);
+
+        assert.exists(certificationRequest.issuedCertificateTokenId);
+
+        let certificate = await new Certificate(certificateId, blockchainProperties).sync();
+
+        assert.equal(certificate.owners[deviceOwnerWallet.address], volume.toString());
+
+        const additionalVolumeToMint = BigNumber.from(1e9);
+        const mintTx = await certificate.mint(deviceOwnerWallet.address, additionalVolumeToMint);
+        await mintTx.wait();
+
+        certificate = await certificate.sync();
+
+        assert.equal(
+            certificate.owners[deviceOwnerWallet.address],
+            volume.add(additionalVolumeToMint).toString()
+        );
     });
 
     it('issuer should be able to revoke a certificationRequest', async () => {


### PR DESCRIPTION
In order to enable I-REC certificates import functionality, we need to support minting extra volume for already issued certificates.

**The use-case is:**
- on I-REC API there exist a cert of 10MWh energy
- trader account A has 5MWh and trade account B has 5MWh
- trader A enters Origin markets - requests and issues an on-chain cert for 5MWh
- then trader B enters Origin markets - since it has the part of the same cert, it should become the owner of 5MWh under the same cert as trader A

**Implementation**:
- Extend issuer.sol with func to call erc1155 mint function
- This new func should be restricted to owner/issuer account only