### PR TITLE
feat/custom icon for mainlayout

### DIFF
--- a/packages/ui/libs/ui/core/src/components/icons/IconLink/IconLink.tsx
+++ b/packages/ui/libs/ui/core/src/components/icons/IconLink/IconLink.tsx
@@ -2,14 +2,15 @@ import { Box, BoxProps } from '@material-ui/core';
 import React, { FC, memo } from 'react';
 import { NavLink } from 'react-router-dom';
 
-export interface IconLinkProps extends BoxProps {
+export interface IconLinkProps {
   url: string;
+  wrapperProps?: BoxProps;
 }
 
 export const IconLink: FC<IconLinkProps> = memo(
-  ({ url, children, ...props }) => {
+  ({ url, children, wrapperProps }) => {
     return (
-      <Box {...props}>
+      <Box {...wrapperProps}>
         <NavLink to={url}>{children}</NavLink>
       </Box>
     );

--- a/packages/ui/libs/ui/core/src/components/navigation/DesktopNav/DesktopNav.tsx
+++ b/packages/ui/libs/ui/core/src/components/navigation/DesktopNav/DesktopNav.tsx
@@ -1,4 +1,4 @@
-import { Drawer, List } from '@material-ui/core';
+import { BoxProps, Drawer, List } from '@material-ui/core';
 import React, { FC, ReactNode } from 'react';
 import { TMenuSection, NavBarSection } from '../NavBarSection';
 import { UsernameAndOrg, UsernameAndOrgProps } from '../../layout';
@@ -11,6 +11,7 @@ export interface DesktopNavProps {
   isAuthenticated: boolean;
   menuSections: TMenuSection[];
   icon?: ReactNode;
+  iconWrapperProps?: BoxProps;
 }
 
 export const DesktopNav: FC<DesktopNavProps> = ({
@@ -18,11 +19,12 @@ export const DesktopNav: FC<DesktopNavProps> = ({
   menuSections = [],
   isAuthenticated,
   icon,
+  iconWrapperProps,
 }) => {
   const classes = useStyles();
   return (
     <Drawer anchor="left" open variant="permanent" className={classes.drawer}>
-      <IconLink url="/">
+      <IconLink url="/" wrapperProps={iconWrapperProps}>
         {icon ? icon : <EnergyWebLogo className={classes.logo} />}
       </IconLink>
       {isAuthenticated && (

--- a/packages/ui/libs/ui/core/src/components/navigation/MobileNav/MobileNav.tsx
+++ b/packages/ui/libs/ui/core/src/components/navigation/MobileNav/MobileNav.tsx
@@ -1,5 +1,5 @@
 import { EnergyWebLogo } from '@energyweb/origin-ui-assets';
-import { Drawer, List } from '@material-ui/core';
+import { BoxProps, Drawer, List } from '@material-ui/core';
 import React, { FC, ReactNode } from 'react';
 import { CloseButton } from '../../buttons';
 import { IconLink } from '../../icons';
@@ -14,6 +14,7 @@ export interface MobileNavProps {
   isAuthenticated: boolean;
   menuSections: TMenuSection[];
   icon?: ReactNode;
+  iconWrapperProps?: BoxProps;
 }
 
 export const MobileNav: FC<MobileNavProps> = ({
@@ -23,6 +24,7 @@ export const MobileNav: FC<MobileNavProps> = ({
   isAuthenticated,
   userAndOrgData,
   icon,
+  iconWrapperProps,
 }) => {
   const classes = useStyles();
   return (
@@ -33,7 +35,7 @@ export const MobileNav: FC<MobileNavProps> = ({
       className={classes.drawer}
     >
       <CloseButton onClose={onClose} />
-      <IconLink url="/">
+      <IconLink url="/" wrapperProps={iconWrapperProps}>
         {icon ? icon : <EnergyWebLogo className={classes.logo} />}
       </IconLink>
       {isAuthenticated && (

--- a/packages/ui/libs/ui/core/src/components/navigation/NavBar/NavBar.tsx
+++ b/packages/ui/libs/ui/core/src/components/navigation/NavBar/NavBar.tsx
@@ -1,5 +1,5 @@
-import { Box } from '@material-ui/core';
-import React, { FC } from 'react';
+import { Box, BoxProps } from '@material-ui/core';
+import React, { FC, ReactNode } from 'react';
 import { UsernameAndOrgProps } from '../../layout';
 import { DesktopNav } from '../DesktopNav';
 import { MobileNav } from '../MobileNav';
@@ -21,6 +21,8 @@ export interface NavBarProps {
   onMobileClose: () => void;
   menuSections: TMenuSection[];
   isAuthenticated: boolean;
+  icon?: ReactNode;
+  iconWrapperProps?: BoxProps;
 }
 
 export const NavBar: FC<NavBarProps> = ({
@@ -30,6 +32,8 @@ export const NavBar: FC<NavBarProps> = ({
   userData,
   orgData,
   isAuthenticated,
+  icon,
+  iconWrapperProps,
 }) => {
   return (
     <>
@@ -40,6 +44,8 @@ export const NavBar: FC<NavBarProps> = ({
           isAuthenticated={isAuthenticated}
           userAndOrgData={{ ...userData, ...orgData }}
           menuSections={menuSections}
+          icon={icon}
+          iconWrapperProps={iconWrapperProps}
         />
       </Box>
       <Box sx={{ display: { lg: 'block', xs: 'none' } }}>
@@ -47,6 +53,8 @@ export const NavBar: FC<NavBarProps> = ({
           isAuthenticated={isAuthenticated}
           userAndOrgData={{ ...userData, ...orgData }}
           menuSections={menuSections}
+          icon={icon}
+          iconWrapperProps={iconWrapperProps}
         />
       </Box>
     </>

--- a/packages/ui/libs/ui/core/src/containers/MainLayout/MainLayout.tsx
+++ b/packages/ui/libs/ui/core/src/containers/MainLayout/MainLayout.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import { BoxProps } from '@material-ui/core';
+import React, { ReactNode } from 'react';
 import { FC } from 'react';
 import { Outlet } from 'react-router-dom';
 import {
@@ -18,15 +19,18 @@ interface MainLayoutProps {
   userData: UserNavData;
   orgData: OrgNavData;
   isAuthenticated: boolean;
+  icon?: ReactNode;
+  iconWrapperProps?: BoxProps;
 }
 
 export const MainLayout: FC<MainLayoutProps> = ({
   topbarButtons,
-  children,
   menuSections,
   userData,
   orgData,
   isAuthenticated,
+  icon,
+  iconWrapperProps,
 }) => {
   const { mobileNavOpen, setMobileNavOpen } = useMainLayoutEffects();
   return (
@@ -43,8 +47,12 @@ export const MainLayout: FC<MainLayoutProps> = ({
         menuSections={menuSections}
         userData={userData}
         orgData={orgData}
+        icon={icon}
+        iconWrapperProps={iconWrapperProps}
       />
-      <PageWrapper>{<Outlet />}</PageWrapper>
+      <PageWrapper>
+        <Outlet />
+      </PageWrapper>
     </>
   );
 };


### PR DESCRIPTION
In this PR added new optional props for Main Layout component:
- `icon`  - allows adding custom icon for sidebar and mobile navigation
- `iconWrapperProps` - allows customising icon wrapper which is a MUI `Box` component