### PR TITLE
fix/asks location filtering

### DIFF
--- a/packages/apps/origin-backend-irec-app/src/integration/external-device.service.ts
+++ b/packages/apps/origin-backend-irec-app/src/integration/external-device.service.ts
@@ -33,8 +33,8 @@ export class ExternalDeviceService implements IExternalDeviceService {
 
         return {
             deviceType: `${device.fuelType};${device.deviceType}`,
-            region: '',
-            province: '',
+            region: device.region,
+            province: device.subregion,
             country: device.countryCode,
             operationalSince: device.commissioningDate.getTime(),
             gridOperator: device.gridOperator

--- a/packages/ui/libs/device/data/src/fetching/deviceFirstImage.ts
+++ b/packages/ui/libs/device/data/src/fetching/deviceFirstImage.ts
@@ -19,17 +19,23 @@ export const useDeviceFirstImageUrl = (
     );
     const urlCreator = window.URL || window.webkitURL;
     const imageUrl = urlCreator.createObjectURL(blob);
-    setImageUrl(imageUrl);
+
+    if (isMountedRef.current === true) {
+      setImageUrl(imageUrl);
+    }
   };
 
   useEffect(() => {
     isMountedRef.current = true;
-    if (imageIds?.length > 0) {
-      getAndSetImage(imageIds[0]);
-    }
     return () => {
       isMountedRef.current = false;
     };
+  }, []);
+
+  useEffect(() => {
+    if (imageIds?.length > 0) {
+      getAndSetImage(imageIds[0]);
+    }
   }, [imageIds]);
 
   return imageUrl;

--- a/packages/ui/libs/exchange/logic/src/utils/prepareSubRegionsOptions.ts
+++ b/packages/ui/libs/exchange/logic/src/utils/prepareSubRegionsOptions.ts
@@ -1,4 +1,5 @@
 import { FormSelectOption } from '@energyweb/origin-ui-core';
+import { Countries } from '@energyweb/utils-general';
 
 export const prepareSubRegionsOptions = (
   allRegions: Record<string, string[]>,
@@ -9,12 +10,14 @@ export const prepareSubRegionsOptions = (
     (option) => option.value
   );
 
+  const countryCode = Countries.find((cntr) => cntr.name === country)?.code;
+
   const subregionsOption = selectedRegionsValues?.flatMap((region) => {
     const matchingSubregions: string[] = allRegions[region];
     const options: FormSelectOption[] = matchingSubregions?.map(
       (subregion) => ({
         label: `${region} - ${subregion}`,
-        value: `${country};${region};${subregion}`,
+        value: `${countryCode};${region};${subregion}`,
       })
     );
     return options;


### PR DESCRIPTION
1. Added missing location properties (`region`, `subregion`) to `location` string on ask creation. 
<img width="1440" alt="Screenshot 2021-09-22 at 09 06 10" src="https://user-images.githubusercontent.com/69903849/134296056-12deb662-9664-4df0-adc8-31b2f2a3b438.png">
<img width="1440" alt="Screenshot 2021-09-22 at 09 22 12" src="https://user-images.githubusercontent.com/69903849/134296066-01da9630-c742-46bd-9b22-2dbebfd5f16a.png">

2. As long as we are using country codes now instead of country names - adjusted location market filter to use country codes for location filtering.

3. Fixed memory leak, which appeared in PublicDeviceCard. This happened due to fetching+updating state of device image on component unmount.  