### PR TITLE
feat/expanded asks

### DIFF
--- a/packages/ui/libs/exchange/data/src/cached/cachedDeviceTypes.ts
+++ b/packages/ui/libs/exchange/data/src/cached/cachedDeviceTypes.ts
@@ -1,0 +1,10 @@
+import { CodeNameDTO } from '@energyweb/issuer-irec-api-react-query-client';
+import { getDeviceControllerGetDeviceTypesQueryKey } from '@energyweb/origin-device-registry-irec-local-api-react-query-client';
+import { useQueryClient } from 'react-query';
+
+export const useCachedAllDeviceTypes = () => {
+  const queryClient = useQueryClient();
+  const deviceTypesQueryKey = getDeviceControllerGetDeviceTypesQueryKey();
+
+  return queryClient.getQueryData<CodeNameDTO[]>(deviceTypesQueryKey);
+};

--- a/packages/ui/libs/exchange/data/src/cached/index.ts
+++ b/packages/ui/libs/exchange/data/src/cached/index.ts
@@ -3,3 +3,4 @@ export * from './cachedExchangeCertificates';
 export * from './cachedFuelTypes';
 export * from './cachedUser';
 export * from './cachedAllDemands';
+export * from './cachedDeviceTypes';

--- a/packages/ui/libs/exchange/data/src/fetching/assetById.ts
+++ b/packages/ui/libs/exchange/data/src/fetching/assetById.ts
@@ -1,0 +1,11 @@
+import {
+  AssetDTO,
+  OrderBookOrderDTO,
+  useAssetControllerGet,
+} from '@energyweb/exchange-irec-react-query-client';
+
+export const useApiGetAssetById = (assetId: OrderBookOrderDTO['assetId']) => {
+  const { data, isLoading } = useAssetControllerGet(assetId);
+  const asset = data || ({} as AssetDTO);
+  return { asset, isLoading };
+};

--- a/packages/ui/libs/exchange/data/src/fetching/iRecDeviceById.ts
+++ b/packages/ui/libs/exchange/data/src/fetching/iRecDeviceById.ts
@@ -1,0 +1,16 @@
+import { AssetDTO } from '@energyweb/exchange-irec-react-query-client';
+import {
+  PublicDeviceDTO,
+  useDeviceControllerGet,
+} from '@energyweb/origin-device-registry-irec-local-api-react-query-client';
+
+export const useApiGetIRecDeviceById = (
+  deviceId: AssetDTO['deviceId'],
+  enabled: boolean
+) => {
+  const { data, isLoading } = useDeviceControllerGet(deviceId, {
+    query: { enabled },
+  });
+  const device = data || ({} as PublicDeviceDTO);
+  return { device, isLoading };
+};

--- a/packages/ui/libs/exchange/data/src/fetching/index.ts
+++ b/packages/ui/libs/exchange/data/src/fetching/index.ts
@@ -14,3 +14,5 @@ export * from './allDemands';
 export * from './bidsAndAsks';
 export * from './userAndAccount';
 export * from './user';
+export * from './assetById';
+export * from './iRecDeviceById';

