### PR TITLE
chore(issuer-api): revert certification requests filtering

### DIFF
--- a/packages/traceability/issuer-api/src/pods/certificate/certificate.controller.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/certificate.controller.ts
@@ -1,6 +1,11 @@
-import moment from 'moment';
-import { BigNumber } from 'ethers';
-import { ApiBearerAuth, ApiBody, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+    ActiveUserGuard,
+    BlockchainAccountGuard,
+    BlockchainAccountDecorator,
+    ExceptionInterceptor,
+    Roles,
+    RolesGuard
+} from '@energyweb/origin-backend-utils';
 import {
     Body,
     Controller,
@@ -19,34 +24,24 @@ import {
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
-
-import {
-    ActiveUserGuard,
-    BlockchainAccountGuard,
-    BlockchainAccountDecorator,
-    ExceptionInterceptor,
-    Roles,
-    RolesGuard
-} from '@energyweb/origin-backend-utils';
 import { Role } from '@energyweb/origin-backend-core';
 
-import {
-    IssueCertificateCommand,
-    IssueCertificateDTO,
-    TransferCertificateCommand,
-    TransferCertificateDTO,
-    ClaimCertificateDTO,
-    ClaimCertificateCommand
-} from './commands';
-import {
-    GetAllCertificatesQuery,
-    GetCertificateQuery,
-    GetAggregateCertifiedEnergyByDeviceIdQuery,
-    GetAllCertificateEventsQuery
-} from './queries';
-import { CertificateDTO } from './dto';
+import { ApiBearerAuth, ApiBody, ApiResponse, ApiTags } from '@nestjs/swagger';
+import moment from 'moment';
+import { BigNumber } from 'ethers';
+import { IssueCertificateCommand } from './commands/issue-certificate.command';
+import { IssueCertificateDTO } from './commands/issue-certificate.dto';
+import { GetAllCertificatesQuery } from './queries/get-all-certificates.query';
+import { GetCertificateQuery } from './queries/get-certificate.query';
+import { TransferCertificateCommand } from './commands/transfer-certificate.command';
+import { TransferCertificateDTO } from './commands/transfer-certificate.dto';
+import { ClaimCertificateDTO } from './commands/claim-certificate.dto';
+import { ClaimCertificateCommand } from './commands/claim-certificate.command';
+import { GetAggregateCertifiedEnergyByDeviceIdQuery } from './queries/get-aggregate-certified-energy-by-device.query';
 import { CertificateEvent } from '../../types';
-import { SuccessResponseDTO } from '../../utils';
+import { GetAllCertificateEventsQuery } from './queries/get-all-certificate-events.query';
+import { CertificateDTO } from './dto/certificate.dto';
+import { SuccessResponseDTO } from '../../utils/success-response.dto';
 import { certificateToDto } from './utils';
 import { Certificate } from './certificate.entity';
 

--- a/packages/traceability/issuer-api/src/pods/certification-request/certification-request.controller.ts
+++ b/packages/traceability/issuer-api/src/pods/certification-request/certification-request.controller.ts
@@ -71,15 +71,8 @@ export class CertificationRequestController {
         type: [CertificationRequestDTO],
         description: 'Returns all Certification Requests'
     })
-    public async getAll(@UserDecorator() user: ILoggedInUser): Promise<CertificationRequestDTO[]> {
-        const fullAccessRoles = [Role.Issuer, Role.Admin];
-        if (fullAccessRoles.some((role) => user.hasRole(role))) {
-            return this.queryBus.execute(new GetAllCertificationRequestsQuery());
-        }
-
-        return this.queryBus.execute(
-            new GetAllCertificationRequestsQuery({ owner: user.blockchainAccountAddress })
-        );
+    public async getAll(): Promise<CertificationRequestDTO[]> {
+        return this.queryBus.execute(new GetAllCertificationRequestsQuery());
     }
 
     @Get('/:certificateId')

--- a/packages/traceability/issuer-api/test/certification-request.e2e-spec.ts
+++ b/packages/traceability/issuer-api/test/certification-request.e2e-spec.ts
@@ -53,53 +53,50 @@ describe('Certification Request tests', () => {
             .expect(HttpStatus.BAD_REQUEST);
     });
 
-    it(`should create a certification request and check listing`, async () => {
-        const {
-            body: { deviceId, fromTime, toTime, created, owner, approved, revoked, files, energy }
-        } = await request(app.getHttpServer())
-            .post('/certification-request')
-            .set({ 'test-user': TestUser.OrganizationDeviceManager })
-            .send(certificationRequestTestData)
-            .expect(HttpStatus.CREATED);
+    [
+        certificationRequestTestData,
+        { ...certificationRequestTestData, to: '0x0089d53f703f7e0843953d48133f74ce247184c2' },
+        { ...certificationRequestTestData, to: '0x7CB57B5A97EABE94205C07890BE4C1AD31E486A8' }
+    ].forEach((certReqData) => {
+        it(`should create a certification request + entry in the DB: ${certReqData.to}`, async () => {
+            const {
+                body: {
+                    deviceId,
+                    fromTime,
+                    toTime,
+                    created,
+                    owner,
+                    approved,
+                    revoked,
+                    files,
+                    energy
+                }
+            } = await request(app.getHttpServer())
+                .post('/certification-request')
+                .set({ 'test-user': TestUser.OrganizationDeviceManager })
+                .send(certReqData)
+                .expect(HttpStatus.CREATED);
 
-        expect(deviceId).to.equal(certificationRequestTestData.deviceId);
-        expect(fromTime).to.equal(certificationRequestTestData.fromTime);
-        expect(toTime).to.equal(certificationRequestTestData.toTime);
-        expect(created).to.be.null;
-        expect(owner).to.equal(getAddress(certificationRequestTestData.to));
-        expect(approved).to.be.false;
-        expect(revoked).to.be.false;
-        expect(JSON.stringify(files)).to.equal(JSON.stringify(certificationRequestTestData.files));
-        expect(energy).to.equal(certificationRequestTestData.energy);
+            expect(deviceId).to.equal(certReqData.deviceId);
+            expect(fromTime).to.equal(certReqData.fromTime);
+            expect(toTime).to.equal(certReqData.toTime);
+            expect(created).to.be.null;
+            expect(owner).to.equal(getAddress(certReqData.to));
+            expect(approved).to.be.false;
+            expect(revoked).to.be.false;
+            expect(JSON.stringify(files)).to.equal(JSON.stringify(certReqData.files));
+            expect(energy).to.equal(certReqData.energy);
 
-        const { body } = await request(app.getHttpServer())
-            .post('/certification-request')
-            .set({ 'test-user': TestUser.OrganizationDeviceManager })
-            .send({
-                ...certificationRequestTestData,
-                to: '0x0089d53f703f7e0843953d48133f74ce247184c2',
-                fromTime: moment().subtract(4, 'month').unix(),
-                toTime: moment().subtract(3, 'month').unix()
-            })
-            .expect(HttpStatus.CREATED);
+            const { body: requests } = await request(app.getHttpServer())
+                .get(`/certification-request`)
+                .set({ 'test-user': TestUser.OrganizationDeviceManager })
+                .expect(HttpStatus.OK);
 
-        const { body: requests } = await request(app.getHttpServer())
-            .get(`/certification-request`)
-            .set({ 'test-user': TestUser.OrganizationDeviceManager })
-            .expect(HttpStatus.OK);
-
-        expect(requests.length).to.equal(1);
-        const cr = requests.find(
-            (req: CertificationRequestDTO) =>
-                req.owner === getAddress(certificationRequestTestData.to)
-        );
-        expect(cr).to.be.not.empty;
-
-        const { body: requests2 } = await request(app.getHttpServer())
-            .get(`/certification-request`)
-            .set({ 'test-user': TestUser.Issuer })
-            .expect(HttpStatus.OK);
-        expect(requests2.length).to.equal(2);
+            const cr = requests.find(
+                (req: CertificationRequestDTO) => req.owner === getAddress(certReqData.to)
+            );
+            expect(cr).to.be.not.empty;
+        });
     });
 
     it('should not be able to request certification request twice for the same time period', async () => {

--- a/packages/traceability/issuer-irec-api/src/pods/certification-request/certification-request.controller.ts
+++ b/packages/traceability/issuer-irec-api/src/pods/certification-request/certification-request.controller.ts
@@ -71,17 +71,8 @@ export class CertificationRequestController {
         type: [FullCertificationRequestDTO],
         description: 'Returns all Certification Requests'
     })
-    public async getAll(
-        @UserDecorator() user: ILoggedInUser
-    ): Promise<FullCertificationRequestDTO[]> {
-        const fullAccessRoles = [Role.Issuer, Role.Admin];
-        if (fullAccessRoles.some((role) => user.hasRole(role))) {
-            return this.queryBus.execute(new GetAllCertificationRequestsQuery());
-        }
-
-        return this.queryBus.execute(
-            new GetAllCertificationRequestsQuery({ owner: user.blockchainAccountAddress })
-        );
+    public async getAll(): Promise<FullCertificationRequestDTO[]> {
+        return this.queryBus.execute(new GetAllCertificationRequestsQuery());
     }
 
     @Get('/:certificateId')

--- a/packages/traceability/issuer-irec-api/test/certification-request.e2e-spec.ts
+++ b/packages/traceability/issuer-irec-api/test/certification-request.e2e-spec.ts
@@ -58,53 +58,50 @@ describe('Certification Request tests', () => {
             .expect(HttpStatus.BAD_REQUEST);
     });
 
-    it(`should create a certification request and check listing`, async () => {
-        const {
-            body: { deviceId, fromTime, toTime, created, owner, approved, revoked, files, energy }
-        } = await request(app.getHttpServer())
-            .post('/irec/certification-request')
-            .set({ 'test-user': TestUser.OrganizationDeviceManager })
-            .send(certificationRequestTestData)
-            .expect(HttpStatus.CREATED);
+    [
+        certificationRequestTestData,
+        { ...certificationRequestTestData, to: '0x0089d53f703f7e0843953d48133f74ce247184c2' },
+        { ...certificationRequestTestData, to: '0x7CB57B5A97EABE94205C07890BE4C1AD31E486A8' }
+    ].forEach((certReqData) => {
+        it(`should create a certification request + entry in the DB: ${certReqData.to}`, async () => {
+            const {
+                body: {
+                    deviceId,
+                    fromTime,
+                    toTime,
+                    created,
+                    owner,
+                    approved,
+                    revoked,
+                    files,
+                    energy
+                }
+            } = await request(app.getHttpServer())
+                .post('/irec/certification-request')
+                .set({ 'test-user': TestUser.OrganizationDeviceManager })
+                .send(certReqData)
+                .expect(HttpStatus.CREATED);
 
-        expect(deviceId).to.equal(certificationRequestTestData.deviceId);
-        expect(fromTime).to.equal(certificationRequestTestData.fromTime);
-        expect(toTime).to.equal(certificationRequestTestData.toTime);
-        expect(created).to.be.null;
-        expect(owner).to.equal(getAddress(certificationRequestTestData.to));
-        expect(approved).to.be.false;
-        expect(revoked).to.be.false;
-        expect(JSON.stringify(files)).to.equal(JSON.stringify(certificationRequestTestData.files));
-        expect(energy).to.equal(certificationRequestTestData.energy);
+            expect(deviceId).to.equal(certReqData.deviceId);
+            expect(fromTime).to.equal(certReqData.fromTime);
+            expect(toTime).to.equal(certReqData.toTime);
+            expect(created).to.be.null;
+            expect(owner).to.equal(getAddress(certReqData.to));
+            expect(approved).to.be.false;
+            expect(revoked).to.be.false;
+            expect(JSON.stringify(files)).to.equal(JSON.stringify(certReqData.files));
+            expect(energy).to.equal(certReqData.energy);
 
-        await request(app.getHttpServer())
-            .post('/irec/certification-request')
-            .set({ 'test-user': TestUser.OrganizationDeviceManager })
-            .send({
-                ...certificationRequestTestData,
-                to: '0x0089d53f703f7e0843953d48133f74ce247184c2',
-                fromTime: moment().subtract(4, 'month').unix(),
-                toTime: moment().subtract(3, 'month').unix()
-            })
-            .expect(HttpStatus.CREATED);
+            const { body: requests } = await request(app.getHttpServer())
+                .get(`/irec/certification-request`)
+                .set({ 'test-user': TestUser.OrganizationDeviceManager })
+                .expect(HttpStatus.OK);
 
-        const { body: requests } = await request(app.getHttpServer())
-            .get(`/irec/certification-request`)
-            .set({ 'test-user': TestUser.OrganizationDeviceManager })
-            .expect(HttpStatus.OK);
-
-        expect(requests.length).to.equal(1);
-        const cr = requests.find(
-            (req: FullCertificationRequestDTO) =>
-                req.owner === getAddress(certificationRequestTestData.to)
-        );
-        expect(cr).to.be.not.empty;
-
-        const { body: requests2 } = await request(app.getHttpServer())
-            .get(`/irec/certification-request`)
-            .set({ 'test-user': TestUser.Issuer })
-            .expect(HttpStatus.OK);
-        expect(requests2.length).to.equal(2);
+            const cr = requests.find(
+                (req: FullCertificationRequestDTO) => req.owner === getAddress(certReqData.to)
+            );
+            expect(cr).to.be.not.empty;
+        });
     });
 
     it('should not be able to request certification request twice for the same time period', async () => {


### PR DESCRIPTION
I removed previously added certification requests filtration by the owner id. I thought that the `owner` field contains an org blockchain address, but it has to be an exchange address. And I can not get the exchange address in this package, also I can not introduce filtering using device ids. Because `issuer-api` package does not depend on any device package.

@JosephBagaric why certification request entity does not have `organizationId` or `userId` fields?
