### PR TITLE
feat/cert claim data

### DIFF
--- a/packages/ui/libs/certificate/logic/src/detail-view/certificateData.ts
+++ b/packages/ui/libs/certificate/logic/src/detail-view/certificateData.ts
@@ -1,5 +1,9 @@
 import { DetailedCertificate } from '@energyweb/origin-ui-certificate-data';
-import { formatDate, PowerFormatter } from '@energyweb/origin-ui-utils';
+import {
+  EnergyFormatter,
+  formatDate,
+  PowerFormatter,
+} from '@energyweb/origin-ui-utils';
 import { useTranslation } from 'react-i18next';
 
 export const useCertificateDataLogic = (certificate: DetailedCertificate) => {
@@ -40,5 +44,39 @@ export const useCertificateDataLogic = (certificate: DetailedCertificate) => {
         true
       ),
     },
+    claimedEnergy: certificate.blockchainPart?.energy?.claimedVolume
+      ? {
+          title: t('certificate.detailView.claimedEnergy'),
+          text: EnergyFormatter.format(
+            certificate.blockchainPart.energy.claimedVolume
+          ),
+        }
+      : undefined,
+    remainingEnergy: certificate.blockchainPart?.energy?.publicVolume
+      ? {
+          title: t('certificate.detailView.remainingEnergy'),
+          text: EnergyFormatter.format(
+            certificate.blockchainPart.energy.publicVolume
+          ),
+        }
+      : undefined,
+    claimBeneficiaries:
+      certificate.blockchainPart?.claims?.length > 0
+        ? {
+            title: t('certificate.detailView.claimBeneficiaries'),
+            listItems: certificate.blockchainPart.claims.map((claim) => {
+              const {
+                beneficiary,
+                location,
+                periodStartDate,
+                periodEndDate,
+                purpose,
+              } = claim.claimData;
+              return `${beneficiary}, ${location}, [From: ${formatDate(
+                periodStartDate
+              )}, To: ${formatDate(periodEndDate)}], Purpose: ${purpose}`;
+            }),
+          }
+        : undefined,
   };
 };

--- a/packages/ui/libs/certificate/view/src/containers/detail-view/CertificateDetails/CertificateDetails.styles.ts
+++ b/packages/ui/libs/certificate/view/src/containers/detail-view/CertificateDetails/CertificateDetails.styles.ts
@@ -31,4 +31,12 @@ export const useStyles = makeStyles((theme) => ({
       textDecoration: 'underline',
     },
   },
+  blockItem: {
+    padding: '18px 26px',
+  },
+  beneficiariesList: {
+    padding: 0,
+    margin: 0,
+    fontFamily: theme.typography.fontFamily,
+  },
 }));