--- a/packages/ui/libs/exchange/logic/src/marketTables/expandedAsksRow.ts
+++ b/packages/ui/libs/exchange/logic/src/marketTables/expandedAsksRow.ts
@@ -1,0 +1,45 @@
+import { formatDate } from '@energyweb/origin-ui-utils';
+import { useTranslation } from 'react-i18next';
+import { getMainFuelType } from '../utils';
+import { TUseExpandedAsksRowLogic } from './types';
+
+export const useExpandedAsksRowLogic: TUseExpandedAsksRowLogic = ({
+  ask,
+  device,
+  allFuelTypes,
+  allDeviceTypes,
+}) => {
+  const { t } = useTranslation();
+  const splitDeviceType = ask.product.deviceType[0].split(';');
+
+  const fuelTypeCode = splitDeviceType[0];
+  const fuelType = getMainFuelType(fuelTypeCode, allFuelTypes);
+
+  const deviceTypeCode = splitDeviceType[1];
+  const deviceType = allDeviceTypes.find(
+    (type) => type.code === deviceTypeCode
+  )?.name;
+
+  return {
+    facilityName: {
+      title: t('exchange.viewMarket.facilityName'),
+      text: device.name,
+    },
+    constructed: {
+      title: t('exchange.viewMarket.constructed'),
+      text: formatDate(device.commissioningDate),
+    },
+    fuelDeviceType: {
+      title: t('exchange.viewMarket.fuelDeviceType'),
+      text: `${fuelType.mainType} ${fuelType.restType} / ${deviceType}`,
+    },
+    generationFrom: {
+      title: t('exchange.viewMarket.generationFrom'),
+      text: formatDate(ask.product.generationFrom),
+    },
+    generationTo: {
+      title: t('exchange.viewMarket.generationTo'),
+      text: formatDate(ask.product.generationTo),
+    },
+  };
+};

--- a/packages/ui/libs/exchange/logic/src/marketTables/index.ts
+++ b/packages/ui/libs/exchange/logic/src/marketTables/index.ts
@@ -2,3 +2,4 @@ export * from './sellOffers';
 export * from './buyOffers';
 export * from './tradingView';
 export * from './buyDirect';
+export * from './expandedAsksRow';

