### PR TITLE
chore: move some @nestjs deps to peer

### DIFF
--- a/packages/devices/origin-energy-api/package.json
+++ b/packages/devices/origin-energy-api/package.json
@@ -26,13 +26,13 @@
     "dependencies": {
         "@energyweb/energy-api-influxdb": "0.8.1",
         "@energyweb/origin-backend-core": "8.0.3",
-        "@nestjs/common": "8.1.1",
         "@nestjs/config": "1.0.2",
-        "@nestjs/core": "8.1.1",
         "@nestjs/passport": "8.0.1",
         "@nestjs/swagger": "5.1.4"
     },
     "devDependencies": {
+        "@nestjs/common": "8.1.1",
+        "@nestjs/core": "8.1.1",
         "@nestjs/testing": "8.1.1",
         "@types/chai": "4.2.15",
         "@types/mocha": "9.0.0",
@@ -48,6 +48,10 @@
         "supertest-capture-error": "1.0.0",
         "ts-node": "9.1.1",
         "typescript": "4.4.4"
+    },
+    "peerDependencies": {
+        "@nestjs/common": "8.1.1",
+        "@nestjs/core": "8.1.1"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/traceability/issuer-api/package.json
+++ b/packages/traceability/issuer-api/package.json
@@ -41,14 +41,10 @@
         "@energyweb/origin-backend-core": "8.0.3",
         "@energyweb/origin-backend-utils": "1.6.1",
         "@energyweb/utils-general": "11.0.4",
-        "@nestjs/common": "8.1.1",
         "@nestjs/config": "1.0.2",
-        "@nestjs/core": "8.1.1",
-        "@nestjs/cqrs": "8.0.0",
         "@nestjs/passport": "8.0.1",
         "@nestjs/schedule": "1.0.1",
         "@nestjs/swagger": "5.1.4",
-        "@nestjs/typeorm": "8.0.2",
         "class-validator": "0.13.1",
         "ethers": "5.3.1",
         "ganache-cli": "6.12.2",
@@ -61,6 +57,10 @@
         "typeorm": "0.2.34"
     },
     "devDependencies": {
+        "@nestjs/common": "8.1.1",
+        "@nestjs/core": "8.1.1",
+        "@nestjs/cqrs": "8.0.0",
+        "@nestjs/typeorm": "8.0.2",
         "@nestjs/cli": "8.1.4",
         "@nestjs/schematics": "8.0.4",
         "@nestjs/testing": "8.1.1",
@@ -80,6 +80,12 @@
         "supertest": "6.1.6",
         "ts-node": "9.1.1",
         "typescript": "4.4.4"
+    },
+    "peerDependencies": {
+        "@nestjs/common": "8.1.1",
+        "@nestjs/core": "8.1.1",
+        "@nestjs/cqrs": "8.0.0",
+        "@nestjs/typeorm": "8.0.2"
     },
     "jest": {
         "moduleFileExtensions": [

--- a/packages/traceability/issuer-api/test/certification-request.e2e-spec.ts
+++ b/packages/traceability/issuer-api/test/certification-request.e2e-spec.ts
@@ -142,7 +142,7 @@ describe('Certification Request tests', () => {
 
         expect(newCertificateId).to.be.above(0);
 
-        await sleep(1000);
+        await sleep(3000);
 
         const { body: certificate } = await request(app.getHttpServer())
             .get(`/certificate/${newCertificateId}`)

--- a/packages/utils/origin-backend-utils/package.json
+++ b/packages/utils/origin-backend-utils/package.json
@@ -30,9 +30,7 @@
     },
     "dependencies": {
         "@energyweb/origin-backend-core": "8.0.3",
-        "@nestjs/common": "8.1.1",
         "@nestjs/config": "1.0.2",
-        "@nestjs/core": "8.1.1",
         "@nestjs/swagger": "5.1.4",
         "bn.js": "5.2.0",
         "class-validator": "0.13.1",
@@ -41,7 +39,13 @@
         "rxjs": "7.4.0",
         "typeorm": "0.2.34"
     },
+    "peerDependencies": {
+        "@nestjs/common": "8.1.1",
+        "@nestjs/core": "8.1.1"
+    },
     "devDependencies": {
+        "@nestjs/common": "8.1.1",
+        "@nestjs/core": "8.1.1",
         "@types/bn.js": "5.1.0",
         "@types/mocha": "9.0.0",
         "@types/node": "14.17.29",


### PR DESCRIPTION
Reason for the change:

After we upgraded nest to v8, I got some really hard to debug/identify problem, with my application not being able to resolve dependencies (from Nest injection mechanism).

For example, Nest could not find `ModuleRef` in it's own CQRS module (`CommandBus` namely, for example).

This is basically related to Nest's author comment: https://github.com/nestjs/nest/issues/7568#issuecomment-880445966

I tried to identify issue precisely (for example by finding to copies of the `@nestjs/core` module in node_modules), but could not. Nevertheless I moved critical Nest dependencies to `peer`, and it was working again.

I did not updated all origin packages, only ones that I needed to make my application working.