### PR TITLE
chore/irec connect form adjust

### DIFF
--- a/packages/ui/libs/organization/logic/src/connect-irec/connectForm.ts
+++ b/packages/ui/libs/organization/logic/src/connect-irec/connectForm.ts
@@ -63,7 +63,5 @@ export const useConnectIRecFormLogic = (
     inputsVariant: 'filled',
     formTitleVariant: 'h6',
     buttonText: t('general.buttons.submit'),
-    buttonDisabled: Boolean(iRecConnection?.active),
-    formDisabled: Boolean(iRecConnection?.active),
   };
 };


### PR DESCRIPTION
Removed disabling Connect I-REC form since `active` property in connection response is not trustful and sometimes could require reseting the connection even though `active === true`