### PR TITLE
feat/add new core components

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -105,7 +105,7 @@
             "commandKind": "global",
             "name": "storybook",
             "summary": "Launch storybook UI in origin-ui-core package",
-            "shellCommand": "cd packages/ui && rushx nx serve ui-core:storybook",
+            "shellCommand": "cd packages/ui && rushx storybook",
             "safeForSimultaneousRushProcesses": true
         }
         // {

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -128,6 +128,7 @@ dependencies:
   '@types/pg': 8.6.1
   '@types/qs': 6.9.7
   '@types/react': 17.0.1
+  '@types/react-beautiful-dnd': 13.1.0
   '@types/react-dom': 17.0.1
   '@types/react-is': 17.0.0
   '@types/react-router-dom': 5.1.7
@@ -210,6 +211,7 @@ dependencies:
   prettier: 2.3.2
   qs: 6.10.1
   react: 17.0.2
+  react-beautiful-dnd: 13.1.0_react-dom@17.0.2+react@17.0.2
   react-chartjs-2: 3.0.3_chart.js@3.3.2+react@17.0.2
   react-dom: 17.0.2_react@17.0.2
   react-dropzone: 11.3.2_react@17.0.2
@@ -9960,6 +9962,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ==
+  /@types/hoist-non-react-statics/3.3.1:
+    dependencies:
+      '@types/react': 17.0.1
+      hoist-non-react-statics: 3.3.2
+    dev: false
+    resolution:
+      integrity: sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
   /@types/html-minifier-terser/5.1.2:
     dev: false
     resolution:
@@ -10277,6 +10286,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-DF9utM6VjuIaY388R6XWWDs7CIDTH7on1k1yR+hqaL/T4/OqSCW5uij28APq9KI82CZf0/qtBJI+pjvXcOh0kQ==
+  /@types/react-beautiful-dnd/13.1.0:
+    dependencies:
+      '@types/react': 17.0.1
+    dev: false
+    resolution:
+      integrity: sha512-RZUwL3gSkA1m3m553ZZkDk89KBRABMWVE3LK7AoSohmx/APGt8U2GApCNj4pHdPwL/vxzZjwuqf3NtlWquuhVw==
   /@types/react-dom/17.0.1:
     dependencies:
       '@types/react': 17.0.1
@@ -10289,6 +10304,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-A0DQ1YWZ0RG2+PV7neAotNCIh8gZ3z7tQnDJyS2xRPDNtAtSPcJ9YyfMP8be36Ha0kQRzbZCrrTMznA4blqO5g==
+  /@types/react-redux/7.1.18:
+    dependencies:
+      '@types/hoist-non-react-statics': 3.3.1
+      '@types/react': 17.0.1
+      hoist-non-react-statics: 3.3.2
+      redux: 4.1.0
+    dev: false
+    resolution:
+      integrity: sha512-9iwAsPyJ9DLTRH+OFeIrm9cAbIj1i2ANL3sKQFATqnPWRbg+jEFXyZOKHiQK/N86pNRXbb4HRxAxo0SIX1XwzQ==
   /@types/react-router-dom/5.1.7:
     dependencies:
       '@types/history': 4.7.9
@@ -15619,6 +15643,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+  /css-box-model/1.2.1:
+    dependencies:
+      tiny-invariant: 1.1.0
+    dev: false
+    resolution:
+      integrity: sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
   /css-color-names/0.0.4:
     dev: false
     resolution:
@@ -29183,6 +29213,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+  /raf-schd/4.0.3:
+    dev: false
+    resolution:
+      integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
   /ramda/0.21.0:
     dev: false
     resolution:
@@ -29280,6 +29314,23 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  /react-beautiful-dnd/13.1.0_react-dom@17.0.2+react@17.0.2:
+    dependencies:
+      '@babel/runtime': 7.14.8
+      css-box-model: 1.2.1
+      memoize-one: 5.2.1
+      raf-schd: 4.0.3
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-redux: 7.2.4_react-dom@17.0.2+react@17.0.2
+      redux: 4.1.0
+      use-memo-one: 1.1.2_react@17.0.2
+    dev: false
+    peerDependencies:
+      react: ^16.8.5 || ^17.0.0
+      react-dom: ^16.8.5 || ^17.0.0
+    resolution:
+      integrity: sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==
   /react-chartjs-2/3.0.3_chart.js@3.3.2+react@17.0.2:
     dependencies:
       chart.js: 3.3.2
@@ -29561,6 +29612,28 @@ packages:
         optional: true
     resolution:
       integrity: sha512-F17OuiL7CS9HDbNt1vUN5Opk0Ua+r2y2liDGLlZh3mbdc3ANob0mgaWB6TOBdlyMewbgg+qf1keS2aCV1qVWOg==
+  /react-redux/7.2.4_react-dom@17.0.2+react@17.0.2:
+    dependencies:
+      '@babel/runtime': 7.14.8
+      '@types/react-redux': 7.1.18
+      hoist-non-react-statics: 3.3.2
+      loose-envify: 1.4.0
+      prop-types: 15.7.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-is: 16.13.1
+    dev: false
+    peerDependencies:
+      react: ^16.8.3 || ^17
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+    resolution:
+      integrity: sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==
   /react-refresh/0.8.3:
     dev: false
     engines:
@@ -34462,6 +34535,14 @@ packages:
         optional: true
     resolution:
       integrity: sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==
+  /use-memo-one/1.1.2_react@17.0.2:
+    dependencies:
+      react: 17.0.2
+    dev: false
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+    resolution:
+      integrity: sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==
   /use/3.1.1:
     dev: false
     engines:
@@ -39037,6 +39118,7 @@ packages:
       '@types/material-ui': 0.21.9
       '@types/node': 14.17.9
       '@types/react': 17.0.1
+      '@types/react-beautiful-dnd': 13.1.0
       '@types/react-dom': 17.0.1
       '@types/react-is': 17.0.0
       '@types/react-router-dom': 5.1.7
@@ -39073,6 +39155,7 @@ packages:
       lodash: 4.17.21
       prettier: 2.3.2
       react: 17.0.2
+      react-beautiful-dnd: 13.1.0_react-dom@17.0.2+react@17.0.2
       react-chartjs-2: 3.0.3_chart.js@3.3.2+react@17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-dropzone: 11.3.2_react@17.0.2
@@ -39103,7 +39186,7 @@ packages:
     peerDependencies:
       moment: '*'
     resolution:
-      integrity: sha512-5QRgyv/3hW1SqiHfhAz9uQh7kL5EIhHTTtbaRsAMfZe5Ej3+cg2/Hc+o/Xs7yQnjuZKvgXH59HhoAtOBhkcn5Q==
+      integrity: sha512-v76mRwfsZ+jczJ4VV6983C5KUsC2w4bgjYuIsYK/LevOMswsz1GkDu+6BHGLHVCA2ciUbyt8NdFaY82i1TC3SQ==
       tarball: file:projects/ui-packages.tgz
     version: 0.0.0
   file:projects/utils-general.tgz:
@@ -39310,6 +39393,7 @@ specifiers:
   '@types/pg': 8.6.1
   '@types/qs': 6.9.7
   '@types/react': 17.0.1
+  '@types/react-beautiful-dnd': 13.1.0
   '@types/react-dom': 17.0.1
   '@types/react-is': 17.0.0
   '@types/react-router-dom': 5.1.7
@@ -39392,6 +39476,7 @@ specifiers:
   prettier: 2.3.2
   qs: 6.10.1
   react: 17.0.2
+  react-beautiful-dnd: 13.1.0
   react-chartjs-2: 3.0.3
   react-dom: 17.0.2
   react-dropzone: 11.3.2

--- a/packages/ui/.storybook/main.js
+++ b/packages/ui/.storybook/main.js
@@ -1,4 +1,7 @@
 module.exports = {
   stories: [],
   addons: ['@storybook/addon-knobs/register', '@storybook/addon-essentials'],
+  typescript: {
+    reactDocgen: 'none',
+  },
 };

