### PR TITLE
fix(issuer-api): Emitting CertificateUpdated and Persisted events

### DIFF
--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/certificate-created.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/certificate-created.handler.ts
@@ -99,10 +99,10 @@ export class CertificateCreatedHandler implements IEventHandler<CertificateCreat
                 await this.unminedCommitmentRepository.delete(txHash);
             }
 
+            await queryRunner.commitTransaction();
+
             this.eventBus.publish(new CertificatePersistedEvent(certificate.id));
             this.eventBus.publish(new CertificateUpdatedEvent(certificate.id, byTxHash));
-
-            await queryRunner.commitTransaction();
         } catch (err) {
             await queryRunner.rollbackTransaction();
 


### PR DESCRIPTION
Only emit CertificateUpdated and Persisted events after changes are commited to db.

Eliminates a racing condition where the API user might expect a certificate to be persisted before the commit actually happens.