### PR TITLE
chore: Exact error message

### DIFF
--- a/packages/ui/libs/device/data/src/handlers/requestCertificates.ts
+++ b/packages/ui/libs/device/data/src/handlers/requestCertificates.ts
@@ -82,7 +82,9 @@ export const useRequestCertificatesHandler = ({
           }
 
           showNotification(
-            t('device.my.notifications.certificateRequestError'),
+            `${t('device.my.notifications.certificateRequestError')}: ${
+              error.response.data.message
+            }`,
             NotificationTypeEnum.Error
           );
         },


### PR DESCRIPTION
After requesting certificates fails, the user is presented with a generic error. This PR makes this error more precise for better user feedback.