--- a/packages/ui/libs/certificate/view/src/containers/detail-view/CertificateDetails/CertificateDetails.tsx
+++ b/packages/ui/libs/certificate/view/src/containers/detail-view/CertificateDetails/CertificateDetails.tsx
@@ -25,6 +25,9 @@ export const CertificateDetails: FC<CertificateDetailsProps> = ({
     isLoading,
     eventsData,
     blockhainTransactionsTitle,
+    claimedEnergy,
+    remainingEnergy,
+    claimBeneficiaries,
   } = useCertificateDetailsEffects(certificate);
   const blockExplorerUrl = (window as any).config.BLOCKCHAIN_EXPLORER_URL;
 
@@ -37,14 +40,34 @@ export const CertificateDetails: FC<CertificateDetailsProps> = ({
           <Grid item md={4} xs={12}>
             <StyledTitleAndText {...certificateId} />
             <StyledTitleAndText {...certifiedEnergy} />
+            {certificate.blockchainPart.isClaimed && (
+              <StyledTitleAndText {...claimedEnergy} />
+            )}
           </Grid>
           <Grid item md={4} xs={12}>
             <StyledTitleAndText {...claimed} />
             <StyledTitleAndText {...creationDate} />
+            {certificate.blockchainPart.isClaimed && (
+              <StyledTitleAndText {...remainingEnergy} />
+            )}
           </Grid>
           <Grid item md={4} xs={12}>
             <StyledTitleAndText {...generationStartDate} />
             <StyledTitleAndText {...generationEndDate} />
+            {certificate.blockchainPart.isClaimed && (
+              <div className={classes.blockItem}>
+                <Typography color="textSecondary" margin="normal">
+                  {claimBeneficiaries?.title}
+                </Typography>
+                <ol className={classes.beneficiariesList}>
+                  {claimBeneficiaries?.listItems?.map((item) => (
+                    <li key={item}>
+                      <Typography>{item}</Typography>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            )}
           </Grid>
         </Grid>
       </Paper>

--- a/packages/ui/libs/certificate/view/src/containers/detail-view/DeviceDetailCard/DeviceDetailCard.effects.ts
+++ b/packages/ui/libs/certificate/view/src/containers/detail-view/DeviceDetailCard/DeviceDetailCard.effects.ts
@@ -1,0 +1,18 @@
+import { ComposedPublicDevice } from '@energyweb/origin-ui-certificate-data';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+
+export const useDeviceDetailCardEffects = (
+  deviceId: ComposedPublicDevice['id']
+) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const handleViewDevice = () => {
+    navigate(`/device/detail-view/${deviceId}`);
+  };
+
+  const viewDeviceText = t('certificate.detailView.viewDevice');
+
+  return { viewDeviceText, handleViewDevice };
+};

--- a/packages/ui/libs/certificate/view/src/containers/detail-view/DeviceDetailCard/DeviceDetailCard.styles.ts
+++ b/packages/ui/libs/certificate/view/src/containers/detail-view/DeviceDetailCard/DeviceDetailCard.styles.ts
@@ -32,4 +32,7 @@ export const useStyles = makeStyles((theme) => ({
     margin: `${theme.spacing(2)} 0`,
   },
   specValue: {},
+  button: {
+    textTransform: 'none',
+  },
 }));

--- a/packages/ui/libs/certificate/view/src/containers/detail-view/DeviceDetailCard/DeviceDetailCard.tsx
+++ b/packages/ui/libs/certificate/view/src/containers/detail-view/DeviceDetailCard/DeviceDetailCard.tsx
@@ -1,14 +1,17 @@
+import { ComposedPublicDevice } from '@energyweb/origin-ui-certificate-data';
 import {
   IconText,
   IconTextProps,
   SpecField,
   SpecFieldProps,
 } from '@energyweb/origin-ui-core';
-import { Box, Card, CardContent } from '@material-ui/core';
+import { Box, Button, Card, CardContent } from '@material-ui/core';
 import React, { FC } from 'react';
+import { useDeviceDetailCardEffects } from './DeviceDetailCard.effects';
 import { useStyles } from './DeviceDetailCard.styles';
 
 export interface DeviceDetailCardProps {
+  deviceId: ComposedPublicDevice['id'];
   headingIconProps: IconTextProps;
   specFields: SpecFieldProps[];
 }
@@ -16,8 +19,12 @@ export interface DeviceDetailCardProps {
 export const DeviceDetailCard: FC<DeviceDetailCardProps> = ({
   headingIconProps,
   specFields,
+  deviceId,
 }) => {
+  const { viewDeviceText, handleViewDevice } =
+    useDeviceDetailCardEffects(deviceId);
   const classes = useStyles();
+
   return (
     <Card className={classes.card}>
       <Box py={1} px={2} className={classes.heading}>
@@ -29,6 +36,16 @@ export const DeviceDetailCard: FC<DeviceDetailCardProps> = ({
           iconProps={{ className: classes.icon }}
           {...headingIconProps}
         />
+      </Box>
+      <Box width="50%" mx="auto" mt={2}>
+        <Button
+          fullWidth
+          color="inherit"
+          onClick={handleViewDevice}
+          className={classes.button}
+        >
+          {viewDeviceText}
+        </Button>
       </Box>
       <CardContent>
         {specFields.map((spec) => (

--- a/packages/ui/libs/certificate/view/src/containers/detail-view/DeviceDetails/DeviceDetails.tsx
+++ b/packages/ui/libs/certificate/view/src/containers/detail-view/DeviceDetails/DeviceDetails.tsx
@@ -24,7 +24,7 @@ export const DeviceDetails: FC<DeviceDetailsProps> = ({ device }) => {
     <div className={classes.wrapper}>
       <DetailViewCarousel device={device} allFuelTypes={allTypes} />
       <DeviceLocationData {...locationProps} />
-      <DeviceDetailCard {...cardProps} />
+      <DeviceDetailCard deviceId={device.id} {...cardProps} />
     </div>
   );
 };

--- a/packages/ui/libs/exchange/data/src/fetching/bidsAndAsks.ts
+++ b/packages/ui/libs/exchange/data/src/fetching/bidsAndAsks.ts
@@ -10,13 +10,15 @@ export const useApiBidsAndAsks = () => {
   const bids = orders?.filter(
     (order) =>
       order.side === OrderSide.Bid &&
-      (order.status === OrderStatus.Active || OrderStatus.PartiallyFilled) &&
+      (order.status === OrderStatus.Active ||
+        order.status === OrderStatus.PartiallyFilled) &&
       !(order as any).demandId
   );
   const asks = orders?.filter(
     (order) =>
       order.side === OrderSide.Ask &&
-      (order.status === OrderStatus.Active || OrderStatus.PartiallyFilled)
+      (order.status === OrderStatus.Active ||
+        order.status === OrderStatus.PartiallyFilled)
   );
 
   return { asks, bids, isLoading };

--- a/packages/ui/libs/ui/localization/src/languages/en.json
+++ b/packages/ui/libs/ui/localization/src/languages/en.json
@@ -504,6 +504,7 @@
         "remainingEnergy": "Remaining (unclaimed) Energy (MWh)",
         "claimBeneficiaries": "Claim beneficiaries",
         "blockchainTransactions": "Blockchain Transactions",
+        "viewDevice": "View Device",
         "events": {
           "exchangeWallet": "Exchange Wallet",
           "exchangeDepositAddress": "Exchange Deposit Address",

--- a/packages/ui/libs/ui/localization/src/languages/en.json
+++ b/packages/ui/libs/ui/localization/src/languages/en.json
@@ -500,6 +500,9 @@
         "creationDate": "Creation Date",
         "generationStartDate": "Generation Start Date",
         "generationEndDate": "Generation End Date",
+        "claimedEnergy": "Claimed Energy (MWh)",
+        "remainingEnergy": "Remaining (unclaimed) Energy (MWh)",
+        "claimBeneficiaries": "Claim beneficiaries",
         "blockchainTransactions": "Blockchain Transactions",
         "events": {
           "exchangeWallet": "Exchange Wallet",


### PR DESCRIPTION
- Extended Certificate Detail View with Claimed Info, which is show only for certificates where at least partial claim has happened:

<img width="1440" alt="Screenshot 2021-08-26 at 09 55 48" src="https://user-images.githubusercontent.com/69903849/130915857-be8d404d-b164-4583-9cde-d85be540d239.png">

- Added View Device button to Device Card inside Certificate Detail View:

<img width="1435" alt="Screenshot 2021-08-26 at 10 15 45" src="https://user-images.githubusercontent.com/69903849/130918780-ea036c79-c18d-46bc-81e5-c2f213b3cc70.png">

- Fixed filtering Asks and Bids tables in My Orders by status (only Active & Partially Filled)