--- a/packages/ui/libs/exchange/logic/src/marketTables/tradingView.tsx
+++ b/packages/ui/libs/exchange/logic/src/marketTables/tradingView.tsx
@@ -17,6 +17,7 @@ import {
 export const formatAsksForTradingView: TFormatAsksForTradingView = ({
   asks,
   allFuelTypes,
+  expandedRowComponent,
 }) => {
   return asks?.map((ask) => {
     const fuelCode = ask.product.deviceType[0].split(';')[0];
@@ -28,6 +29,7 @@ export const formatAsksForTradingView: TFormatAsksForTradingView = ({
       fuelType: <Icon style={{ width: 20 }} />,
       volume: PowerFormatter.format(parseInt(ask.volume)),
       price: ask.price / 100,
+      expandedRowComponent,
     };
   });
 };
@@ -38,6 +40,7 @@ export const useAsksTableLogic: TUseAsksTableLogic = ({
   isLoading,
   user,
   className,
+  expandedRowComponent,
 }) => {
   const { t } = useTranslation();
   return {
@@ -48,7 +51,9 @@ export const useAsksTableLogic: TUseAsksTableLogic = ({
     },
     loading: isLoading,
     getCustomRowClassName: getOwnedOrderStyles(asks, user?.id, className),
-    data: formatAsksForTradingView({ asks, allFuelTypes }) ?? [],
+    data:
+      formatAsksForTradingView({ asks, allFuelTypes, expandedRowComponent }) ??
+      [],
   };
 };
 

--- a/packages/ui/libs/exchange/logic/src/marketTables/types.ts
+++ b/packages/ui/libs/exchange/logic/src/marketTables/types.ts
@@ -1,9 +1,15 @@
 import { OrderBookOrderDTO } from '@energyweb/exchange-irec-react-query-client';
+import { UserDTO } from '@energyweb/origin-backend-react-query-client';
 import {
   CodeNameDTO,
-  UserDTO,
+  PublicDeviceDTO,
 } from '@energyweb/origin-device-registry-irec-local-api-react-query-client';
-import { TableComponentProps, TableRowData } from '@energyweb/origin-ui-core';
+import {
+  SmallTitleWithTextProps,
+  TableComponentProps,
+  TableRowData,
+} from '@energyweb/origin-ui-core';
+import { FC } from 'react';
 import { TFunction } from 'react-i18next';
 
 // Sell offers table
@@ -49,6 +55,7 @@ export type TUseAsksTableArgs = {
   isLoading: boolean;
   className: string;
   user: UserDTO;
+  expandedRowComponent: FC<{ id: OrderBookOrderDTO['id'] }>;
 };
 export type TFormatAsksForTradingView = (
   props: Omit<TUseAsksTableArgs, 'isLoading' | 'user' | 'className'>
@@ -71,3 +78,20 @@ export type TUseBidsTableLogic = (
   props: TUseBidsTableArgs
 ) => TableComponentProps<OrderBookOrderDTO['id']>;
 // Trading view
+
+// Expanded asks row
+export type TUseExpandedAsksRowLogicArgs = {
+  ask: OrderBookOrderDTO;
+  device: PublicDeviceDTO;
+  allFuelTypes: CodeNameDTO[];
+  allDeviceTypes: CodeNameDTO[];
+};
+
+export type TUseExpandedAsksRowLogic = (args: TUseExpandedAsksRowLogicArgs) => {
+  facilityName: SmallTitleWithTextProps;
+  constructed: SmallTitleWithTextProps;
+  fuelDeviceType: SmallTitleWithTextProps;
+  generationFrom: SmallTitleWithTextProps;
+  generationTo: SmallTitleWithTextProps;
+};
+// Expanded asks row

--- a/packages/ui/libs/exchange/logic/src/utils/getOwnedOrderStyles.ts
+++ b/packages/ui/libs/exchange/logic/src/utils/getOwnedOrderStyles.ts
@@ -8,6 +8,6 @@ export const getOwnedOrderStyles = (
 ) => {
   return (id: OrderBookOrderDTO['id']) => {
     const order = orders.find((order) => order.id === id);
-    if (order.userId === userId?.toString()) return className;
+    if (userId && order.userId === userId.toString()) return className;
   };
 };

--- a/packages/ui/libs/exchange/view/src/containers/orderbook/ExpandedAsksRow/ExpandedAsksRow.effects.ts
+++ b/packages/ui/libs/exchange/view/src/containers/orderbook/ExpandedAsksRow/ExpandedAsksRow.effects.ts
@@ -1,0 +1,34 @@
+import { OrderBookOrderDTO } from '@energyweb/exchange-irec-react-query-client';
+import {
+  useApiGetAssetById,
+  useApiGetIRecDeviceById,
+  useCachedAllDeviceTypes,
+  useCachedAllFuelTypes,
+} from '@energyweb/origin-ui-exchange-data';
+import { useExpandedAsksRowLogic } from '@energyweb/origin-ui-exchange-logic';
+import { useOrderBookAsksContext } from '../../../context';
+
+export const useExpandedAsksRowEffects = (id: OrderBookOrderDTO['id']) => {
+  const asks = useOrderBookAsksContext();
+  const ask = asks.find((ask) => ask.id === id);
+  const assetId = ask?.assetId;
+  const allFuelTypes = useCachedAllFuelTypes();
+  const allDeviceTypes = useCachedAllDeviceTypes();
+
+  const { asset, isLoading: isAssetLoading } = useApiGetAssetById(assetId);
+  const { device, isLoading: isDeviceLoading } = useApiGetIRecDeviceById(
+    asset.deviceId,
+    !isAssetLoading
+  );
+
+  const expandedViewFields = useExpandedAsksRowLogic({
+    ask,
+    device,
+    allFuelTypes,
+    allDeviceTypes,
+  });
+
+  const isLoading = isAssetLoading || isDeviceLoading;
+
+  return { isLoading, ...expandedViewFields };
+};

--- a/packages/ui/libs/exchange/view/src/containers/orderbook/ExpandedAsksRow/ExpandedAsksRow.tsx
+++ b/packages/ui/libs/exchange/view/src/containers/orderbook/ExpandedAsksRow/ExpandedAsksRow.tsx
@@ -1,0 +1,46 @@
+import { OrderBookOrderDTO } from '@energyweb/exchange-irec-react-query-client';
+import { SmallTitleWithText } from '@energyweb/origin-ui-core';
+import { Box, CircularProgress, Grid } from '@material-ui/core';
+import React, { FC } from 'react';
+import { useExpandedAsksRowEffects } from './ExpandedAsksRow.effects';
+
+interface ExpandedAsksRow {
+  id: OrderBookOrderDTO['id'];
+}
+
+export const ExpandedAsksRow: FC<ExpandedAsksRow> = ({ id }) => {
+  const {
+    isLoading,
+    facilityName,
+    constructed,
+    fuelDeviceType,
+    generationFrom,
+    generationTo,
+  } = useExpandedAsksRowEffects(id);
+
+  if (isLoading) return <CircularProgress />;
+
+  return (
+    <Box>
+      <Grid container>
+        <Grid item xs={12} sm={6}>
+          <SmallTitleWithText {...facilityName} />
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <SmallTitleWithText {...constructed} />
+        </Grid>
+      </Grid>
+      <Grid container sx={{ my: { sm: 2 } }}>
+        <SmallTitleWithText {...fuelDeviceType} />
+      </Grid>
+      <Grid container>
+        <Grid item xs={12} sm={6}>
+          <SmallTitleWithText {...generationFrom} />
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <SmallTitleWithText {...generationTo} />
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};

--- a/packages/ui/libs/exchange/view/src/containers/orderbook/ExpandedAsksRow/index.ts
+++ b/packages/ui/libs/exchange/view/src/containers/orderbook/ExpandedAsksRow/index.ts
@@ -1,0 +1,1 @@
+export * from './ExpandedAsksRow';

--- a/packages/ui/libs/exchange/view/src/containers/orderbook/TradingView/TradingView.effects.tsx
+++ b/packages/ui/libs/exchange/view/src/containers/orderbook/TradingView/TradingView.effects.tsx
@@ -6,12 +6,13 @@ import {
   useAsksTableLogic,
   useBidsTableLogic,
 } from '@energyweb/origin-ui-exchange-logic';
-import { useMediaQuery, useTheme } from '@material-ui/core';
+import { Theme, useMediaQuery } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import React from 'react';
+import { MultipleDeviceIcons } from '../MultipleDeviceIcons';
+import { ExpandedAsksRow } from '../ExpandedAsksRow';
 import { TradingViewProps } from './TradingView';
 import { useStyles } from './TradingView.styles';
-import { MultipleDeviceIcons } from '../MultipleDeviceIcons';
 
 export const useTradingViewEffects = ({
   orderBookData,
@@ -21,8 +22,9 @@ export const useTradingViewEffects = ({
   const allFuelTypes = useCachedAllFuelTypes();
   const user = useCachedUser();
   const classes = useStyles();
-  const theme = useTheme();
-  const mobileView = useMediaQuery(theme.breakpoints.down('md'));
+  const mobileView = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.down('md')
+  );
 
   const asksTableProps = useAsksTableLogic({
     asks: orderBookData.asks,
@@ -30,6 +32,7 @@ export const useTradingViewEffects = ({
     allFuelTypes,
     user,
     className: classes.owned,
+    expandedRowComponent: ExpandedAsksRow,
   });
 
   const bidsTableLogic = useBidsTableLogic({

--- a/packages/ui/libs/exchange/view/src/containers/orderbook/TradingView/TradingView.tsx
+++ b/packages/ui/libs/exchange/view/src/containers/orderbook/TradingView/TradingView.tsx
@@ -2,6 +2,7 @@ import { TableComponent } from '@energyweb/origin-ui-core';
 import { TOrderBookData } from '@energyweb/origin-ui-exchange-data';
 import { Box, Grid } from '@material-ui/core';
 import React, { FC } from 'react';
+import { OrderBookAsksProvider } from '../../../context';
 import { OrderBookTableHeader } from '../OrderBookTableHeader';
 import { useTradingViewEffects } from './TradingView.effects';
 
@@ -31,7 +32,9 @@ export const TradingView: FC<TradingViewProps> = (props) => {
             currentOrders={props.orderBookData?.asks?.length}
             popoverText={popoverTextAsks}
           />
-          <TableComponent {...asksTableProps} />
+          <OrderBookAsksProvider asks={props.orderBookData?.asks}>
+            <TableComponent {...asksTableProps} />
+          </OrderBookAsksProvider>
         </Grid>
         <Grid item md={6} xs={12}>
           <OrderBookTableHeader

--- a/packages/ui/libs/exchange/view/src/context/asks/index.ts
+++ b/packages/ui/libs/exchange/view/src/context/asks/index.ts
@@ -1,0 +1,1 @@
+export * from './provider';

--- a/packages/ui/libs/exchange/view/src/context/asks/provider.tsx
+++ b/packages/ui/libs/exchange/view/src/context/asks/provider.tsx
@@ -1,0 +1,18 @@
+import { OrderBookOrderDTO } from '@energyweb/exchange-irec-react-query-client';
+import React, { createContext, useContext, FC } from 'react';
+
+const OrderBookAsksStore = createContext<OrderBookOrderDTO[]>(null);
+
+export const OrderBookAsksProvider: FC<{
+  asks: OrderBookOrderDTO[];
+}> = ({ asks, children }) => {
+  return (
+    <OrderBookAsksStore.Provider value={asks}>
+      {children}
+    </OrderBookAsksStore.Provider>
+  );
+};
+
+export const useOrderBookAsksContext = () => {
+  return useContext(OrderBookAsksStore);
+};

--- a/packages/ui/libs/exchange/view/src/context/index.ts
+++ b/packages/ui/libs/exchange/view/src/context/index.ts
@@ -1,1 +1,2 @@
 export * from './modals';
+export * from './asks';

--- a/packages/ui/libs/ui/core/src/components/table/TableComponentRow/TableComponentRow.effects.ts
+++ b/packages/ui/libs/ui/core/src/components/table/TableComponentRow/TableComponentRow.effects.ts
@@ -1,0 +1,38 @@
+import {
+  TableHeaderData,
+  TableRowData,
+} from '../../../containers/TableComponent';
+import { useState } from 'react';
+
+export const useTableComponentRowEffects = <Id>(
+  row: TableRowData<Id>,
+  onRowClick: (id: Id) => void,
+  headerData: TableHeaderData
+) => {
+  const [showExpanded, setShowExpanded] = useState(false);
+
+  const handleExpandRow = () => {
+    row.expandedRowComponent && setShowExpanded(!showExpanded);
+  };
+
+  const handleRowClick = () => {
+    onRowClick && onRowClick(row.id);
+  };
+
+  const handleClick = row.expandedRowComponent
+    ? handleExpandRow
+    : handleRowClick;
+  const headerKeys = Object.keys(headerData);
+
+  const applyHoverStyles =
+    Boolean(onRowClick) || Boolean(row.expandedRowComponent);
+  const ExpandedRow = row.expandedRowComponent;
+
+  return {
+    headerKeys,
+    handleClick,
+    showExpanded,
+    ExpandedRow,
+    applyHoverStyles,
+  };
+};

--- a/packages/ui/libs/ui/core/src/components/table/TableComponentRow/TableComponentRow.tsx
+++ b/packages/ui/libs/ui/core/src/components/table/TableComponentRow/TableComponentRow.tsx
@@ -1,8 +1,9 @@
-import { TableRow } from '@material-ui/core';
+import { TableCell, TableRow } from '@material-ui/core';
 import React, { PropsWithChildren, ReactElement } from 'react';
 import { TableRowData, TableHeaderData } from '../../../containers';
 import { TableComponentActions } from '../TableComponentActions';
 import { TableComponentCell } from '../TableComponentCell';
+import { useTableComponentRowEffects } from './TableComponentRow.effects';
 import { useStyles } from './TableComponentRow.styles';
 
 interface TableComponentRowProps<Id> {
@@ -22,31 +23,46 @@ export const TableComponentRow: TTableComponentRow = ({
   onRowClick,
   className,
 }) => {
+  const {
+    handleClick,
+    headerKeys,
+    showExpanded,
+    ExpandedRow,
+    applyHoverStyles,
+  } = useTableComponentRowEffects(row, onRowClick, headerData);
+
   const classes = useStyles();
-  const headerKeys = Object.keys(headerData);
-
-  const handleClick = () => {
-    onRowClick && onRowClick(row.id);
-  };
-
-  const rowClass = `${className} ${onRowClick && classes.hover}`;
+  const rowClass = `${className} ${applyHoverStyles && classes.hover}`;
 
   return (
-    <TableRow className={rowClass} onClick={handleClick}>
-      {headerKeys.map((key) =>
-        key === 'actions' ? (
-          <TableComponentActions
-            key={key + row.id.toString()}
-            id={row.id}
-            actions={row.actions}
-          />
-        ) : (
-          <TableComponentCell
-            key={key + row.id.toString()}
-            cellData={row[key]}
-          />
-        )
+    <>
+      <TableRow
+        className={rowClass}
+        onClick={handleClick}
+        hover={applyHoverStyles}
+      >
+        {headerKeys.map((key) =>
+          key === 'actions' ? (
+            <TableComponentActions
+              key={key + row.id.toString()}
+              id={row.id}
+              actions={row.actions}
+            />
+          ) : (
+            <TableComponentCell
+              key={key + row.id.toString()}
+              cellData={row[key]}
+            />
+          )
+        )}
+      </TableRow>
+      {row.expandedRowComponent && showExpanded && (
+        <TableRow>
+          <TableCell colSpan={headerKeys.length}>
+            <ExpandedRow id={row.id} />
+          </TableCell>
+        </TableRow>
       )}
-    </TableRow>
+    </>
   );
 };

--- a/packages/ui/libs/ui/core/src/containers/TableComponent/TableComponent.types.ts
+++ b/packages/ui/libs/ui/core/src/containers/TableComponent/TableComponent.types.ts
@@ -13,6 +13,7 @@ export type TableActionData<Id> = {
 export type TableRowData<Id> = {
   id: Id;
   actions?: TableActionData<Id>[];
+  expandedRowComponent?: FC<{ id: Id }>;
   [key: string]: any;
 };
 

--- a/packages/ui/libs/ui/localization/src/languages/en.json
+++ b/packages/ui/libs/ui/localization/src/languages/en.json
@@ -650,6 +650,9 @@
         "matching": "Matching",
         "asks": "Asks",
         "bids": "Bids",
+        "facilityName": "Facility Name",
+        "constructed": "Constructed",
+        "fuelDeviceType": "Fuel type / Device type",
         "popover": {
           "asksDescription": "Below you see the sell offers that are matching the certificate criteria you defined in the market filter.",
           "asksFurtherInstructions": "To see all available asks, remove the set market filters. To see a list of your active asks go to \"My Orders\".",


### PR DESCRIPTION
In this PR:
- Added optional expanding functionality for `TableComponentRow`
- Now when clicking on any ask in Trading View -> Asks table user will see an info about the device.
![Screenshot 2021-09-21 at 12 46 45](https://user-images.githubusercontent.com/69903849/134151161-e7147aab-6ece-44b1-b0d6-26aec596fc7a.png)
![Screenshot 2021-09-21 at 12 46 55](https://user-images.githubusercontent.com/69903849/134151119-b4c813f9-bc56-41d6-b5d8-8cea67c3af9a.png)

Long fuel type + device type and light theme: 
![Screenshot 2021-09-21 at 12 51 55](https://user-images.githubusercontent.com/69903849/134151218-0e14f215-e156-4e45-96b2-7f81593fff1b.png)