### PR TITLE
fix/routing

### DIFF
--- a/packages/ui/apps/origin-ui/src/AppContainer/AppContainer.tsx
+++ b/packages/ui/apps/origin-ui/src/AppContainer/AppContainer.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
+import { NotificationsCenter } from '@energyweb/origin-ui-core';
 
 import App from '../components/App';
 import { OriginGlobalStyles } from '../components';
 import { useAppContainerEffects } from './AppContainer.effects';
-import { NotificationsCenter } from '@energyweb/origin-ui-core';
 
 export const AppContainer = () => {
-  const { topbarButtons, menuSections, user, isAuthenticated } =
+  const { topbarButtons, menuSections, user, isAuthenticated, routesConfig } =
     useAppContainerEffects();
 
   return (
@@ -18,6 +18,7 @@ export const AppContainer = () => {
         user={user}
         isAuthenticated={isAuthenticated}
         topbarButtons={topbarButtons}
+        routesConfig={routesConfig}
       />
     </>
   );

--- a/packages/ui/apps/origin-ui/src/AppContainer/index.ts
+++ b/packages/ui/apps/origin-ui/src/AppContainer/index.ts
@@ -1,2 +1,2 @@
 export * from './AppContainer';
-export { RoutesConfig } from './AppContainer.effects';
+export * from './AppContainer.effects';

--- a/packages/ui/apps/origin-ui/src/AppContainer/index.ts
+++ b/packages/ui/apps/origin-ui/src/AppContainer/index.ts
@@ -1,1 +1,2 @@
 export * from './AppContainer';
+export { RoutesConfig } from './AppContainer.effects';

--- a/packages/ui/apps/origin-ui/src/components/App.tsx
+++ b/packages/ui/apps/origin-ui/src/components/App.tsx
@@ -16,19 +16,29 @@ import { CertificateApp } from '@energyweb/origin-ui-certificate-view';
 import { ExchangeApp } from '@energyweb/origin-ui-exchange-view';
 import { useUserAndOrgData } from '@energyweb/origin-ui-user-logic';
 import { UserDTO } from '@energyweb/origin-backend-react-query-client';
+import { RoutesConfig } from '../AppContainer';
 
 export interface AppProps {
   isAuthenticated: boolean;
   topbarButtons: TopBarButtonData[];
   user: UserDTO;
   menuSections: TMenuSection[];
+  routesConfig: RoutesConfig;
 }
 
 initializeI18N(getOriginLanguage());
 
 const App: FC<AppProps> = memo(
-  ({ isAuthenticated, user, menuSections, topbarButtons }) => {
+  ({ isAuthenticated, user, menuSections, topbarButtons, routesConfig }) => {
     const { orgData, userData } = useUserAndOrgData(user);
+    const {
+      accountRoutes,
+      adminRoutes,
+      orgRoutes,
+      certificateRoutes,
+      deviceRoutes,
+      exchangeRoutes,
+    } = routesConfig;
 
     return (
       <Routes>
@@ -44,13 +54,36 @@ const App: FC<AppProps> = memo(
             />
           }
         >
-          <Route path="device/*" element={<DeviceApp />} />
-          <Route path="exchange/*" element={<ExchangeApp />} />
-          <Route path="certificate/*" element={<CertificateApp />} />
-          <Route path="organization/*" element={<OrganizationApp />} />
-          <Route path="auth/*" element={<AuthApp />} />
-          <Route path="account/*" element={<AccountApp />} />
-          <Route path="admin/*" element={<AdminApp />} />
+          <Route
+            path="device/*"
+            element={<DeviceApp routesConfig={deviceRoutes} />}
+          />
+          <Route
+            path="exchange/*"
+            element={<ExchangeApp routesConfig={exchangeRoutes} />}
+          />
+          <Route
+            path="certificate/*"
+            element={<CertificateApp routesConfig={certificateRoutes} />}
+          />
+          <Route
+            path="organization/*"
+            element={<OrganizationApp routesConfig={orgRoutes} />}
+          />
+          <Route
+            path="account/*"
+            element={<AccountApp routesConfig={accountRoutes} />}
+          />
+          <Route
+            path="admin/*"
+            element={<AdminApp routesConfig={adminRoutes} />}
+          />
+          <Route
+            path="auth/*"
+            element={
+              <AuthApp routesConfig={{ showRegister: !isAuthenticated }} />
+            }
+          />
 
           <Route element={<Navigate to="device/all" />} />
         </Route>

--- a/packages/ui/apps/origin-ui/src/hooks/useInterceptors.ts
+++ b/packages/ui/apps/origin-ui/src/hooks/useInterceptors.ts
@@ -11,7 +11,7 @@ declare global {
   }
 }
 
-export const useAxiosInterceptors = () => {
+export const useAxiosDefaults = () => {
   const token = getAuthenticationToken();
 
   axios.defaults.baseURL = window.config.BACKEND_URL;

--- a/packages/ui/libs/certificate/data/src/handlers/exchangeTransferCertificate.ts
+++ b/packages/ui/libs/certificate/data/src/handlers/exchangeTransferCertificate.ts
@@ -9,12 +9,14 @@ import {
   showNotification,
 } from '@energyweb/origin-ui-core';
 import { PowerFormatter } from '@energyweb/origin-ui-utils';
+import { Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 
 export const useExchangeTransferCertificateHandler = (
   receiverAddress: string,
-  resetList: () => void
+  resetList: () => void,
+  setTxPending: Dispatch<SetStateAction<boolean>>
 ) => {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -22,6 +24,7 @@ export const useExchangeTransferCertificateHandler = (
   const { mutate } = useTransferControllerRequestSend();
 
   return <Id>(id: Id, amount: string) => {
+    setTxPending(true);
     const formattedAmount = PowerFormatter.getBaseValueFromValueInDisplayUnit(
       Number(amount)
     ).toString();
@@ -51,6 +54,7 @@ export const useExchangeTransferCertificateHandler = (
             NotificationTypeEnum.Error
           );
         },
+        onSettled: () => setTxPending(false),
       }
     );
   };

--- a/packages/ui/libs/certificate/data/src/handlers/sellCertificate.ts
+++ b/packages/ui/libs/certificate/data/src/handlers/sellCertificate.ts
@@ -12,20 +12,23 @@ import {
 } from '@energyweb/origin-ui-core';
 import { PowerFormatter } from '@energyweb/origin-ui-utils';
 import dayjs from 'dayjs';
+import { Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 
 export const useSellCertificateHandler = (
   price: string,
   exchangeCertificates: AccountAssetDTO[],
-  resetList: () => void
+  resetList: () => void,
+  setTxPending: Dispatch<SetStateAction<boolean>>
 ) => {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const exchangeCertificatesQueryKey = getAccountBalanceControllerGetQueryKey();
   const { mutate } = useOrderControllerCreateAsk();
 
-  return <Id>(id: Id, amount: string) => {
+  const sellHandler = <Id>(id: Id, amount: string) => {
+    setTxPending(true);
     const assetId = exchangeCertificates.find(
       (cert) =>
         cert.asset.id === (id as unknown as AccountAssetDTO['asset']['id'])
@@ -58,7 +61,10 @@ export const useSellCertificateHandler = (
             NotificationTypeEnum.Error
           );
         },
+        onSettled: () => setTxPending(false),
       }
     );
   };
+
+  return { sellHandler };
 };

--- a/packages/ui/libs/certificate/data/src/handlers/withdrawCertificate.ts
+++ b/packages/ui/libs/certificate/data/src/handlers/withdrawCertificate.ts
@@ -9,13 +9,15 @@ import {
   NotificationTypeEnum,
 } from '@energyweb/origin-ui-core';
 import { PowerFormatter } from '@energyweb/origin-ui-utils';
+import { Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 
 export const useWithdrawCertificateHandler = (
   address: string,
   exchangeCertificates: AccountAssetDTO[],
-  resetList: () => void
+  resetList: () => void,
+  setTxPending: Dispatch<SetStateAction<boolean>>
 ) => {
   const { t } = useTranslation();
   const { mutate } = useTransferControllerRequestWithdrawal();
@@ -23,6 +25,7 @@ export const useWithdrawCertificateHandler = (
   const exchangeCertificatesQueryKey = getAccountBalanceControllerGetQueryKey();
 
   return <Id>(id: Id, amount: string) => {
+    setTxPending(true);
     const assetId = exchangeCertificates.find(
       (cert) =>
         cert.asset.id === (id as unknown as AccountAssetDTO['asset']['id'])
@@ -54,6 +57,7 @@ export const useWithdrawCertificateHandler = (
             NotificationTypeEnum.Error
           );
         },
+        onSettled: () => setTxPending(false),
       }
     );
   };

--- a/packages/ui/libs/certificate/logic/src/claims/claimsReport.ts
+++ b/packages/ui/libs/certificate/logic/src/claims/claimsReport.ts
@@ -5,6 +5,7 @@ import {
   TFormatClaimsReportData,
   TFormatClaimsReportReturnData,
 } from './types';
+import { useNavigate } from 'react-router-dom';
 
 const formatClaimsReportData: TFormatClaimsReportData = ({
   devices,
@@ -50,6 +51,7 @@ export const useLogicClaimsReport: TUseLogicClaimsReport = ({
   loading,
 }) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   return {
     header: {
       fuelType: t('certificate.claimsReport.fuelType'),
@@ -70,5 +72,9 @@ export const useLogicClaimsReport: TUseLogicClaimsReport = ({
       claimedCertificates,
       allFuelTypes,
     }),
+    onRowClick: (id) => {
+      const certificateId = id.split(';')[0];
+      navigate(`/certificate/detail-view/${certificateId}`);
+    },
   };
 };

--- a/packages/ui/libs/certificate/logic/src/menu/index.ts
+++ b/packages/ui/libs/certificate/logic/src/menu/index.ts
@@ -1,6 +1,6 @@
 import { TMenuSection } from '@energyweb/origin-ui-core';
 
-type TGetCertificateMenuArgs = {
+export type TGetCertificateMenuArgs = {
   t: (tag: string) => string;
   isOpen: boolean;
   showSection: boolean;

--- a/packages/ui/libs/certificate/view/src/CertificateApp.tsx
+++ b/packages/ui/libs/certificate/view/src/CertificateApp.tsx
@@ -12,22 +12,48 @@ import {
   ApprovedPage,
 } from './pages';
 
-export const CertificateApp: FC = () => {
+export interface CertificateAppProps {
+  routesConfig: {
+    showExchangeInbox: boolean;
+    showBlockchainInbox: boolean;
+    showClaimsReport: boolean;
+    showRequests: boolean;
+    showPending: boolean;
+    showApproved: boolean;
+  };
+}
+
+export const CertificateApp: FC<CertificateAppProps> = ({ routesConfig }) => {
+  const {
+    showExchangeInbox,
+    showBlockchainInbox,
+    showClaimsReport,
+    showRequests,
+    showPending,
+    showApproved,
+  } = routesConfig;
+
   return (
     <Routes>
-      <Route path="exchange-inbox" element={<ExchangeInboxPage />} />
-      <Route
-        path="blockchain-inbox"
-        element={
-          <TransactionPendingProvider>
-            <BlockchainInboxPage />
-          </TransactionPendingProvider>
-        }
-      />
-      <Route path="claims-report" element={<ClaimsReportPage />} />
-      <Route path="requests" element={<RequestsPage />} />
-      <Route path="pending" element={<PendingPage />} />
-      <Route path="approved" element={<ApprovedPage />} />
+      {showExchangeInbox && (
+        <Route path="exchange-inbox" element={<ExchangeInboxPage />} />
+      )}
+      {showBlockchainInbox && (
+        <Route
+          path="blockchain-inbox"
+          element={
+            <TransactionPendingProvider>
+              <BlockchainInboxPage />
+            </TransactionPendingProvider>
+          }
+        />
+      )}
+      {showClaimsReport && (
+        <Route path="claims-report" element={<ClaimsReportPage />} />
+      )}
+      {showRequests && <Route path="requests" element={<RequestsPage />} />}
+      {showPending && <Route path="pending" element={<PendingPage />} />}
+      {showApproved && <Route path="approved" element={<ApprovedPage />} />}
       <Route path="detail-view/:id" element={<DetailViewPage />} />
       <Route path="*" element={<PageNotFound />} />
     </Routes>

--- a/packages/ui/libs/certificate/view/src/CertificateApp.tsx
+++ b/packages/ui/libs/certificate/view/src/CertificateApp.tsx
@@ -36,7 +36,14 @@ export const CertificateApp: FC<CertificateAppProps> = ({ routesConfig }) => {
   return (
     <Routes>
       {showExchangeInbox && (
-        <Route path="exchange-inbox" element={<ExchangeInboxPage />} />
+        <Route
+          path="exchange-inbox"
+          element={
+            <TransactionPendingProvider>
+              <ExchangeInboxPage />
+            </TransactionPendingProvider>
+          }
+        />
       )}
       {showBlockchainInbox && (
         <Route

--- a/packages/ui/libs/certificate/view/src/containers/action/ExchangeTransferAction/ExchangeTransferAction.effects.ts
+++ b/packages/ui/libs/certificate/view/src/containers/action/ExchangeTransferAction/ExchangeTransferAction.effects.ts
@@ -8,11 +8,13 @@ import {
 import { useExchangeTransferActionLogic } from '@energyweb/origin-ui-certificate-logic';
 import { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useTransactionPendingDispatch } from '../../../context';
 
 export const useExchangeTransferActionPropsEffects = (
   selectedIds: AccountAssetDTO['asset']['id'][],
   resetIds: () => void
 ) => {
+  const setTxPending = useTransactionPendingDispatch();
   const { t } = useTranslation();
   const [recipientAddress, setRecipientAddress] = useState('');
 
@@ -28,7 +30,8 @@ export const useExchangeTransferActionPropsEffects = (
 
   const transferHandler = useExchangeTransferCertificateHandler(
     recipientAddress,
-    resetIds
+    resetIds,
+    setTxPending
   );
 
   const actionLogic = useExchangeTransferActionLogic({

--- a/packages/ui/libs/certificate/view/src/containers/action/SellAction/SellAction.effects.ts
+++ b/packages/ui/libs/certificate/view/src/containers/action/SellAction/SellAction.effects.ts
@@ -7,6 +7,7 @@ import {
 } from '@energyweb/origin-ui-certificate-data';
 import { useSellActionLogic } from '@energyweb/origin-ui-certificate-logic';
 import { ChangeEvent, useState } from 'react';
+import { useTransactionPendingDispatch } from '../../../context';
 
 export const useSellActionEffects = (
   selectedIds: AccountAssetDTO['asset']['id'][],
@@ -14,6 +15,7 @@ export const useSellActionEffects = (
 ) => {
   const [totalAmount, setTotalAmount] = useState<number>();
   const [price, setPrice] = useState('');
+  const setTxPending = useTransactionPendingDispatch();
 
   const handlePriceChange = (event: ChangeEvent<HTMLInputElement>) => {
     setPrice(event.target.value);
@@ -28,10 +30,11 @@ export const useSellActionEffects = (
     setPrice('');
   };
 
-  const sellHandler = useSellCertificateHandler(
+  const { sellHandler } = useSellCertificateHandler(
     price,
     exchangeCertificates,
-    resetAction
+    resetAction,
+    setTxPending
   );
 
   const actionLogic = useSellActionLogic({

--- a/packages/ui/libs/certificate/view/src/containers/action/WithdrawAction/WithdrawAction.effects.ts
+++ b/packages/ui/libs/certificate/view/src/containers/action/WithdrawAction/WithdrawAction.effects.ts
@@ -7,11 +7,13 @@ import {
   useWithdrawCertificateHandler,
 } from '@energyweb/origin-ui-certificate-data';
 import { useWithdrawActionLogic } from '@energyweb/origin-ui-certificate-logic';
+import { useTransactionPendingDispatch } from '../../../context';
 
 export const useWithdrawActionEffects = (
   selectedIds: AccountAssetDTO['asset']['id'][],
   resetIds: () => void
 ) => {
+  const setTxPending = useTransactionPendingDispatch();
   const exchangeCertificates = useCachedExchangeCertificates();
   const allDevices = useCachedAllDevices();
   const allFuelTypes = useCachedAllFuelTypes();
@@ -22,7 +24,8 @@ export const useWithdrawActionEffects = (
   const withdrawHandler = useWithdrawCertificateHandler(
     withdrawalAddress,
     exchangeCertificates,
-    resetIds
+    resetIds,
+    setTxPending
   );
 
   const actionLogic = useWithdrawActionLogic({

--- a/packages/ui/libs/certificate/view/src/pages/ExchangeInboxPage/ExchangeInboxPage.effects.tsx
+++ b/packages/ui/libs/certificate/view/src/pages/ExchangeInboxPage/ExchangeInboxPage.effects.tsx
@@ -17,9 +17,11 @@ import {
   WithdrawAction,
   ExchangeTransferAction,
 } from '../../containers';
+import { useTransactionPendingStore } from '../../context';
 
 export const useExchangeInboxPageEffects = () => {
   const { t } = useTranslation();
+  const txPending = useTransactionPendingStore();
 
   const {
     user,
@@ -75,5 +77,6 @@ export const useExchangeInboxPageEffects = () => {
     noCertificatesText,
     canAccessPage,
     requirementsProps,
+    txPending,
   };
 };

--- a/packages/ui/libs/certificate/view/src/pages/ExchangeInboxPage/ExchangeInboxPage.tsx
+++ b/packages/ui/libs/certificate/view/src/pages/ExchangeInboxPage/ExchangeInboxPage.tsx
@@ -10,6 +10,7 @@ export const ExchangeInboxPage: FC = () => {
     noCertificatesText,
     canAccessPage,
     requirementsProps,
+    txPending,
   } = useExchangeInboxPageEffects();
 
   if (isLoading) return <CircularProgress />;
@@ -21,6 +22,7 @@ export const ExchangeInboxPage: FC = () => {
   return (
     <ItemsListWithActions
       emptyListComponent={<Typography>{noCertificatesText}</Typography>}
+      disabled={txPending}
       {...listProps}
     />
   );

--- a/packages/ui/libs/device/data/src/fetching/deviceImage.ts
+++ b/packages/ui/libs/device/data/src/fetching/deviceImage.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { ComposedPublicDevice } from '../types';
+import { fileDownloadHandler } from './file';
+
+export const useDeviceImageUrl = (
+  imageIds: ComposedPublicDevice['imageIds']
+) => {
+  const [imageUrl, setImageUrl] = useState<string>(null);
+
+  const getAndSetImage = async (id: string) => {
+    const response = await fileDownloadHandler(id);
+    const imageType = (response as any).headers['content-type'];
+    const blob = new Blob(
+      [Buffer.from((response.data as any).data as unknown as string)],
+      {
+        type: imageType,
+      }
+    );
+    const urlCreator = window.URL || window.webkitURL;
+    const imageUrl = urlCreator.createObjectURL(blob);
+    setImageUrl(imageUrl);
+  };
+
+  useEffect(() => {
+    if (imageIds?.length > 0) {
+      getAndSetImage(imageIds[0]);
+    }
+  }, [imageIds]);
+
+  return imageUrl;
+};

--- a/packages/ui/libs/device/data/src/fetching/file.ts
+++ b/packages/ui/libs/device/data/src/fetching/file.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export const fileDownloadHandler = async (id: string) => {
+  return await axios.get(`api/file/${id}`);
+};

--- a/packages/ui/libs/device/data/src/fetching/index.ts
+++ b/packages/ui/libs/device/data/src/fetching/index.ts
@@ -7,3 +7,5 @@ export * from './myDevices';
 export * from './pendingDevices';
 export * from './regionsConfig';
 export * from './userAndAccount';
+export * from './file';
+export * from './deviceImage';

--- a/packages/ui/libs/device/logic/src/menu/index.ts
+++ b/packages/ui/libs/device/logic/src/menu/index.ts
@@ -1,6 +1,6 @@
 import { TMenuSection } from '@energyweb/origin-ui-core';
 
-type TGetDeviceMenuArgs = {
+export type TGetDeviceMenuArgs = {
   t: (tag: string) => string;
   isOpen: boolean;
   showSection: boolean;

--- a/packages/ui/libs/device/logic/src/myDeviceCard/myDeviceCard.ts
+++ b/packages/ui/libs/device/logic/src/myDeviceCard/myDeviceCard.ts
@@ -10,6 +10,7 @@ import { getMainFuelType, getEnergyTypeImage } from '../utils';
 export const useSpecsForMyDeviceCard: TUseSpecsForMyDeviceCard = ({
   device,
   allTypes,
+  imageUrl,
 }) => {
   const { t } = useTranslation();
 
@@ -45,8 +46,7 @@ export const useSpecsForMyDeviceCard: TUseSpecsForMyDeviceCard = ({
     };
 
   return {
-    // This is impossible to get properly due to way we handle files
-    imageUrl: '',
+    imageUrl,
     fallbackIcon: deviceIconRegular,
     cardHeaderProps,
     cardContentProps,

--- a/packages/ui/libs/device/logic/src/myDeviceCard/types.ts
+++ b/packages/ui/libs/device/logic/src/myDeviceCard/types.ts
@@ -9,6 +9,7 @@ import { ComposedDevice } from '@energyweb/origin-ui-device-data';
 type TUseSpecsForMyDeviceCardArgs = {
   device: ComposedDevice;
   allTypes: CodeNameDTO[];
+  imageUrl: string;
 };
 
 export type TUseSpecsForMyDeviceCardReturnType = {

--- a/packages/ui/libs/device/view/src/DeviceApp.tsx
+++ b/packages/ui/libs/device/view/src/DeviceApp.tsx
@@ -13,17 +13,44 @@ import {
   DeviceImportPage,
 } from './pages';
 
-export const DeviceApp: FC = () => {
+export interface DeviceAppProps {
+  routesConfig: {
+    showAllDevices: boolean;
+    showMapView: boolean;
+    showMyDevices: boolean;
+    showPendingDevices: boolean;
+    showRegisterDevice: boolean;
+    showDeviceImport: boolean;
+  };
+}
+
+export const DeviceApp: FC<DeviceAppProps> = ({ routesConfig }) => {
+  const {
+    showAllDevices,
+    showMapView,
+    showMyDevices,
+    showPendingDevices,
+    showRegisterDevice,
+    showDeviceImport,
+  } = routesConfig;
   return (
     <DeviceModalsProvider>
       <Routes>
-        <Route path="all" element={<AllDevicesPage />} />
-        <Route path="map" element={<MapViewPage />} />
-        <Route path="my" element={<MyDevicesPage />} />
-        <Route path="pending" element={<PendingPage />} />
-        <Route path="register" element={<RegisterPage />} />
-        <Route path="detail-view/:id" element={<DetailViewPage />} />
-        <Route path="import" element={<DeviceImportPage />} />
+        {showAllDevices && <Route path="all" element={<AllDevicesPage />} />}
+        {showMapView && <Route path="map" element={<MapViewPage />} />}
+        {showMyDevices && <Route path="my" element={<MyDevicesPage />} />}
+        {showPendingDevices && (
+          <Route path="pending" element={<PendingPage />} />
+        )}
+        {showRegisterDevice && (
+          <Route path="register" element={<RegisterPage />} />
+        )}
+        {showAllDevices && (
+          <Route path="detail-view/:id" element={<DetailViewPage />} />
+        )}
+        {showDeviceImport && (
+          <Route path="import" element={<DeviceImportPage />} />
+        )}
         <Route path="*" element={<PageNotFound />} />
       </Routes>
       <DeviceModalsCenter />

--- a/packages/ui/libs/device/view/src/containers/card/MyDeviceCard/MyDeviceCard.effects.ts
+++ b/packages/ui/libs/device/view/src/containers/card/MyDeviceCard/MyDeviceCard.effects.ts
@@ -1,12 +1,17 @@
 import { CodeNameDTO } from '@energyweb/origin-device-registry-irec-local-api-react-query-client';
-import { ComposedDevice } from '@energyweb/origin-ui-device-data';
+import {
+  ComposedDevice,
+  useDeviceImageUrl,
+} from '@energyweb/origin-ui-device-data';
 import { useSpecsForMyDeviceCard } from '@energyweb/origin-ui-device-logic';
 
 export const useMyDeviceCardEffects = (
   device: ComposedDevice,
   allTypes: CodeNameDTO[]
 ) => {
-  const cardProps = useSpecsForMyDeviceCard({ device, allTypes });
+  const imageUrl = useDeviceImageUrl(device.imageIds);
+
+  const cardProps = useSpecsForMyDeviceCard({ device, allTypes, imageUrl });
 
   return cardProps;
 };

--- a/packages/ui/libs/device/view/src/containers/file/DeviceImagesUpload/DeviceImagesUpload.effects.ts
+++ b/packages/ui/libs/device/view/src/containers/file/DeviceImagesUpload/DeviceImagesUpload.effects.ts
@@ -21,7 +21,6 @@ export const useDeviceImagesUploadEffects = () => {
   const onDeviceImageChange = (newValues: UploadedFile[]) =>
     setImageIds(newValues);
 
-  const buttonDisabled = imageIds.length < 1;
   const buttonText = t('general.buttons.submit');
 
   return {
@@ -30,7 +29,6 @@ export const useDeviceImagesUploadEffects = () => {
     uploadFunction,
     onDeviceImageChange,
     deviceImagesHeading,
-    buttonDisabled,
     buttonText,
   };
 };

--- a/packages/ui/libs/device/view/src/containers/file/DeviceImagesUpload/DeviceImagesUpload.tsx
+++ b/packages/ui/libs/device/view/src/containers/file/DeviceImagesUpload/DeviceImagesUpload.tsx
@@ -24,7 +24,6 @@ export const DeviceImagesUpload: FC<DeviceImagesUploadProps> = ({
     uploadFunction,
     onDeviceImageChange,
     deviceImagesHeading,
-    buttonDisabled,
     buttonText,
   } = useDeviceImagesUploadEffects();
 
@@ -48,7 +47,7 @@ export const DeviceImagesUpload: FC<DeviceImagesUploadProps> = ({
           name="submit"
           size="large"
           variant="contained"
-          disabled={buttonDisabled || loading}
+          disabled={loading}
           onClick={() => submitHandler(values)}
         >
           {buttonText}

--- a/packages/ui/libs/exchange/logic/src/menu/index.ts
+++ b/packages/ui/libs/exchange/logic/src/menu/index.ts
@@ -1,6 +1,6 @@
 import { TMenuSection } from '@energyweb/origin-ui-core';
 
-type TGetExchangeMenuArgs = {
+export type TGetExchangeMenuArgs = {
   t: (tag: string) => string;
   isOpen: boolean;
   showSection: boolean;

--- a/packages/ui/libs/exchange/view/src/ExchangeApp.tsx
+++ b/packages/ui/libs/exchange/view/src/ExchangeApp.tsx
@@ -13,17 +13,46 @@ import {
   MyOrdersPage,
 } from './pages';
 
-export const ExchangeApp: FC = () => {
+export interface ExchangeAppProps {
+  routesConfig: {
+    showViewMarket: boolean;
+    showAllBundles: boolean;
+    showCreateBundle: boolean;
+    showMyTrades: boolean;
+    showSupply: boolean;
+    showMyBundles: boolean;
+    showMyOrders: boolean;
+  };
+}
+
+export const ExchangeApp: FC<ExchangeAppProps> = ({ routesConfig }) => {
+  const {
+    showViewMarket,
+    showAllBundles,
+    showCreateBundle,
+    showMyTrades,
+    showSupply,
+    showMyBundles,
+    showMyOrders,
+  } = routesConfig;
   return (
     <ExchangeModalsProvider>
       <Routes>
-        <Route path="/view-market" element={<ViewMarketPage />} />
-        <Route path="/all-bundles" element={<AllBundlesPage />} />
-        <Route path="/create-bundle" element={<CreateBundlePage />} />
-        <Route path="/my-bundles" element={<MyBundlesPage />} />
-        <Route path="/my-trades" element={<MyTradesPage />} />
-        <Route path="/supply" element={<SupplyPage />} />
-        <Route path="/my-orders" element={<MyOrdersPage />} />
+        {showViewMarket && (
+          <Route path="/view-market" element={<ViewMarketPage />} />
+        )}
+        {showAllBundles && (
+          <Route path="/all-bundles" element={<AllBundlesPage />} />
+        )}
+        {showCreateBundle && (
+          <Route path="/create-bundle" element={<CreateBundlePage />} />
+        )}
+        {showMyBundles && (
+          <Route path="/my-bundles" element={<MyBundlesPage />} />
+        )}
+        {showMyTrades && <Route path="/my-trades" element={<MyTradesPage />} />}
+        {showSupply && <Route path="/supply" element={<SupplyPage />} />}
+        {showMyOrders && <Route path="/my-orders" element={<MyOrdersPage />} />}
         <Route path="*" element={<PageNotFound />} />
       </Routes>
       <ExchangeModals />

--- a/packages/ui/libs/organization/data/src/orgRegister.ts
+++ b/packages/ui/libs/organization/data/src/orgRegister.ts
@@ -11,6 +11,7 @@ import {
 } from '@energyweb/origin-ui-core';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
+import { useNavigate } from 'react-router-dom';
 
 interface IUseOrganizationRegisterHandlerProps {
   openRoleChangedModal: () => void;
@@ -31,6 +32,7 @@ export const useOrganizationRegisterHandler = ({
 }: IUseOrganizationRegisterHandlerProps) => {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const { mutate } = useOrganizationControllerRegister();
   const userKey = getUserControllerMeQueryKey();
@@ -45,6 +47,7 @@ export const useOrganizationRegisterHandler = ({
       { data: formattedValues },
       {
         onSuccess: () => {
+          navigate('/organization/my');
           showNotification(
             t('organization.register.notifications.registeredSuccess'),
             NotificationTypeEnum.Success

--- a/packages/ui/libs/organization/data/src/registerIRec.ts
+++ b/packages/ui/libs/organization/data/src/registerIRec.ts
@@ -11,6 +11,7 @@ import {
 } from '@energyweb/origin-ui-core';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
+import { useNavigate } from 'react-router-dom';
 
 export type IRecRegistrationInfoForm = {
   accountType: IRECAccountType;
@@ -55,6 +56,7 @@ export type IRecRegisterFormMergedType = IRecRegistrationInfoForm &
 export const useIRecRegisterHandler = (openRegisteredModal: () => void) => {
   const { mutate } = useRegistrationControllerRegister();
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   const queryClient = useQueryClient();
   const iRecOrgKey = getRegistrationControllerGetRegistrationsQueryKey();
@@ -83,6 +85,7 @@ export const useIRecRegisterHandler = (openRegisteredModal: () => void) => {
       { data: formattedData },
       {
         onSuccess: () => {
+          navigate('/organization/my');
           openRegisteredModal();
           queryClient.invalidateQueries(iRecOrgKey);
         },

--- a/packages/ui/libs/organization/logic/src/menu/menu.ts
+++ b/packages/ui/libs/organization/logic/src/menu/menu.ts
@@ -1,7 +1,7 @@
 import { TMenuSection, TModuleMenuItem } from '@energyweb/origin-ui-core';
 import { TFunction } from 'i18next';
 
-type TGetOrganizationMenuArgs = {
+export type TGetOrganizationMenuArgs = {
   t: TFunction;
   isOpen: boolean;
   showSection: boolean;

--- a/packages/ui/libs/organization/logic/src/register/signatoryInfoForm.ts
+++ b/packages/ui/libs/organization/logic/src/register/signatoryInfoForm.ts
@@ -13,7 +13,7 @@ export const createSignatoryInfoForm: TCreateSignatoryInfoForm = (t) => ({
     signatoryCity: '',
     signatoryCountry: [],
     signatoryEmail: '',
-    signatoryTelephone: '',
+    signatoryPhoneNumber: '',
   },
   validationSchema: yup.object().shape({
     signatoryFullName: yup
@@ -41,10 +41,10 @@ export const createSignatoryInfoForm: TCreateSignatoryInfoForm = (t) => ({
       .email()
       .required()
       .label(t('organization.register.signatoryEmail')),
-    signatoryTelephone: yup
+    signatoryPhoneNumber: yup
       .string()
       .required()
-      .label(t('organization.register.signatoryTelephone')),
+      .label(t('organization.register.signatoryPhoneNumber')),
   }),
   fields: [
     {
@@ -81,7 +81,7 @@ export const createSignatoryInfoForm: TCreateSignatoryInfoForm = (t) => ({
       required: true,
     },
     {
-      name: 'signatoryTelephone',
+      name: 'signatoryPhoneNumber',
       label: t('organization.register.signatoryPhoneNumber'),
       required: true,
     },

--- a/packages/ui/libs/organization/logic/src/register/types.ts
+++ b/packages/ui/libs/organization/logic/src/register/types.ts
@@ -26,7 +26,7 @@ export type SignatoryInfoFormValues = {
   signatoryCountry: FormSelectOption[];
   signatoryEmail: string;
   signatoryFullName: string;
-  signatoryTelephone: string;
+  signatoryPhoneNumber: string;
   signatoryZipCode: string;
 };
 

--- a/packages/ui/libs/organization/view/src/OrganizationApp.tsx
+++ b/packages/ui/libs/organization/view/src/OrganizationApp.tsx
@@ -14,18 +14,53 @@ import {
   CreateBeneficiaryPage,
 } from './pages';
 
-export const OrganizationApp: FC = () => {
+interface OrganizationAppProps {
+  routesConfig: {
+    showRegisterOrg: boolean;
+    showMyOrg: boolean;
+    showMembers: boolean;
+    showInvitations: boolean;
+    showInvite: boolean;
+    showAllOrgs: boolean;
+    showRegisterIRec: boolean;
+    showCreateBeneficiary: boolean;
+  };
+}
+
+export const OrganizationApp: FC<OrganizationAppProps> = ({ routesConfig }) => {
+  const {
+    showRegisterOrg,
+    showMyOrg,
+    showMembers,
+    showInvitations,
+    showInvite,
+    showAllOrgs,
+    showRegisterIRec,
+    showCreateBeneficiary,
+  } = routesConfig;
+
   return (
     <OrganizationModalsProvider>
       <Routes>
-        <Route path="my" element={<OrganizationViewPage />} />
-        <Route path="invitations" element={<InvitationsPage />} />
-        <Route path="invite" element={<InvitePage />} />
-        <Route path="members" element={<MembersPage />} />
-        <Route path="all" element={<AllOrganizationsPage />} />
-        <Route path="register" element={<RegisterPage />} />
-        <Route path="register-irec" element={<RegisterIRecPage />} />
-        <Route path="create-beneficiary" element={<CreateBeneficiaryPage />} />
+        {showMyOrg && <Route path="my" element={<OrganizationViewPage />} />}
+        {showInvitations && (
+          <Route path="invitations" element={<InvitationsPage />} />
+        )}
+        {showInvite && <Route path="invite" element={<InvitePage />} />}
+        {showMembers && <Route path="members" element={<MembersPage />} />}
+        {showAllOrgs && <Route path="all" element={<AllOrganizationsPage />} />}
+        {showRegisterOrg && (
+          <Route path="register" element={<RegisterPage />} />
+        )}
+        {showRegisterIRec && (
+          <Route path="register-irec" element={<RegisterIRecPage />} />
+        )}
+        {showCreateBeneficiary && (
+          <Route
+            path="create-beneficiary"
+            element={<CreateBeneficiaryPage />}
+          />
+        )}
 
         <Route path="*" element={<PageNotFound />} />
       </Routes>

--- a/packages/ui/libs/ui/core/src/components/notification/NotificationsCenter/NotificationsCenter.styles.ts
+++ b/packages/ui/libs/ui/core/src/components/notification/NotificationsCenter/NotificationsCenter.styles.ts
@@ -8,6 +8,7 @@ export const useStyles = makeStyles((theme) => ({
       opacity: 0.9,
       borderBottom: `1px solid ${theme.palette.primary.main}`,
       padding: theme.spacing(2),
+      fontFamily: theme.typography.fontFamily,
     },
   },
 }));

--- a/packages/ui/libs/user/logic/src/menu/getAccountMenu.ts
+++ b/packages/ui/libs/user/logic/src/menu/getAccountMenu.ts
@@ -1,15 +1,15 @@
 import { TMenuSection } from '@energyweb/origin-ui-core';
 import { TFunction } from 'i18next';
 
-interface IAccountMenuFnArgs {
+export type TGetAccountMenuArgs = {
   t: TFunction;
   isOpen: boolean;
   showSection: boolean;
   showSettings: boolean;
   showUserProfile: boolean;
-}
+};
 
-type TGetAccountMenuFn = (args?: IAccountMenuFnArgs) => TMenuSection;
+type TGetAccountMenuFn = (args?: TGetAccountMenuArgs) => TMenuSection;
 
 export const getAccountMenu: TGetAccountMenuFn = ({
   t,

--- a/packages/ui/libs/user/logic/src/menu/getAdminMenu.ts
+++ b/packages/ui/libs/user/logic/src/menu/getAdminMenu.ts
@@ -1,15 +1,15 @@
 import { TFunction } from 'i18next';
 import { TMenuSection } from '@energyweb/origin-ui-core';
 
-interface IGetAdminMenuFnArgs {
+export type TGetAdminMenuArgs = {
   t: TFunction;
   isOpen: boolean;
   showSection: boolean;
   showUsers: boolean;
   showClaims: boolean;
-}
+};
 
-type TUseAdminMenuFn = (args?: IGetAdminMenuFnArgs) => TMenuSection;
+type TUseAdminMenuFn = (args?: TGetAdminMenuArgs) => TMenuSection;
 
 export const getAdminMenu: TUseAdminMenuFn = ({
   t,

--- a/packages/ui/libs/user/view/src/AccountApp.tsx
+++ b/packages/ui/libs/user/view/src/AccountApp.tsx
@@ -3,11 +3,19 @@ import React, { FC } from 'react';
 import { Route, Routes } from 'react-router';
 import { SettingsPage, ProfilePage } from './pages';
 
-export const AccountApp: FC = () => {
+interface AccountAppProps {
+  routesConfig: {
+    showUserProfile: boolean;
+    showSettings: boolean;
+  };
+}
+
+export const AccountApp: FC<AccountAppProps> = ({ routesConfig }) => {
+  const { showUserProfile, showSettings } = routesConfig;
   return (
     <Routes>
-      <Route path="profile" element={<ProfilePage />} />
-      <Route path="settings" element={<SettingsPage />} />
+      {showUserProfile && <Route path="profile" element={<ProfilePage />} />}
+      {showSettings && <Route path="settings" element={<SettingsPage />} />}
       <Route path="*" element={<PageNotFound />} />
     </Routes>
   );

--- a/packages/ui/libs/user/view/src/AdminApp.tsx
+++ b/packages/ui/libs/user/view/src/AdminApp.tsx
@@ -1,15 +1,25 @@
 import { PageNotFound } from '@energyweb/origin-ui-core';
-import React from 'react';
+import React, { FC } from 'react';
 
 import { Route, Routes } from 'react-router';
 import { AdminUsersPage, AdminUpdateUserPage, AdminClaimsPage } from './pages';
 
-export const AdminApp = () => {
+interface AdminAppProps {
+  routesConfig: {
+    showClaims: boolean;
+    showUsers: boolean;
+  };
+}
+
+export const AdminApp: FC<AdminAppProps> = ({ routesConfig }) => {
+  const { showClaims, showUsers } = routesConfig;
   return (
     <Routes>
-      <Route path="users" element={<AdminUsersPage />} />
-      <Route path="update-user/:id" element={<AdminUpdateUserPage />} />
-      <Route path="claims" element={<AdminClaimsPage />} />
+      {showUsers && <Route path="users" element={<AdminUsersPage />} />}
+      {showUsers && (
+        <Route path="update-user/:id" element={<AdminUpdateUserPage />} />
+      )}
+      {showClaims && <Route path="claims" element={<AdminClaimsPage />} />}
       <Route path="*" element={<PageNotFound />} />
     </Routes>
   );

--- a/packages/ui/libs/user/view/src/AuthApp.tsx
+++ b/packages/ui/libs/user/view/src/AuthApp.tsx
@@ -6,11 +6,18 @@ import { UserModalsProvider } from './context';
 import { UserModalsCenter } from './containers/modals';
 import { PageNotFound } from '@energyweb/origin-ui-core';
 
-export const AuthApp: FC = () => {
+interface AuthAppProps {
+  routesConfig: {
+    showRegister: boolean;
+  };
+}
+
+export const AuthApp: FC<AuthAppProps> = ({ routesConfig }) => {
+  const { showRegister } = routesConfig;
   return (
     <UserModalsProvider>
       <Routes>
-        <Route path="register" element={<RegisterPage />} />
+        {showRegister && <Route path="register" element={<RegisterPage />} />}
         <Route path="*" element={<PageNotFound />} />
       </Routes>
       <UserModalsCenter />


### PR DESCRIPTION
In this PR:
- Hid the routes from all ui apps following the rules for displaying menu items in sidebar navigation
- Fixed the naming of the property in Register Organization form, which blocked the registration
- Now Blockchain Inbox is available only for users with blockchainAccountAddress attached to their organization
- Make device image upload optional in Device Registration form

- Displaying device images in My Devices
- When clicking on table row in Claims Report - user will be redirected to the Certificate Detail View of clicked certificate
- Added loading state for all exchange inbox actions
- Notifications messages now has the same font family as MUI-theme