### PR TITLE
fix/device images

### DIFF
--- a/packages/ui/libs/device/data/src/fetching/deviceFirstImage.ts
+++ b/packages/ui/libs/device/data/src/fetching/deviceFirstImage.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { ComposedPublicDevice } from '../types';
+import { publicFileDownloadHandler } from './file';
+
+export const useDeviceFirstImageUrl = (
+  imageIds: ComposedPublicDevice['imageIds']
+) => {
+  const [imageUrl, setImageUrl] = useState('');
+
+  const getAndSetImage = async (id: string) => {
+    const response = await publicFileDownloadHandler(id);
+    const imageType = (response as any).headers['content-type'];
+    const blob = new Blob(
+      [Buffer.from((response.data as any).data as unknown as string)],
+      {
+        type: imageType,
+      }
+    );
+    const urlCreator = window.URL || window.webkitURL;
+    const imageUrl = urlCreator.createObjectURL(blob);
+    setImageUrl(imageUrl);
+  };
+
+  useEffect(() => {
+    if (imageIds?.length > 0) {
+      getAndSetImage(imageIds[0]);
+    }
+  }, [imageIds]);
+
+  return imageUrl;
+};

--- a/packages/ui/libs/device/data/src/fetching/deviceImages.ts
+++ b/packages/ui/libs/device/data/src/fetching/deviceImages.ts
@@ -1,14 +1,14 @@
 import { useEffect, useState } from 'react';
 import { ComposedPublicDevice } from '../types';
-import { fileDownloadHandler } from './file';
+import { publicFileDownloadHandler } from './file';
 