--- a/packages/ui/libs/ui/core/src/components/cardTable/CardTableContent/CardTableContent.styles.ts
+++ b/packages/ui/libs/ui/core/src/components/cardTable/CardTableContent/CardTableContent.styles.ts
@@ -1,0 +1,61 @@
+import { makeStyles } from '@material-ui/core';
+
+export const useStyles = makeStyles((theme) => ({
+  tableWrapper: {
+    maxWidth: 650,
+    maxHeight: '100vh',
+    overflowX: 'auto',
+    [theme.breakpoints.down('lg')]: {
+      maxWidth: 420,
+    },
+    [theme.breakpoints.down('md')]: {
+      maxWidth: 190,
+    },
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: 100,
+    },
+  },
+  table: {
+    borderSpacing: 0,
+    borderCollapse: 'collapse',
+    width: '100%',
+    tableLayout: 'fixed',
+  },
+  tableHeadCell: {
+    width: 210,
+    height: 90,
+    position: 'sticky',
+    top: 0,
+    padding: 0,
+    border: `1px solid ${theme.palette.grey[400]}`,
+    [theme.breakpoints.down('md')]: {
+      width: 190,
+      height: 80,
+    },
+    [theme.breakpoints.down('sm')]: {
+      width: 100,
+      height: 40,
+    },
+  },
+  tableCell: {
+    width: 210,
+    height: 120,
+    padding: 0,
+    border: `1px solid ${theme.palette.grey[400]}`,
+    [theme.breakpoints.down('md')]: {
+      width: 190,
+      height: 110,
+    },
+    [theme.breakpoints.down('sm')]: {
+      width: 100,
+      height: 60,
+    },
+  },
+  tableCellWrapper: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+}));