-export const useDeviceImageUrl = (
+export const useDeviceImageUrls = (
   imageIds: ComposedPublicDevice['imageIds']
 ) => {
-  const [imageUrl, setImageUrl] = useState<string>(null);
+  const [imageUrls, setImageUrls] = useState<string[]>([]);
 
-  const getAndSetImage = async (id: string) => {
-    const response = await fileDownloadHandler(id);
+  const getImageUrl = async (id: string) => {
+    const response = await publicFileDownloadHandler(id);
     const imageType = (response as any).headers['content-type'];
     const blob = new Blob(
       [Buffer.from((response.data as any).data as unknown as string)],
@@ -18,14 +18,21 @@ export const useDeviceImageUrl = (
     );
     const urlCreator = window.URL || window.webkitURL;
     const imageUrl = urlCreator.createObjectURL(blob);
-    setImageUrl(imageUrl);
+    return imageUrl;
+  };
+
+  const getAndSetAllImages = async (imageIds: string[]) => {
+    const receivedUrls = await Promise.all(
+      imageIds.map(async (id) => await getImageUrl(id))
+    );
+    setImageUrls(receivedUrls);
   };
 
   useEffect(() => {
     if (imageIds?.length > 0) {
-      getAndSetImage(imageIds[0]);
+      getAndSetAllImages(imageIds);
     }
   }, [imageIds]);
 
-  return imageUrl;
+  return imageUrls;
 };

--- a/packages/ui/libs/device/data/src/fetching/file.ts
+++ b/packages/ui/libs/device/data/src/fetching/file.ts
@@ -3,3 +3,7 @@ import axios from 'axios';
 export const fileDownloadHandler = async (id: string) => {
   return await axios.get(`api/file/${id}`);
 };
+
+export const publicFileDownloadHandler = async (id: string) => {
+  return await axios.get(`api/file/public/${id}`);
+};

--- a/packages/ui/libs/device/data/src/fetching/index.ts
+++ b/packages/ui/libs/device/data/src/fetching/index.ts
@@ -8,4 +8,5 @@ export * from './pendingDevices';
 export * from './regionsConfig';
 export * from './userAndAccount';
 export * from './file';
-export * from './deviceImage';
+export * from './deviceFirstImage';
+export * from './deviceImages';

--- a/packages/ui/libs/device/data/src/handlers/fileUpload.ts
+++ b/packages/ui/libs/device/data/src/handlers/fileUpload.ts
@@ -1,5 +1,12 @@
-import { fileControllerUpload } from '@energyweb/origin-backend-react-query-client';
+import {
+  fileControllerUpload,
+  fileControllerUploadAnonymously,
+} from '@energyweb/origin-backend-react-query-client';
 
 export const fileUploadHandler = async (file: Blob[]) => {
   return await fileControllerUpload({ files: file });
+};
+
+export const publicFileUploadHandler = async (file: Blob[]) => {
+  return await fileControllerUploadAnonymously({ files: file });
 };

--- a/packages/ui/libs/device/logic/src/allDeviceCard/allDeviceCard.ts
+++ b/packages/ui/libs/device/logic/src/allDeviceCard/allDeviceCard.ts
@@ -14,6 +14,7 @@ export const useSpecsForAllDeviceCard: TUseSpecsForAllDeviceCard = ({
   device,
   allTypes,
   clickHandler,
+  imageUrl,
 }) => {
   const { t } = useTranslation();
 
@@ -49,7 +50,7 @@ export const useSpecsForAllDeviceCard: TUseSpecsForAllDeviceCard = ({
   const cardProps: Omit<CardWithImageProps, 'content'> = {
     heading: device.name,
     hoverText: t('device.card.hoverText').toUpperCase(),
-    imageUrl: '',
+    imageUrl,
     fallbackIcon: deviceIcon,
     onActionClick: () => clickHandler(detailViewLink),
   };

--- a/packages/ui/libs/device/logic/src/allDeviceCard/types.ts
+++ b/packages/ui/libs/device/logic/src/allDeviceCard/types.ts
@@ -10,6 +10,7 @@ type TUseSpecsForAllDeviceCardArgs = {
   device: ComposedPublicDevice;
   allTypes: CodeNameDTO[];
   clickHandler: (link: string) => void;
+  imageUrl: string;
 };
 
 type TUseSpecsForAllDeviceCardReturnType = {

--- a/packages/ui/libs/device/view/src/containers/card/MyDeviceCard/MyDeviceCard.effects.ts
+++ b/packages/ui/libs/device/view/src/containers/card/MyDeviceCard/MyDeviceCard.effects.ts
@@ -1,7 +1,7 @@
 import { CodeNameDTO } from '@energyweb/origin-device-registry-irec-local-api-react-query-client';
 import {
   ComposedDevice,
-  useDeviceImageUrl,
+  useDeviceFirstImageUrl,
 } from '@energyweb/origin-ui-device-data';
 import { useSpecsForMyDeviceCard } from '@energyweb/origin-ui-device-logic';
 
@@ -9,7 +9,7 @@ export const useMyDeviceCardEffects = (
   device: ComposedDevice,
   allTypes: CodeNameDTO[]
 ) => {
-  const imageUrl = useDeviceImageUrl(device.imageIds);
+  const imageUrl = useDeviceFirstImageUrl(device.imageIds);
 
   const cardProps = useSpecsForMyDeviceCard({ device, allTypes, imageUrl });
 

--- a/packages/ui/libs/device/view/src/containers/card/PublicDeviceCard/PublicDeviceCard.effects.ts
+++ b/packages/ui/libs/device/view/src/containers/card/PublicDeviceCard/PublicDeviceCard.effects.ts
@@ -1,6 +1,9 @@
 import { useSpecsForAllDeviceCard } from '@energyweb/origin-ui-device-logic';
 
-import { ComposedPublicDevice } from '@energyweb/origin-ui-device-data';
+import {
+  ComposedPublicDevice,
+  useDeviceFirstImageUrl,
+} from '@energyweb/origin-ui-device-data';
 import { CodeNameDTO } from '@energyweb/origin-device-registry-irec-local-api-react-query-client';
 import { useNavigate } from 'react-router';
 
@@ -15,12 +18,15 @@ export const usePublicDeviceCardEffects = ({
 }: TUsePublicDeviceCardEffectsArgs) => {
   const navigate = useNavigate();
 
+  const imageUrl = useDeviceFirstImageUrl(device.imageIds);
+
   const viewDetailsClickHandler = (link: string) => navigate(link);
 
   const { specsData, iconsData, cardProps } = useSpecsForAllDeviceCard({
     device,
     allTypes: allDeviceTypes,
     clickHandler: viewDetailsClickHandler,
+    imageUrl,
   });
 
   return { specsData, iconsData, cardProps };

--- a/packages/ui/libs/device/view/src/containers/carousel/DetailViewCarousel/DetailViewCarousel.tsx
+++ b/packages/ui/libs/device/view/src/containers/carousel/DetailViewCarousel/DetailViewCarousel.tsx
@@ -1,5 +1,4 @@
 import { CodeNameDTO } from '@energyweb/origin-device-registry-irec-local-api-react-query-client';
-import { BlockTintedBottom, ImagesCarousel } from '@energyweb/origin-ui-core';
 import { ComposedPublicDevice } from '@energyweb/origin-ui-device-data';
 import React, { FC } from 'react';
 import { CarouselModeEnum } from '../CarouselControls';
@@ -20,39 +19,25 @@ export const DetailViewCarousel: FC<DetailViewCarouselProps> = ({
   const { carouselMode, handleModeChange } = useDetailViewCarouselEffects();
   const classes = useStyles();
   return (
-    <ImagesCarousel
-      carouselProps={{
-        interval: 10000,
-        navButtonsAlwaysInvisible: true,
-        indicatorContainerProps: {
-          className: classes.indicatorContainer,
-          style: {},
-        },
-      }}
-    >
-      <BlockTintedBottom
-        height={carouselMode === CarouselModeEnum.Map ? 70 : undefined}
-      >
-        {carouselMode === CarouselModeEnum.Photo ? (
-          <DeviceImagesCarousel
-            deviceName={device.name}
-            images={device.imageIds}
-            fuelType={device.fuelType}
-            allFuelTypes={allFuelTypes}
-            carouselMode={carouselMode}
-            handleModeChange={handleModeChange}
-            itemProps={{ className: classes.item }}
-          />
-        ) : (
-          <DeviceMapCarousel
-            device={device}
-            carouselMode={carouselMode}
-            handleModeChange={handleModeChange}
-            mapContainerClassName={classes.mapContainer}
-            itemProps={{ className: classes.item }}
-          />
-        )}
-      </BlockTintedBottom>
-    </ImagesCarousel>
+    <>
+      {carouselMode === CarouselModeEnum.Photo ? (
+        <DeviceImagesCarousel
+          deviceName={device.name}
+          imageIds={device.imageIds}
+          fuelType={device.fuelType}
+          allFuelTypes={allFuelTypes}
+          carouselMode={carouselMode}
+          handleModeChange={handleModeChange}
+          itemProps={{ className: classes.item }}
+        />
+      ) : (
+        <DeviceMapCarousel
+          device={device}
+          carouselMode={carouselMode}
+          handleModeChange={handleModeChange}
+          itemProps={{ className: classes.item }}
+        />
+      )}
+    </>
   );
 };

--- a/packages/ui/libs/device/view/src/containers/carousel/DeviceImagesCarousel/DeviceImagesCarousel.effects.ts
+++ b/packages/ui/libs/device/view/src/containers/carousel/DeviceImagesCarousel/DeviceImagesCarousel.effects.ts
@@ -1,5 +1,9 @@
 import { CodeNameDTO } from '@energyweb/origin-device-registry-irec-local-api-react-query-client';
-import { ComposedPublicDevice } from '@energyweb/origin-ui-device-data';
+import {
+  ComposedDevice,
+  ComposedPublicDevice,
+  useDeviceImageUrls,
+} from '@energyweb/origin-ui-device-data';
 import {
   getEnergyTypeImage,
   getMainFuelType,
@@ -7,14 +11,17 @@ import {
 import { EnergyTypeEnum } from '@energyweb/origin-ui-utils';
 
 export const useDeviceImagesCarouselEffects = (
+  imageIds: ComposedDevice['imageIds'],
   fuelType: ComposedPublicDevice['fuelType'],
   allFuelTypes: CodeNameDTO[]
 ) => {
+  const imageUrls = useDeviceImageUrls(imageIds);
+
   const { mainType } = getMainFuelType(fuelType, allFuelTypes);
   const FallbackIcon = getEnergyTypeImage(
     mainType.toLowerCase() as EnergyTypeEnum,
     true
   );
 
-  return FallbackIcon;
+  return { FallbackIcon, imageUrls };
 };

--- a/packages/ui/libs/device/view/src/containers/carousel/DeviceImagesCarousel/DeviceImagesCarousel.styles.ts
+++ b/packages/ui/libs/device/view/src/containers/carousel/DeviceImagesCarousel/DeviceImagesCarousel.styles.ts
@@ -1,21 +1,25 @@
 import { makeStyles } from '@material-ui/core';
 
 export const useStyles = makeStyles((theme) => ({
-  item: {
-    width: '100%',
+  indicatorContainer: {
+    position: 'absolute',
+    textAlign: 'left',
+    maxWidth: 150,
     [theme.breakpoints.up('lg')]: {
-      height: 380,
+      left: 250,
+      bottom: 25,
     },
     [theme.breakpoints.down('lg')]: {
-      height: 250,
+      left: 225,
+      bottom: 15,
     },
     [theme.breakpoints.down('md')]: {
-      height: 220,
+      left: 200,
+      bottom: 10,
     },
     [theme.breakpoints.down('sm')]: {
-      height: 200,
+      maxWidth: 100,
+      left: 180,
     },
-    objectFit: 'cover',
-    borderRadius: 5,
   },
 }));

--- a/packages/ui/libs/device/view/src/containers/carousel/DeviceImagesCarousel/DeviceImagesCarousel.tsx
+++ b/packages/ui/libs/device/view/src/containers/carousel/DeviceImagesCarousel/DeviceImagesCarousel.tsx
@@ -3,10 +3,12 @@ import { ComposedPublicDevice } from '@energyweb/origin-ui-device-data';
 import { CarouselControls, CarouselModeEnum } from '../CarouselControls';
 import { CodeNameDTO } from '@energyweb/origin-device-registry-irec-local-api-react-query-client';
 import { useDeviceImagesCarouselEffects } from './DeviceImagesCarousel.effects';
+import { BlockTintedBottom, ImagesCarousel } from '@energyweb/origin-ui-core';
+import { useStyles } from './DeviceImagesCarousel.styles';
 
 export interface DeviceImagesCarouselProps {
   deviceName: ComposedPublicDevice['name'];
-  images: ComposedPublicDevice['imageIds'];
+  imageIds: ComposedPublicDevice['imageIds'];
   allFuelTypes: CodeNameDTO[];
   fuelType: ComposedPublicDevice['fuelType'];
   itemProps: React.SVGAttributes<HTMLOrSVGElement>;
@@ -19,23 +21,51 @@ export interface DeviceImagesCarouselProps {
 
 export const DeviceImagesCarousel: FC<DeviceImagesCarouselProps> = ({
   deviceName,
-  images,
+  imageIds,
   fuelType,
   allFuelTypes,
   itemProps,
   carouselMode,
   handleModeChange,
 }) => {
-  const FallbackIcon = useDeviceImagesCarouselEffects(fuelType, allFuelTypes);
-
+  const { FallbackIcon, imageUrls } = useDeviceImagesCarouselEffects(
+    imageIds,
+    fuelType,
+    allFuelTypes
+  );
+  const classes = useStyles();
   return (
-    <>
-      <FallbackIcon {...itemProps} />
-      <CarouselControls
-        deviceName={deviceName}
-        carouselMode={carouselMode}
-        handleModeChange={handleModeChange}
-      />
-    </>
+    <ImagesCarousel
+      carouselProps={{
+        interval: 10000,
+        navButtonsAlwaysInvisible: true,
+        indicatorContainerProps: {
+          className: classes.indicatorContainer,
+          style: {},
+        },
+      }}
+    >
+      {imageUrls.length > 0 ? (
+        imageUrls.map((url) => (
+          <BlockTintedBottom key={url}>
+            <img src={url} {...itemProps} />
+            <CarouselControls
+              deviceName={deviceName}
+              carouselMode={carouselMode}
+              handleModeChange={handleModeChange}
+            />
+          </BlockTintedBottom>
+        ))
+      ) : (
+        <BlockTintedBottom>
+          <FallbackIcon {...itemProps} />
+          <CarouselControls
+            deviceName={deviceName}
+            carouselMode={carouselMode}
+            handleModeChange={handleModeChange}
+          />
+        </BlockTintedBottom>
+      )}
+    </ImagesCarousel>
   );
 };

--- a/packages/ui/libs/device/view/src/containers/carousel/DeviceMapCarousel/DeviceMapCarousel.styles.ts
+++ b/packages/ui/libs/device/view/src/containers/carousel/DeviceMapCarousel/DeviceMapCarousel.styles.ts
@@ -1,0 +1,8 @@
+import { makeStyles } from '@material-ui/core';
+
+export const useStyles = makeStyles({
+  mapContainer: {
+    width: '100%',
+    height: '100%',
+  },
+});

--- a/packages/ui/libs/device/view/src/containers/carousel/DeviceMapCarousel/DeviceMapCarousel.tsx
+++ b/packages/ui/libs/device/view/src/containers/carousel/DeviceMapCarousel/DeviceMapCarousel.tsx
@@ -1,8 +1,9 @@
-import { GenericMap } from '@energyweb/origin-ui-core';
+import { BlockTintedBottom, GenericMap } from '@energyweb/origin-ui-core';
 import { ComposedPublicDevice } from '@energyweb/origin-ui-device-data';
 import React, { FC } from 'react';
 import { useDeviceAppEnv } from '../../../context';
 import { CarouselControls, CarouselModeEnum } from '../CarouselControls';
+import { useStyles } from './DeviceMapCarousel.styles';
 
 interface DeviceMapCarouselProps {
   device: ComposedPublicDevice;
@@ -12,7 +13,6 @@ interface DeviceMapCarouselProps {
     mode: CarouselModeEnum
   ) => void;
   itemProps: React.HTMLAttributes<HTMLDivElement>;
-  mapContainerClassName?: string;
 }
 
 export const DeviceMapCarousel: FC<DeviceMapCarouselProps> = ({
@@ -20,28 +20,30 @@ export const DeviceMapCarousel: FC<DeviceMapCarouselProps> = ({
   itemProps,
   carouselMode,
   handleModeChange,
-  mapContainerClassName,
 }) => {
+  const classes = useStyles();
   const { googleMapsApiKey } = useDeviceAppEnv();
   return (
-    <div {...itemProps}>
-      <GenericMap
-        apiKey={googleMapsApiKey}
-        allItems={[device]}
-        containerClassName={mapContainerClassName}
-        mapProps={{
-          options: {
-            mapTypeControl: false,
-            streetViewControl: false,
-            fullscreenControl: true,
-          },
-        }}
-      />
-      <CarouselControls
-        deviceName={device.name}
-        carouselMode={carouselMode}
-        handleModeChange={handleModeChange}
-      />
-    </div>
+    <BlockTintedBottom height={70}>
+      <div {...itemProps}>
+        <GenericMap
+          apiKey={googleMapsApiKey}
+          allItems={[device]}
+          containerClassName={classes.mapContainer}
+          mapProps={{
+            options: {
+              mapTypeControl: false,
+              streetViewControl: false,
+              fullscreenControl: true,
+            },
+          }}
+        />
+        <CarouselControls
+          deviceName={device.name}
+          carouselMode={carouselMode}
+          handleModeChange={handleModeChange}
+        />
+      </div>
+    </BlockTintedBottom>
   );
 };

--- a/packages/ui/libs/device/view/src/containers/file/DeviceImagesUpload/DeviceImagesUpload.effects.ts
+++ b/packages/ui/libs/device/view/src/containers/file/DeviceImagesUpload/DeviceImagesUpload.effects.ts
@@ -1,5 +1,5 @@
 import { UploadedFile } from '@energyweb/origin-ui-core';
-import { fileUploadHandler } from '@energyweb/origin-ui-device-data';
+import { publicFileUploadHandler } from '@energyweb/origin-ui-device-data';
 import { DeviceImagesFormValues } from '@energyweb/origin-ui-device-logic';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,7 +17,7 @@ export const useDeviceImagesUploadEffects = () => {
   const uploadText = t('file.upload.dropOrClick');
   const deviceImagesHeading = t('device.register.deviceImagesFormTitle');
 
-  const uploadFunction = fileUploadHandler;
+  const uploadFunction = publicFileUploadHandler;
   const onDeviceImageChange = (newValues: UploadedFile[]) =>
     setImageIds(newValues);
 


### PR DESCRIPTION
In this PR fixed displaying uploaded device images in All Devices and Device Detail View. 
Fix was processed via changing the used upload endpoint from `api/file/`  to  `api/file/public` and using public download endpoint when retrieving images.
Also refactored a bit the way Images Carousel is organised in Device Detail View.

![Screenshot 2021-09-02 at 11 15 52](https://user-images.githubusercontent.com/69903849/131808960-4bc98602-7753-4517-a8e9-0b78fa45bd00.png)
![Screenshot 2021-09-02 at 11 16 05](https://user-images.githubusercontent.com/69903849/131808968-86d3709f-a329-41f2-95db-e62194d99fad.png)
![Screenshot 2021-09-02 at 11 16 15](https://user-images.githubusercontent.com/69903849/131808975-5650f9ea-4f9f-4f5c-9a92-3c06dbdc3084.png)