--- a/packages/ui/libs/ui/core/src/components/cardTable/CardTableContent/CardTableContent.tsx
+++ b/packages/ui/libs/ui/core/src/components/cardTable/CardTableContent/CardTableContent.tsx
@@ -1,0 +1,137 @@
+import React, {
+  DetailedHTMLProps,
+  TableHTMLAttributes,
+  ThHTMLAttributes,
+  TdHTMLAttributes,
+  HTMLAttributes,
+  PropsWithChildren,
+  ReactElement,
+} from 'react';
+import { useStyles } from './CardTableContent.styles';
+
+export type CardTableHeader<Id> = {
+  id: Id;
+  component: React.FC<{ id: Id }>;
+};
+
+export type CardTableItem<HeaderId, VerticalHeaderId> = {
+  headerId: HeaderId;
+  verticalHeaderId: VerticalHeaderId;
+  component: React.FC<{
+    headerId: HeaderId;
+    verticalHeaderId: VerticalHeaderId;
+  }>;
+};
+
+export interface CardTableContentProps<HeaderId, VerticalHeaderId> {
+  headers: CardTableHeader<HeaderId>[];
+  rows: CardTableItem<HeaderId, VerticalHeaderId>[][];
+  tableWrapperProps?: DetailedHTMLProps<
+    HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >;
+  tableProps?: DetailedHTMLProps<
+    TableHTMLAttributes<HTMLTableElement>,
+    HTMLTableElement
+  >;
+  tableHeadCellProps?: DetailedHTMLProps<
+    ThHTMLAttributes<HTMLTableHeaderCellElement>,
+    HTMLTableHeaderCellElement
+  >;
+  tableCellProps?: DetailedHTMLProps<
+    TdHTMLAttributes<HTMLTableHeaderCellElement>,
+    HTMLTableHeaderCellElement
+  >;
+  cellContentWrapperProps?: DetailedHTMLProps<
+    HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >;
+}
+
+export type TCardTableContent = <HeaderId, VerticalHeaderId>(
+  props: PropsWithChildren<CardTableContentProps<HeaderId, VerticalHeaderId>>
+) => ReactElement;
+
+export const CardTableContent: TCardTableContent = ({
+  headers,
+  rows,
+  tableWrapperProps,
+  tableProps,
+  tableHeadCellProps,
+  tableCellProps,
+  cellContentWrapperProps,
+}) => {
+  const classes = useStyles();
+  const { className: tableWrapperClass, ...restTableWrapperProps } =
+    tableWrapperProps || {};
+  const { className: tableClass, ...restTableProps } = tableProps || {};
+  const { className: tableHeadCellClass, ...restTableHeadCellProps } =
+    tableHeadCellProps || {};
+  const { className: cellContentWrapperClass, ...restCellContentWrapperProps } =
+    cellContentWrapperProps || {};
+  const { className: tableCellClass, ...restTableCellProps } =
+    tableCellProps || {};
+  return (
+    <div
+      className={`${classes.tableWrapper} ${tableWrapperClass}`}
+      {...restTableWrapperProps}
+    >
+      <table
+        cellSpacing="0"
+        className={`${classes.table} ${tableClass}`}
+        {...restTableProps}
+      >
+        <thead>
+          <tr>
+            {headers.map((header) => {
+              const { component: Component } = header;
+              return (
+                <th
+                  className={`${classes.tableHeadCell} ${tableHeadCellClass}`}
+                  key={`${header.id}`}
+                  {...restTableHeadCellProps}
+                >
+                  <div
+                    className={`${classes.tableCellWrapper} ${cellContentWrapperClass}`}
+                    {...restCellContentWrapperProps}
+                  >
+                    {Component ? <Component id={header.id} /> : null}
+                  </div>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={`row-${row[0].verticalHeaderId}`}>
+              {headers.map((header) => {
+                const cellData = row.find((row) => row.headerId === header.id);
+                const { component: Component } = cellData;
+                return (
+                  <td
+                    className={`${classes.tableCell} ${tableCellClass}`}
+                    key={`cell-${cellData.verticalHeaderId}-${cellData.headerId}`}
+                    {...restTableCellProps}
+                  >
+                    <div
+                      className={`${classes.tableCellWrapper} ${cellContentWrapperClass}`}
+                      {...restCellContentWrapperProps}
+                    >
+                      {Component ? (
+                        <Component
+                          headerId={cellData.headerId}
+                          verticalHeaderId={cellData.verticalHeaderId}
+                        />
+                      ) : null}
+                    </div>
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/packages/ui/libs/ui/core/src/components/cardTable/CardTableContent/index.ts
+++ b/packages/ui/libs/ui/core/src/components/cardTable/CardTableContent/index.ts
@@ -1,0 +1,1 @@
+export * from './CardTableContent';

--- a/packages/ui/libs/ui/core/src/components/cardTable/CardTableTotalColumn/CardTableTotalColumn.styles.ts
+++ b/packages/ui/libs/ui/core/src/components/cardTable/CardTableTotalColumn/CardTableTotalColumn.styles.ts
@@ -1,0 +1,46 @@
+import { makeStyles } from '@material-ui/core';
+
+export const useStyles = makeStyles((theme) => ({
+  table: {
+    borderSpacing: 0,
+    borderCollapse: 'collapse',
+    tableLayout: 'fixed',
+  },
+  tableHeadCell: {
+    width: 210,
+    height: 90,
+    position: 'sticky',
+    top: 0,
+    padding: 0,
+    border: `1px solid ${theme.palette.grey[400]}`,
+    [theme.breakpoints.down('md')]: {
+      width: 190,
+      height: 80,
+    },
+    [theme.breakpoints.down('sm')]: {
+      width: 100,
+      height: 40,
+    },
+  },
+  tableCell: {
+    width: 210,
+    height: 120,
+    padding: 0,
+    border: `1px solid ${theme.palette.grey[400]}`,
+    [theme.breakpoints.down('md')]: {
+      width: 190,
+      height: 105,
+    },
+    [theme.breakpoints.down('sm')]: {
+      width: 100,
+      height: 60,
+    },
+  },
+  totalCellWrapper: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+}));

--- a/packages/ui/libs/ui/core/src/components/cardTable/CardTableTotalColumn/CardTableTotalColumn.tsx
+++ b/packages/ui/libs/ui/core/src/components/cardTable/CardTableTotalColumn/CardTableTotalColumn.tsx
@@ -1,0 +1,98 @@
+import React, {
+  ReactNode,
+  DetailedHTMLProps,
+  TableHTMLAttributes,
+  ThHTMLAttributes,
+  TdHTMLAttributes,
+  HTMLAttributes,
+  PropsWithChildren,
+  ReactElement,
+} from 'react';
+import { useStyles } from './CardTableTotalColumn.styles';
+
+export type TTotalItem<Id> = {
+  id: Id;
+  component: React.FC<{ id: Id }>;
+};
+
+export interface CardTableTotalColumnProps<Id> {
+  header: ReactNode;
+  totalItems: TTotalItem<Id>[];
+  tableProps?: DetailedHTMLProps<
+    TableHTMLAttributes<HTMLTableElement>,
+    HTMLTableElement
+  >;
+  tableHeadCellProps?: DetailedHTMLProps<
+    ThHTMLAttributes<HTMLTableHeaderCellElement>,
+    HTMLTableHeaderCellElement
+  >;
+  tableCellProps?: DetailedHTMLProps<
+    TdHTMLAttributes<HTMLTableHeaderCellElement>,
+    HTMLTableHeaderCellElement
+  >;
+  cellContentWrapperProps?: DetailedHTMLProps<
+    HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >;
+}
+
+export type TCardTableTotalColumn = <Id>(
+  props: PropsWithChildren<CardTableTotalColumnProps<Id>>
+) => ReactElement;
+
+export const CardTableTotalColumn: TCardTableTotalColumn = ({
+  header,
+  totalItems,
+  tableProps,
+  tableHeadCellProps,
+  tableCellProps,
+  cellContentWrapperProps,
+}) => {
+  const classes = useStyles();
+  const { className: tableClass, ...restTableProps } = tableProps || {};
+  const { className: tableHeadCellClass, ...restTableHeadProps } =
+    tableHeadCellProps || {};
+  const { className: cellContentWrapperClass, ...restCellContentWrapperProps } =
+    cellContentWrapperProps || {};
+  const { className: tableCellClass, ...restTableCellProps } =
+    tableCellProps || {};
+  return (
+    <table className={`${classes.table} ${tableClass}`} {...restTableProps}>
+      <thead>
+        <tr>
+          <th
+            className={`${classes.tableHeadCell} ${tableHeadCellClass}`}
+            {...restTableHeadProps}
+          >
+            <div
+              className={`${classes.totalCellWrapper} ${cellContentWrapperClass}`}
+              {...restCellContentWrapperProps}
+            >
+              {header}
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {totalItems.map((item) => {
+          const { component: Component } = item;
+          return (
+            <tr key={`total-column-${item.id}`}>
+              <td
+                className={`${classes.tableCell} ${tableCellClass}`}
+                {...restTableCellProps}
+              >
+                <div
+                  className={`${classes.totalCellWrapper} ${cellContentWrapperClass}`}
+                  {...restCellContentWrapperProps}
+                >
+                  {Component ? <Component id={item.id} /> : null}
+                </div>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};

--- a/packages/ui/libs/ui/core/src/components/cardTable/CardTableTotalColumn/index.ts
+++ b/packages/ui/libs/ui/core/src/components/cardTable/CardTableTotalColumn/index.ts
@@ -1,0 +1,1 @@
+export * from './CardTableTotalColumn';

--- a/packages/ui/libs/ui/core/src/components/cardTable/CardTableVerticalHeaders/CardTableVerticalHeaders.styles.ts
+++ b/packages/ui/libs/ui/core/src/components/cardTable/CardTableVerticalHeaders/CardTableVerticalHeaders.styles.ts
@@ -1,0 +1,37 @@
+import { makeStyles } from '@material-ui/core';
+
+export const useStyles = makeStyles((theme) => ({
+  table: {
+    borderSpacing: 0,
+    borderCollapse: 'collapse',
+    tableLayout: 'fixed',
+  },
+  tableHeadCell: {
+    width: 210,
+    height: 90,
+    padding: 0,
+    border: '1px solid transparent',
+    [theme.breakpoints.down('md')]: {
+      width: 190,
+      height: 80,
+    },
+    [theme.breakpoints.down('sm')]: {
+      width: 100,
+      height: 40,
+    },
+  },
+  tableCell: {
+    width: 210,
+    height: 120,
+    padding: 0,
+    border: `1px solid ${theme.palette.grey[400]}`,
+    [theme.breakpoints.down('md')]: {
+      width: 190,
+      height: 80,
+    },
+    [theme.breakpoints.down('sm')]: {
+      width: 100,
+      height: 60,
+    },
+  },
+}));

--- a/packages/ui/libs/ui/core/src/components/cardTable/CardTableVerticalHeaders/CardTableVerticalHeaders.tsx
+++ b/packages/ui/libs/ui/core/src/components/cardTable/CardTableVerticalHeaders/CardTableVerticalHeaders.tsx
@@ -1,0 +1,75 @@
+import React, {
+  DetailedHTMLProps,
+  TableHTMLAttributes,
+  ThHTMLAttributes,
+  TdHTMLAttributes,
+  PropsWithChildren,
+  ReactElement,
+} from 'react';
+import { useStyles } from './CardTableVerticalHeaders.styles';
+
+export type TVerticalHeader<Id> = {
+  id: Id;
+  component: React.FC<{ id: Id }>;
+};
+
+export interface CardTableVerticalHeaders<Id> {
+  verticalHeaders: TVerticalHeader<Id>[];
+  tableProps?: DetailedHTMLProps<
+    TableHTMLAttributes<HTMLTableElement>,
+    HTMLTableElement
+  >;
+  tableHeadCellProps?: DetailedHTMLProps<
+    ThHTMLAttributes<HTMLTableHeaderCellElement>,
+    HTMLTableHeaderCellElement
+  >;
+  tableCellProps?: DetailedHTMLProps<
+    TdHTMLAttributes<HTMLTableHeaderCellElement>,
+    HTMLTableHeaderCellElement
+  >;
+}
+
+export type TCardTableVerticalHeaders = <Id>(
+  props: PropsWithChildren<CardTableVerticalHeaders<Id>>
+) => ReactElement;
+
+export const CardTableVerticalHeaders: TCardTableVerticalHeaders = ({
+  verticalHeaders,
+  tableProps,
+  tableHeadCellProps,
+  tableCellProps,
+}) => {
+  const classes = useStyles();
+  const { className: tableClassName, ...restTableProps } = tableProps || {};
+  const { className: tableHeadClassName, ...restTableHeadProps } =
+    tableHeadCellProps || {};
+  const { className: tableCellClassName, ...restTableCellProps } =
+    tableCellProps || {};
+  return (
+    <table className={`${classes.table} ${tableClassName}`} {...restTableProps}>
+      <thead>
+        <tr>
+          <th
+            className={`${classes.tableHeadCell} ${tableHeadClassName}`}
+            {...restTableHeadProps}
+          />
+        </tr>
+      </thead>
+      <tbody>
+        {verticalHeaders.map((header) => {
+          const { component: Component } = header;
+          return (
+            <tr key={`vertical-header-${header.id}`}>
+              <td
+                className={`${classes.tableCell} ${tableCellClassName}`}
+                {...restTableCellProps}
+              >
+                {Component ? <Component id={header.id} /> : null}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};

--- a/packages/ui/libs/ui/core/src/components/cardTable/CardTableVerticalHeaders/index.ts
+++ b/packages/ui/libs/ui/core/src/components/cardTable/CardTableVerticalHeaders/index.ts
@@ -1,0 +1,1 @@
+export * from './CardTableVerticalHeaders';

--- a/packages/ui/libs/ui/core/src/components/cardTable/index.ts
+++ b/packages/ui/libs/ui/core/src/components/cardTable/index.ts
@@ -1,0 +1,3 @@
+export * from './CardTableVerticalHeaders';
+export * from './CardTableTotalColumn';
+export * from './CardTableContent';

--- a/packages/ui/libs/ui/core/src/components/form/MaterialDatepicker/MaterialDatepicker.tsx
+++ b/packages/ui/libs/ui/core/src/components/form/MaterialDatepicker/MaterialDatepicker.tsx
@@ -1,7 +1,11 @@
 import React, { FC } from 'react';
 import { DateFormatEnum } from '@energyweb/origin-ui-utils';
 import { Box, TextField, TextFieldProps } from '@material-ui/core';
-import { DatePicker, LocalizationProvider } from '@material-ui/lab';
+import {
+  DatePicker,
+  DatePickerProps,
+  LocalizationProvider,
+} from '@material-ui/lab';
 import AdapterDayJs from '@material-ui/lab/AdapterDayjs';
 import { Dayjs } from 'dayjs';
 import { GenericFormField } from '../../../containers';
@@ -17,6 +21,7 @@ export interface MaterialDatepickerProps {
   errorExists?: boolean;
   errorText?: string;
   variant?: TextFieldProps['variant'];
+  datePickerProps?: DatePickerProps;
 }
 
 export const MaterialDatepicker: FC<MaterialDatepickerProps> = ({
@@ -27,6 +32,7 @@ export const MaterialDatepicker: FC<MaterialDatepickerProps> = ({
   errorText,
   variant,
   field,
+  datePickerProps,
 }) => {
   const classes = useStyles();
   const {
@@ -86,9 +92,15 @@ export const MaterialDatepicker: FC<MaterialDatepickerProps> = ({
             variant={variant}
             label={field.label}
             required={field.required}
+            placeholder={field.placeholder || field.label}
+            inputProps={{
+              ...props.inputProps,
+              placeholder: field.placeholder || field.label,
+            }}
             {...field.textFieldProps}
           />
         )}
+        {...datePickerProps}
       />
     </LocalizationProvider>
   );

--- a/packages/ui/libs/ui/core/src/components/index.ts
+++ b/packages/ui/libs/ui/core/src/components/index.ts
@@ -9,3 +9,4 @@ export * from './notification';
 export * from './list';
 export * from './card';
 export * from './buttons';
+export * from './cardTable';

--- a/packages/ui/libs/ui/core/src/components/layout/TimeframeSelect/TimeframeSelect.stories.tsx
+++ b/packages/ui/libs/ui/core/src/components/layout/TimeframeSelect/TimeframeSelect.stories.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { Meta } from '@storybook/react';
+import { TimeframeSelect, TimeframeSelectProps } from './TimeframeSelect';
+import dayjs, { Dayjs } from 'dayjs';
+
+export default {
+  title: 'Layout / TimeframeSelect',
+  component: TimeframeSelect,
+} as Meta;
+
+export const Default = (args: TimeframeSelectProps) => {
+  const [from, setFrom] = useState(dayjs().subtract(1, 'day').startOf('day'));
+  const [to, setTo] = useState(dayjs().endOf('day'));
+  const fromPickerProps: TimeframeSelectProps['fromPickerProps'] = {
+    value: from,
+    onChange: (value: Dayjs) => setFrom(value),
+    field: {
+      name: 'from',
+      label: '',
+      placeholder: 'From date',
+    },
+  };
+  const toPickerProps: TimeframeSelectProps['toPickerProps'] = {
+    value: to,
+    onChange: (value: Dayjs) => setTo(value),
+    field: {
+      name: 'to',
+      label: '',
+      placeholder: 'To date',
+    },
+  };
+
+  return (
+    <TimeframeSelect
+      fromPickerProps={fromPickerProps}
+      toPickerProps={toPickerProps}
+      {...args}
+    />
+  );
+};
+
+Default.args = {
+  title: 'Select timeframe',
+};

--- a/packages/ui/libs/ui/core/src/components/layout/TimeframeSelect/TimeframeSelect.styles.ts
+++ b/packages/ui/libs/ui/core/src/components/layout/TimeframeSelect/TimeframeSelect.styles.ts
@@ -1,0 +1,51 @@
+import { makeStyles } from '@material-ui/core';
+
+export const useStyles = makeStyles((theme) => ({
+  wrapper: {
+    padding: 0,
+  },
+  frame: {
+    height: '100%',
+    flexWrap: 'nowrap',
+    boxSizing: 'border-box',
+    [theme.breakpoints.down('lg')]: {
+      flexWrap: 'wrap',
+    },
+  },
+  titleWrapper: {
+    width: '100%',
+    [theme.breakpoints.down('lg')]: {
+      maxWidth: '100%',
+    },
+  },
+  title: {
+    color: theme.palette.text.primary,
+    fontSize: 18,
+    lineHeight: '27px',
+  },
+  dates: {
+    margin: '0 0 0 19px',
+    width: 'auto',
+    flexWrap: 'nowrap',
+    [theme.breakpoints.down('lg')]: {
+      width: '100%',
+      justifyContent: 'center',
+      margin: '20px 0 0',
+    },
+    [theme.breakpoints.down('md')]: {
+      flexWrap: 'wrap',
+    },
+    [theme.breakpoints.down('sm')]: {
+      margin: '10px 0 0',
+    },
+  },
+  divider: {
+    margin: '0 4px',
+    [theme.breakpoints.down('md')]: {
+      width: '100%',
+      display: 'flex',
+      justifyContent: 'center',
+      margin: '5px 0',
+    },
+  },
+}));

--- a/packages/ui/libs/ui/core/src/components/layout/TimeframeSelect/TimeframeSelect.tsx
+++ b/packages/ui/libs/ui/core/src/components/layout/TimeframeSelect/TimeframeSelect.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import {
   Box,
   BoxProps,
@@ -20,6 +20,7 @@ export interface TimeframeSelectProps {
   containerProps?: GridProps;
   pickersContainerProps?: GridProps;
   dividerProps?: BoxProps;
+  customDivider?: ReactNode;
 }
 
 export const TimeframeSelect: FC<TimeframeSelectProps> = ({
@@ -32,6 +33,7 @@ export const TimeframeSelect: FC<TimeframeSelectProps> = ({
   containerProps,
   pickersContainerProps,
   dividerProps,
+  customDivider,
 }) => {
   const classes = useStyles();
 
@@ -63,7 +65,13 @@ export const TimeframeSelect: FC<TimeframeSelectProps> = ({
           {...pickersContainerProps}
         >
           <MaterialDatepicker {...fromPickerProps} />
-          <Box className={classes.divider} {...dividerProps}></Box>
+
+          {customDivider ? (
+            customDivider
+          ) : (
+            <Box className={classes.divider} {...dividerProps} />
+          )}
+
           <MaterialDatepicker {...toPickerProps} />
         </Grid>
       </Grid>

--- a/packages/ui/libs/ui/core/src/components/layout/TimeframeSelect/TimeframeSelect.tsx
+++ b/packages/ui/libs/ui/core/src/components/layout/TimeframeSelect/TimeframeSelect.tsx
@@ -1,0 +1,72 @@
+import React, { FC } from 'react';
+import {
+  Box,
+  BoxProps,
+  Grid,
+  GridProps,
+  Typography,
+  TypographyProps,
+} from '@material-ui/core';
+import { MaterialDatepicker, MaterialDatepickerProps } from '../../form';
+import { useStyles } from './TimeframeSelect.styles';
+
+export interface TimeframeSelectProps {
+  fromPickerProps: MaterialDatepickerProps;
+  toPickerProps: MaterialDatepickerProps;
+  title?: string;
+  titleProps?: TypographyProps;
+  titleWrapperProps?: BoxProps;
+  wrapperProps?: BoxProps;
+  containerProps?: GridProps;
+  pickersContainerProps?: GridProps;
+  dividerProps?: BoxProps;
+}
+
+export const TimeframeSelect: FC<TimeframeSelectProps> = ({
+  title,
+  fromPickerProps,
+  toPickerProps,
+  titleProps,
+  titleWrapperProps,
+  wrapperProps,
+  containerProps,
+  pickersContainerProps,
+  dividerProps,
+}) => {
+  const classes = useStyles();
+
+  return (
+    <Box className={classes.wrapper} {...wrapperProps}>
+      <Grid
+        className={classes.frame}
+        container
+        alignItems="center"
+        {...containerProps}
+      >
+        {title && (
+          <Box
+            className={classes.titleWrapper}
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            {...titleWrapperProps}
+          >
+            <Typography className={classes.title} {...titleProps}>
+              {title}
+            </Typography>
+          </Box>
+        )}
+        <Grid
+          className={classes.dates}
+          container
+          alignItems="center"
+          {...pickersContainerProps}
+        >
+          <MaterialDatepicker {...fromPickerProps} />
+          <Box className={classes.divider} {...dividerProps}></Box>
+          <MaterialDatepicker {...toPickerProps} />
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};

--- a/packages/ui/libs/ui/core/src/components/layout/TimeframeSelect/index.ts
+++ b/packages/ui/libs/ui/core/src/components/layout/TimeframeSelect/index.ts
@@ -1,0 +1,1 @@
+export * from './TimeframeSelect';

--- a/packages/ui/libs/ui/core/src/components/layout/index.ts
+++ b/packages/ui/libs/ui/core/src/components/layout/index.ts
@@ -10,3 +10,4 @@ export * from './ResponsiveSidebar';
 export * from './BlockTintedBottom';
 export * from './PageNotFound';
 export * from './Requirements';
+export * from './TimeframeSelect';

--- a/packages/ui/libs/ui/core/src/components/list/GenericCardsList/GenericCardsList.effects.ts
+++ b/packages/ui/libs/ui/core/src/components/list/GenericCardsList/GenericCardsList.effects.ts
@@ -1,0 +1,23 @@
+import { DropResult } from 'react-beautiful-dnd';
+
+const reorder = (list: any[], startIndex: number, endIndex: number) => {
+  const [removed] = list.splice(startIndex, 1);
+  list.splice(endIndex, 0, removed);
+  return list;
+};
+
+export const useGenericCardsListEffects = <ItemType>(
+  list?: ItemType[],
+  handleDrag?: (newList: ItemType[]) => Promise<void>
+) => {
+  const onCardDragEnd = async (result: DropResult) => {
+    if (!result.destination || !list || !handleDrag) return;
+    const reorderedList = reorder(
+      list,
+      result.source.index,
+      result.destination.index
+    );
+    await handleDrag(reorderedList);
+  };
+  return { onCardDragEnd };
+};

--- a/packages/ui/libs/ui/core/src/components/list/GenericCardsList/GenericCardsList.styles.ts
+++ b/packages/ui/libs/ui/core/src/components/list/GenericCardsList/GenericCardsList.styles.ts
@@ -1,0 +1,10 @@
+import { makeStyles } from '@material-ui/core';
+
+export const useStyles = makeStyles({
+  skeleton: {
+    height: 160,
+    width: 280,
+    margin: '10px 0',
+    transform: 'none',
+  },
+});

--- a/packages/ui/libs/ui/core/src/components/list/GenericCardsList/GenericCardsList.tsx
+++ b/packages/ui/libs/ui/core/src/components/list/GenericCardsList/GenericCardsList.tsx
@@ -1,0 +1,150 @@
+import React, { PropsWithChildren, ReactElement } from 'react';
+import {
+  Box,
+  Checkbox,
+  FormControlLabel,
+  Grid,
+  Skeleton,
+  Stack,
+  Typography,
+  BoxProps,
+  TypographyProps,
+  CheckboxProps,
+} from '@material-ui/core';
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import { ListCard, CardsListItem } from '../ListCard';
+import { useStyles } from './GenericCardsList.styles';
+import { useGenericCardsListEffects } from './GenericCardsList.effects';
+
+const skeletonList = Array.from(Array(3).keys());
+
+export interface GenericCardsListProps<Id> {
+  checkedIds: Id[];
+  handleCheck: (id: Id) => void;
+  allItems: CardsListItem<Id>[];
+  loading: boolean;
+  listTitle?: string;
+  listTitleProps?: TypographyProps;
+  checkAllText?: string;
+  allChecked?: boolean;
+  handleAllCheck?: () => void;
+  handleDrag?: (newOrder: CardsListItem<Id>[]) => Promise<void>;
+  selectOnCardClick?: boolean;
+  dragNdrop?: boolean;
+  listWrapperProps?: BoxProps;
+  headerWrapperProps?: BoxProps;
+  selectAllCheckboxProps?: CheckboxProps;
+}
+
+export type TGenericCardsList = <Id>(
+  props: PropsWithChildren<GenericCardsListProps<Id>>
+) => ReactElement;
+
+export const GenericCardsList: TGenericCardsList = ({
+  checkedIds,
+  handleCheck,
+  checkAllText,
+  listTitle,
+  listTitleProps,
+  allChecked,
+  handleAllCheck,
+  loading,
+  allItems,
+  handleDrag,
+  selectOnCardClick,
+  dragNdrop,
+  listWrapperProps,
+  headerWrapperProps,
+  selectAllCheckboxProps,
+  children,
+}) => {
+  const classes = useStyles();
+  const { onCardDragEnd } = useGenericCardsListEffects(allItems, handleDrag);
+  return (
+    <Box {...listWrapperProps}>
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+        {...headerWrapperProps}
+      >
+        {listTitle && (
+          <Typography fontSize={20} {...listTitleProps}>
+            {listTitle}
+          </Typography>
+        )}
+        {checkAllText && (
+          <FormControlLabel
+            label={checkAllText}
+            control={
+              <Checkbox
+                color="primary"
+                checked={allChecked}
+                onChange={handleAllCheck}
+                {...selectAllCheckboxProps}
+              />
+            }
+          />
+        )}
+      </Box>
+      <DragDropContext onDragEnd={onCardDragEnd}>
+        <Droppable
+          isDropDisabled={!dragNdrop || !handleDrag}
+          droppableId="droppable"
+        >
+          {(provided) => (
+            <Grid
+              ref={provided.innerRef}
+              container
+              flexDirection="column"
+              justifyContent="flex-start"
+              alignItems="center"
+            >
+              {loading ? (
+                <Stack>
+                  {skeletonList.map((key) => (
+                    <Skeleton
+                      key={key}
+                      className={classes.skeleton}
+                      variant="rectangular"
+                    />
+                  ))}
+                </Stack>
+              ) : (
+                allItems.map((item, idx) => {
+                  const isCardSelected = checkedIds.indexOf(item.id) !== -1;
+                  return (
+                    <Draggable
+                      isDragDisabled={!dragNdrop || !handleDrag}
+                      key={`${item.id}`}
+                      draggableId={`${item.id}`}
+                      index={idx}
+                    >
+                      {(provided) => (
+                        <Grid
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                          item
+                        >
+                          <ListCard
+                            selectOnCardClick={selectOnCardClick}
+                            selected={isCardSelected}
+                            handleSelect={handleCheck}
+                            item={item}
+                          />
+                        </Grid>
+                      )}
+                    </Draggable>
+                  );
+                })
+              )}
+              {provided.placeholder}
+            </Grid>
+          )}
+        </Droppable>
+      </DragDropContext>
+      {children}
+    </Box>
+  );
+};

--- a/packages/ui/libs/ui/core/src/components/list/GenericCardsList/index.ts
+++ b/packages/ui/libs/ui/core/src/components/list/GenericCardsList/index.ts
@@ -1,0 +1,1 @@
+export * from './GenericCardsList';

--- a/packages/ui/libs/ui/core/src/components/list/ListCard/ListCard.styles.ts
+++ b/packages/ui/libs/ui/core/src/components/list/ListCard/ListCard.styles.ts
@@ -1,0 +1,39 @@
+import { HexToRGBA, LightenColor } from '@energyweb/origin-ui-theme';
+import { makeStyles } from '@material-ui/core';
+
+export const useStyles = makeStyles((theme) => ({
+  card: {
+    height: 160,
+    width: 280,
+    border: `0.5px solid ${LightenColor(
+      theme.palette.background.paper,
+      -5,
+      theme.palette.mode
+    )}`,
+    boxSizing: 'border-box',
+    borderRadius: 5,
+    flexShrink: 0,
+    boxShadow: 'none',
+    transition: theme.transitions.create(['box-shadow', 'border'], {
+      duration: 200,
+    }),
+    padding: 10,
+    marginBottom: 10,
+    '&:hover': {
+      border: `0.5px solid ${HexToRGBA(theme.palette.primary.main, 60)}`,
+      cursor: 'pointer',
+    },
+  },
+  selected: {
+    border: `0.5px solid ${LightenColor(
+      theme.palette.background.paper,
+      -5,
+      theme.palette.mode
+    )}`,
+    boxShadow: `0 0 2pt 1pt ${LightenColor(
+      theme.palette.primary.main,
+      20,
+      theme.palette.mode
+    )}`,
+  },
+}));

--- a/packages/ui/libs/ui/core/src/components/list/ListCard/ListCard.tsx
+++ b/packages/ui/libs/ui/core/src/components/list/ListCard/ListCard.tsx
@@ -1,0 +1,65 @@
+import {
+  Box,
+  BoxProps,
+  Card,
+  CardProps,
+  Checkbox,
+  CheckboxProps,
+} from '@material-ui/core';
+import React, { PropsWithChildren, ReactElement } from 'react';
+import { useStyles } from './ListCard.styles';
+
+export interface CardsListItem<Id> {
+  id: Id;
+  content: React.FC<{ id: Id }>;
+  itemCardProps?: CardProps;
+  checkbox?: boolean;
+  checkboxWrapperProps?: BoxProps;
+  checkboxProps?: Omit<CheckboxProps, 'value' | 'onChange'>;
+  contentWrapperProps?: BoxProps;
+}
+
+interface ListCardProps<Id> {
+  item: CardsListItem<Id>;
+  selected: boolean;
+  handleSelect: (id: Id) => void;
+  selectOnCardClick?: boolean;
+}
+
+export type TListCard = <Id>(
+  props: PropsWithChildren<ListCardProps<Id>>
+) => ReactElement;
+
+export const ListCard: TListCard = ({
+  item,
+  selected,
+  handleSelect,
+  selectOnCardClick,
+}) => {
+  const handleCardSelect = () => handleSelect(item.id);
+  const { content: ItemContent } = item;
+  const classes = useStyles();
+  return (
+    <Card
+      className={`${classes.card} ${selected && classes.selected}`}
+      {...item.itemCardProps}
+      onClick={selectOnCardClick ? handleCardSelect : undefined}
+    >
+      <Box display="flex">
+        {item.checkbox && (
+          <Box {...item.checkboxWrapperProps}>
+            <Checkbox
+              color="primary"
+              checked={selected}
+              onChange={handleCardSelect}
+              {...item.checkboxProps}
+            />
+          </Box>
+        )}
+        <Box {...item.contentWrapperProps}>
+          <ItemContent id={item.id} />
+        </Box>
+      </Box>
+    </Card>
+  );
+};

--- a/packages/ui/libs/ui/core/src/components/list/ListCard/index.ts
+++ b/packages/ui/libs/ui/core/src/components/list/ListCard/index.ts
@@ -1,0 +1,1 @@
+export * from './ListCard';

--- a/packages/ui/libs/ui/core/src/components/list/index.ts
+++ b/packages/ui/libs/ui/core/src/components/list/index.ts
@@ -2,3 +2,5 @@ export * from './GenericItemsList';
 export * from './ListActionsBlock';
 export * from './ListItemComponent';
 export * from './ListItemsContainer';
+export * from './GenericCardsList';
+export * from './ListCard';

--- a/packages/ui/libs/ui/core/src/components/utils/ConditionalWrapper/ConditionalWrapper.tsx
+++ b/packages/ui/libs/ui/core/src/components/utils/ConditionalWrapper/ConditionalWrapper.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface ConditionalWrapperProps {
+  condition: boolean;
+  wrapper: React.FC;
+}
+
+export const ConditionalWrapper: React.FC<ConditionalWrapperProps> = ({
+  condition,
+  wrapper: Wrapper,
+  children,
+}) => {
+  if (condition) return <Wrapper>{children}</Wrapper>;
+  return <>{children}</>;
+};

--- a/packages/ui/libs/ui/core/src/components/utils/ConditionalWrapper/index.ts
+++ b/packages/ui/libs/ui/core/src/components/utils/ConditionalWrapper/index.ts
@@ -1,0 +1,1 @@
+export * from './ConditionalWrapper';

--- a/packages/ui/libs/ui/core/src/components/utils/index.ts
+++ b/packages/ui/libs/ui/core/src/components/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './ConditionalWrapper';

--- a/packages/ui/libs/ui/core/src/containers/CardsListBlock/CardListBlock.stories.tsx
+++ b/packages/ui/libs/ui/core/src/containers/CardsListBlock/CardListBlock.stories.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { Box, Typography } from '@material-ui/core';
+import { CardsListBlock, CardsListBlockProps } from './CardsListBlock';
+import { CardsListItem } from '../../components/list';
+
+export default {
+  title: 'Containers / CardsListBlock',
+  component: CardsListBlock,
+} as Meta;
+
+const BlockContent: CardsListBlockProps<number>['Content'] = ({
+  selectedIds,
+}) => {
+  return (
+    <Box m={4}>
+      <Typography>
+        {`Currently selected ID's: ${selectedIds.join(', ')}`}
+      </Typography>
+    </Box>
+  );
+};
+
+const CardItemContent: CardsListItem<number>['content'] = ({ id }) => {
+  return (
+    <Box>
+      <Typography>{`Name of item ${id}`}</Typography>
+      <Typography>{`Description of item ${id}`}</Typography>
+    </Box>
+  );
+};
+
+export const WithoutCheckboxes = (args: CardsListBlockProps<number>) => {
+  return <CardsListBlock {...args} />;
+};
+
+WithoutCheckboxes.args = {
+  allItems: [
+    {
+      id: 1,
+      content: CardItemContent,
+    },
+    {
+      id: 2,
+      content: CardItemContent,
+    },
+    {
+      id: 3,
+      content: CardItemContent,
+    },
+  ],
+  Content: BlockContent,
+  loading: false,
+  listTitle: '',
+  checkAllText: '',
+  selectOnCardClick: true,
+  dragNdrop: false,
+};
+
+export const WithCheckboxes = (args: CardsListBlockProps<number>) => {
+  return <CardsListBlock {...args} />;
+};
+
+WithCheckboxes.args = {
+  allItems: [
+    {
+      id: 1,
+      content: CardItemContent,
+      checkbox: true,
+    },
+    {
+      id: 2,
+      content: CardItemContent,
+      checkbox: true,
+    },
+    {
+      id: 3,
+      content: CardItemContent,
+      checkbox: true,
+    },
+  ],
+  Content: BlockContent,
+  loading: false,
+  listTitle: '',
+  checkAllText: 'Select all',
+  selectOnCardClick: false,
+  dragNdrop: false,
+};
+
+export const WithDragNDrop = (args: CardsListBlockProps<number>) => {
+  return <CardsListBlock {...args} />;
+};
+
+WithDragNDrop.args = {
+  allItems: [
+    {
+      id: 1,
+      content: CardItemContent,
+    },
+    {
+      id: 2,
+      content: CardItemContent,
+    },
+    {
+      id: 3,
+      content: CardItemContent,
+    },
+  ],
+  Content: BlockContent,
+  loading: false,
+  listTitle: '',
+  checkAllText: '',
+  selectOnCardClick: true,
+  handleDrag: (reorderedList) => console.log(reorderedList),
+  dragNdrop: true,
+};

--- a/packages/ui/libs/ui/core/src/containers/CardsListBlock/CardsListBlock.effects.ts
+++ b/packages/ui/libs/ui/core/src/containers/CardsListBlock/CardsListBlock.effects.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { CardsListItem } from '../../components/list';
+
+export const useCardsListBlockEffects = <Id>(allItems: CardsListItem<Id>[]) => {
+  const [checkedIds, setCheckedIds] = useState<Id[]>([]);
+
+  const handleCheck = (id: Id) => {
+    if (checkedIds.includes(id)) {
+      const newChecked = [...checkedIds].filter(
+        (checkedId) => checkedId !== id
+      );
+      return setCheckedIds(newChecked);
+    }
+    const newChecked = [...checkedIds, id];
+    setCheckedIds(newChecked);
+  };
+
+  const allChecked = checkedIds.length === allItems.length;
+
+  const handleAllCheck = () => {
+    if (allChecked) {
+      return setCheckedIds([]);
+    }
+    const newChecked = allItems.map((item) => item.id);
+    setCheckedIds(newChecked);
+  };
+
+  return { handleCheck, checkedIds, allChecked, handleAllCheck };
+};

--- a/packages/ui/libs/ui/core/src/containers/CardsListBlock/CardsListBlock.tsx
+++ b/packages/ui/libs/ui/core/src/containers/CardsListBlock/CardsListBlock.tsx
@@ -1,0 +1,67 @@
+import React, { PropsWithChildren, ReactElement } from 'react';
+import { Grid } from '@material-ui/core';
+import { GenericCardsListProps, GenericCardsList } from '../../components';
+import { useCardsListBlockEffects } from './CardsListBlock.effects';
+
+export interface CardsListBlockProps<Id> {
+  allItems: GenericCardsListProps<Id>['allItems'];
+  loading: GenericCardsListProps<Id>['loading'];
+  Content: React.FC<{ selectedIds: Id[] }>;
+  listTitle?: GenericCardsListProps<Id>['listTitle'];
+  listTitleProps?: GenericCardsListProps<Id>['listTitleProps'];
+  handleDrag?: GenericCardsListProps<Id>['handleDrag'];
+  checkAllText?: GenericCardsListProps<Id>['checkAllText'];
+  selectOnCardClick?: GenericCardsListProps<Id>['selectOnCardClick'];
+  dragNdrop?: GenericCardsListProps<Id>['dragNdrop'];
+  listWrapperProps?: GenericCardsListProps<Id>['listWrapperProps'];
+  headerWrapperProps?: GenericCardsListProps<Id>['headerWrapperProps'];
+  selectAllCheckboxProps?: GenericCardsListProps<Id>['selectAllCheckboxProps'];
+}
+
+export type TCardsListBlock = <Id>(
+  props: PropsWithChildren<CardsListBlockProps<Id>>
+) => ReactElement;
+
+export const CardsListBlock: TCardsListBlock = ({
+  allItems,
+  loading,
+  Content,
+  listTitle,
+  listTitleProps,
+  handleDrag,
+  checkAllText,
+  selectOnCardClick,
+  listWrapperProps,
+  headerWrapperProps,
+  selectAllCheckboxProps,
+  dragNdrop,
+}) => {
+  const { checkedIds, handleCheck, allChecked, handleAllCheck } =
+    useCardsListBlockEffects(allItems);
+  return (
+    <Grid container>
+      <Grid item>
+        <GenericCardsList
+          checkedIds={checkedIds}
+          handleCheck={handleCheck}
+          allChecked={allChecked}
+          handleAllCheck={handleAllCheck}
+          allItems={allItems}
+          loading={loading}
+          handleDrag={handleDrag}
+          listTitle={listTitle}
+          listTitleProps={listTitleProps}
+          checkAllText={checkAllText}
+          selectOnCardClick={selectOnCardClick}
+          listWrapperProps={listWrapperProps}
+          headerWrapperProps={headerWrapperProps}
+          selectAllCheckboxProps={selectAllCheckboxProps}
+          dragNdrop={dragNdrop}
+        />
+      </Grid>
+      <Grid item>
+        <Content selectedIds={checkedIds} />
+      </Grid>
+    </Grid>
+  );
+};

--- a/packages/ui/libs/ui/core/src/containers/CardsListBlock/index.ts
+++ b/packages/ui/libs/ui/core/src/containers/CardsListBlock/index.ts
@@ -1,0 +1,1 @@
+export * from './CardsListBlock';

--- a/packages/ui/libs/ui/core/src/containers/CardsTable/CardsTable.effects.ts
+++ b/packages/ui/libs/ui/core/src/containers/CardsTable/CardsTable.effects.ts
@@ -1,0 +1,12 @@
+import { CardTableItem, TVerticalHeader } from '../../components';
+
+export const useCardsTableEffects = <VerticalHeaderId, HeaderId>(
+  verticalHeaders: TVerticalHeader<VerticalHeaderId>[],
+  rows: CardTableItem<HeaderId, VerticalHeaderId>[][]
+) => {
+  const orderedRows = verticalHeaders.map((header) =>
+    rows.find((row) => row[0].verticalHeaderId === header.id)
+  );
+
+  return { orderedRows };
+};

--- a/packages/ui/libs/ui/core/src/containers/CardsTable/CardsTable.stories.tsx
+++ b/packages/ui/libs/ui/core/src/containers/CardsTable/CardsTable.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { CardsTable } from './CardsTable';
+import { CardsTableProps } from './CardsTable.types';
+import {
+  headers,
+  rows,
+  totalColumnItems,
+  TotalHeader,
+  verticalHeaders,
+} from './mocks';
+
+export default {
+  title: 'Containers / CardsTable',
+  component: CardsTable,
+} as Meta;
+
+export const Default = (args: CardsTableProps<number, string>) => (
+  <CardsTable {...args} />
+);
+
+Default.args = {
+  verticalHeaders: verticalHeaders,
+  totalColumnHeader: <TotalHeader />,
+  totalColumnItems: totalColumnItems,
+  headers: headers,
+  rows: rows,
+};

--- a/packages/ui/libs/ui/core/src/containers/CardsTable/CardsTable.tsx
+++ b/packages/ui/libs/ui/core/src/containers/CardsTable/CardsTable.tsx
@@ -1,0 +1,62 @@
+import { Box } from '@material-ui/core';
+import React from 'react';
+import {
+  CardTableContent,
+  CardTableTotalColumn,
+  CardTableVerticalHeaders,
+} from '../../components';
+import { useCardsTableEffects } from './CardsTable.effects';
+import { TCardsTable } from './CardsTable.types';
+
+export const CardsTable: TCardsTable = ({
+  verticalHeaders,
+  verticalHeadersTableCellProps,
+  verticalHeadersTableHeadCellProps,
+  verticalHeadersTableProps,
+  totalColumnHeader,
+  totalColumnItems,
+  totalTableCellContentWrapperProps,
+  totalTableCellProps,
+  totalTableHeadCellProps,
+  totalTableProps,
+  headers,
+  rows,
+  tableWrapperProps,
+  tableProps,
+  tableHeadCellProps,
+  tableCellProps,
+  tableCellContentWrapperProps,
+}) => {
+  const { orderedRows } = useCardsTableEffects(verticalHeaders, rows);
+  return (
+    <Box display="flex">
+      <CardTableVerticalHeaders
+        verticalHeaders={verticalHeaders}
+        tableProps={verticalHeadersTableProps}
+        tableHeadCellProps={verticalHeadersTableHeadCellProps}
+        tableCellProps={verticalHeadersTableCellProps}
+      />
+
+      <CardTableContent
+        headers={headers}
+        rows={orderedRows}
+        tableWrapperProps={tableWrapperProps}
+        tableProps={tableProps}
+        tableHeadCellProps={tableHeadCellProps}
+        tableCellProps={tableCellProps}
+        cellContentWrapperProps={tableCellContentWrapperProps}
+      />
+
+      {totalColumnHeader && totalColumnItems && (
+        <CardTableTotalColumn
+          header={totalColumnHeader}
+          totalItems={totalColumnItems}
+          tableProps={totalTableProps}
+          tableHeadCellProps={totalTableHeadCellProps}
+          cellContentWrapperProps={totalTableCellContentWrapperProps}
+          tableCellProps={totalTableCellProps}
+        />
+      )}
+    </Box>
+  );
+};

--- a/packages/ui/libs/ui/core/src/containers/CardsTable/CardsTable.types.ts
+++ b/packages/ui/libs/ui/core/src/containers/CardsTable/CardsTable.types.ts
@@ -1,0 +1,79 @@
+import {
+  DetailedHTMLProps,
+  TableHTMLAttributes,
+  ThHTMLAttributes,
+  TdHTMLAttributes,
+  ReactNode,
+  HTMLAttributes,
+  PropsWithChildren,
+  ReactElement,
+} from 'react';
+import {
+  CardTableHeader,
+  CardTableItem,
+  TTotalItem,
+  TVerticalHeader,
+} from '../../components';
+
+export interface CardsTableProps<VerticalHeaderId, HeaderId> {
+  // vertical headers table props
+  verticalHeaders: TVerticalHeader<VerticalHeaderId>[];
+  verticalHeadersTableProps?: DetailedHTMLProps<
+    TableHTMLAttributes<HTMLTableElement>,
+    HTMLTableElement
+  >;
+  verticalHeadersTableHeadCellProps?: DetailedHTMLProps<
+    ThHTMLAttributes<HTMLTableHeaderCellElement>,
+    HTMLTableHeaderCellElement
+  >;
+  verticalHeadersTableCellProps?: DetailedHTMLProps<
+    TdHTMLAttributes<HTMLTableHeaderCellElement>,
+    HTMLTableHeaderCellElement
+  >;
+  // total table props
+  totalColumnHeader?: ReactNode;
+  totalColumnItems?: TTotalItem<VerticalHeaderId>[];
+  totalTableProps?: DetailedHTMLProps<
+    TableHTMLAttributes<HTMLTableElement>,
+    HTMLTableElement
+  >;
+  totalTableHeadCellProps?: DetailedHTMLProps<
+    ThHTMLAttributes<HTMLTableHeaderCellElement>,
+    HTMLTableHeaderCellElement
+  >;
+  totalTableCellProps?: DetailedHTMLProps<
+    TdHTMLAttributes<HTMLTableHeaderCellElement>,
+    HTMLTableHeaderCellElement
+  >;
+  totalTableCellContentWrapperProps?: DetailedHTMLProps<
+    HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >;
+  // content table props
+  headers: CardTableHeader<HeaderId>[];
+  rows: CardTableItem<HeaderId, VerticalHeaderId>[][];
+  tableWrapperProps?: DetailedHTMLProps<
+    HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >;
+  tableProps?: DetailedHTMLProps<
+    TableHTMLAttributes<HTMLTableElement>,
+    HTMLTableElement
+  >;
+  tableHeadCellProps?: DetailedHTMLProps<
+    ThHTMLAttributes<HTMLTableHeaderCellElement>,
+    HTMLTableHeaderCellElement
+  >;
+  tableCellProps?: DetailedHTMLProps<
+    TdHTMLAttributes<HTMLTableHeaderCellElement>,
+    HTMLTableHeaderCellElement
+  >;
+  tableCellContentWrapperProps?: DetailedHTMLProps<
+    HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >;
+}
+
+export type TCardsTable = <VerticalHeaderId, HeaderId>(
+  props: PropsWithChildren<CardsTableProps<VerticalHeaderId, HeaderId>>
+) => ReactElement;

--- a/packages/ui/libs/ui/core/src/containers/CardsTable/index.ts
+++ b/packages/ui/libs/ui/core/src/containers/CardsTable/index.ts
@@ -1,0 +1,2 @@
+export * from './CardsTable';
+export * from './CardsTable.types';

--- a/packages/ui/libs/ui/core/src/containers/CardsTable/mocks.tsx
+++ b/packages/ui/libs/ui/core/src/containers/CardsTable/mocks.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+import { Box, Typography } from '@material-ui/core';
+import {
+  CardTableHeader,
+  CardTableItem,
+  TTotalItem,
+  TVerticalHeader,
+} from '../../components';
+
+const VerticalHeaderComponent: React.FC<{ id: number }> = ({ id }) => {
+  return (
+    <Box
+      width="100%"
+      height="100%"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      style={{ backgroundColor: id === 0 ? '#F2F7CF' : '#D9D9D9' }}
+    >
+      <Typography color="InfoText">
+        {id === 0 ? 'Total:' : `Consumer ${id}`}
+      </Typography>
+    </Box>
+  );
+};
+
+export const verticalHeaders: TVerticalHeader<number>[] = [
+  {
+    id: 1,
+    component: VerticalHeaderComponent,
+  },
+  {
+    id: 2,
+    component: VerticalHeaderComponent,
+  },
+  {
+    id: 3,
+    component: VerticalHeaderComponent,
+  },
+  {
+    id: 0,
+    component: VerticalHeaderComponent,
+  },
+];
+
+export const TotalHeader = () => {
+  return (
+    <Box
+      width="100%"
+      height="100%"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      style={{ backgroundColor: '#F2F7CF' }}
+    >
+      <Typography color="InfoText">Total:</Typography>
+    </Box>
+  );
+};
+
+const TotalItemComponent: React.FC<{ id: number }> = ({ id }) => {
+  return (
+    <Box
+      width="100%"
+      height="100%"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      style={{ backgroundColor: '#F2F7CF' }}
+    >
+      <Box>
+        <Typography color="InfoText">
+          {id === 0 ? 'Total for all consumers:' : `For consumer ${id}:`}
+        </Typography>
+        <Typography color="InfoText">
+          {id === 0 ? 'Total:6000 MWh' : `Total - ${id * 1000} MWh`}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export const totalColumnItems: TTotalItem<number>[] = [
+  {
+    id: 1,
+    component: TotalItemComponent,
+  },
+  {
+    id: 2,
+    component: TotalItemComponent,
+  },
+  {
+    id: 3,
+    component: TotalItemComponent,
+  },
+  {
+    id: 0,
+    component: TotalItemComponent,
+  },
+];
+
+const HeaderComponent: React.FC<{ id: string }> = ({ id }) => {
+  const idToDisplay = id.split('-').join(' ').toUpperCase();
+  return (
+    <Box
+      width="100%"
+      height="100%"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      style={{ backgroundColor: '#D9D9D9' }}
+    >
+      <Typography color="InfoText">{idToDisplay}</Typography>
+    </Box>
+  );
+};
+
+export const headers: CardTableHeader<string>[] = [
+  {
+    id: 'device-1',
+    component: HeaderComponent,
+  },
+  {
+    id: 'device-2',
+    component: HeaderComponent,
+  },
+  {
+    id: 'device-3',
+    component: HeaderComponent,
+  },
+];
+
+const TableCellComponent: React.FC<{
+  headerId: string;
+  verticalHeaderId: number;
+}> = ({ headerId, verticalHeaderId }) => {
+  if (verticalHeaderId === 0) {
+    return (
+      <Box
+        width="100%"
+        height="100%"
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        style={{ backgroundColor: '#F2F7CF' }}
+      >
+        <Box>
+          <Typography color="InfoText">Total for device ID:</Typography>
+          <Typography color="InfoText">{headerId}</Typography>
+        </Box>
+      </Box>
+    );
+  }
+  return (
+    <Box
+      width="100%"
+      height="100%"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      style={{ backgroundColor: '#D9D9D9' }}
+    >
+      <Box>
+        <Typography color="InfoText">Device ID: {headerId}</Typography>
+        <Typography color="InfoText">
+          Consumer ID: {verticalHeaderId}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export const rows: CardTableItem<string, number>[][] = [
+  [
+    {
+      headerId: 'device-1',
+      verticalHeaderId: 1,
+      component: TableCellComponent,
+    },
+    {
+      headerId: 'device-2',
+      verticalHeaderId: 1,
+      component: TableCellComponent,
+    },
+    {
+      headerId: 'device-3',
+      verticalHeaderId: 1,
+      component: TableCellComponent,
+    },
+  ],
+  [
+    {
+      headerId: 'device-1',
+      verticalHeaderId: 2,
+      component: TableCellComponent,
+    },
+    {
+      headerId: 'device-2',
+      verticalHeaderId: 2,
+      component: TableCellComponent,
+    },
+    {
+      headerId: 'device-3',
+      verticalHeaderId: 2,
+      component: TableCellComponent,
+    },
+  ],
+  [
+    {
+      headerId: 'device-1',
+      verticalHeaderId: 3,
+      component: TableCellComponent,
+    },
+    {
+      headerId: 'device-2',
+      verticalHeaderId: 3,
+      component: TableCellComponent,
+    },
+    {
+      headerId: 'device-3',
+      verticalHeaderId: 3,
+      component: TableCellComponent,
+    },
+  ],
+  [
+    {
+      headerId: 'device-1',
+      verticalHeaderId: 0,
+      component: TableCellComponent,
+    },
+    {
+      headerId: 'device-2',
+      verticalHeaderId: 0,
+      component: TableCellComponent,
+    },
+    {
+      headerId: 'device-3',
+      verticalHeaderId: 0,
+      component: TableCellComponent,
+    },
+  ],
+];

--- a/packages/ui/libs/ui/core/src/containers/GenericForm/GenericForm.types.ts
+++ b/packages/ui/libs/ui/core/src/containers/GenericForm/GenericForm.types.ts
@@ -20,6 +20,7 @@ export type GenericFormField = {
   name: string;
   label: string;
   type?: 'text' | 'password';
+  placeholder?: string;
   required?: boolean;
   select?: boolean;
   additionalInputProps?: {

--- a/packages/ui/libs/ui/core/src/containers/index.ts
+++ b/packages/ui/libs/ui/core/src/containers/index.ts
@@ -5,3 +5,4 @@ export * from './TableComponent';
 export * from './FileUpload';
 export * from './DownloadableChip';
 export * from './ItemsListWithActions';
+export * from './CardsListBlock';

--- a/packages/ui/libs/ui/core/src/containers/index.ts
+++ b/packages/ui/libs/ui/core/src/containers/index.ts
@@ -6,3 +6,4 @@ export * from './FileUpload';
 export * from './DownloadableChip';
 export * from './ItemsListWithActions';
 export * from './CardsListBlock';
+export * from './CardsTable';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "nx": "nx",
-    "start": "./dev-env.sh && nx serve",
+    "start": "./dev-env.sh && nx serve --port=3000",
     "config-env": "bash env.sh",
     "build:ui-utils": "nx run ui-utils:build --buildableProjectDepsInPackageJsonType=dependencies",
     "build:ui-theme": "nx run ui-theme:build",
@@ -27,6 +27,7 @@
     "deploy:container:heroku:canary": "make push-heroku-canary",
     "deploy:container:heroku:canary-v2": "make push-heroku-canary-v2",
     "deploy:container:heroku:stable": "make push-heroku-stable",
+    "storybook": "nx run ui-core:storybook --port=6006",
     "test": "nx test",
     "lint": "nx workspace-lint && nx lint",
     "e2e": "nx e2e",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -96,6 +96,7 @@
     "@web3-react/core": "6.1.9",
     "@web3-react/injected-connector": "6.0.7",
     "@ethersproject/providers": "5.3.1",
+    "react-beautiful-dnd": "13.1.0",
     "chart.js": "3.3.2",
     "tslib": "2.3.0",
     "yup": "0.32.9"
@@ -132,6 +133,7 @@
     "@types/react-is": "17.0.0",
     "@types/react-router-dom": "5.1.7",
     "@types/webpack": "4.41.21",
+    "@types/react-beautiful-dnd": "13.1.0",
     "@typescript-eslint/eslint-plugin": "4.3.0",
     "@typescript-eslint/parser": "4.3.0",
     "babel-jest": "26.2.2",


### PR DESCRIPTION
New components added to ui-core package:
1. TimeFrame select:
<img width="1213" alt="Screenshot 2021-08-13 at 13 26 50" src="https://user-images.githubusercontent.com/69903849/129344087-9550636d-b8e3-4fec-ac9b-b168e4df7ca2.png">
2. Cards list with built-in Drag-n-Drop functionality, ability to make them with/without checkboxes and some default styling and responsive behaviour:
<img width="1217" alt="Screenshot 2021-08-13 at 13 26 29" src="https://user-images.githubusercontent.com/69903849/129344182-4600c39f-d85e-46a2-905b-4cfa6167ca6a.png">
3. Cards table with optional Total Column. 
Has default styles and default scrollable main table for screens smaller than laptop:
<img width="1113" alt="Screenshot 2021-08-13 at 13 25 28" src="https://user-images.githubusercontent.com/69903849/129344576-03f3dda5-ae11-44e6-9da6-39b4b9399830.png">
<img width="591" alt="Screenshot 2021-08-13 at 13 25 43" src="https://user-images.githubusercontent.com/69903849/129344596-dc169b4a-212d-4fd8-8581-1ba4cafdebf8.png">
