### PR TITLE
chore(issuer): optimize cert sync, and events retrieval

### DIFF
--- a/packages/traceability/issuer/src/blockchain-facade/CertificateUtils.ts
+++ b/packages/traceability/issuer/src/blockchain-facade/CertificateUtils.ts
@@ -202,7 +202,8 @@ export const getAllCertificateEvents = async (
 
 export const calculateOwnership = async (
     certificateId: ICertificate['id'],
-    blockchainProperties: IBlockchainProperties
+    blockchainProperties: IBlockchainProperties,
+    creationBlockNumber = 0
 ): Promise<IShareInCertificate> => {
     const ownedShares: IShareInCertificate = {};
     const { registry } = blockchainProperties;
@@ -210,21 +211,24 @@ export const calculateOwnership = async (
     const transferSingleEvents = (
         await getEventsFromContract(
             registry,
-            registry.filters.TransferSingle(null, null, null, null, null)
+            registry.filters.TransferSingle(null, null, null, null, null),
+            creationBlockNumber
         )
     ).filter((event) => event.id.eq(certificateId));
 
     const transferBatchEvents = (
         await getEventsFromContract(
             registry,
-            registry.filters.TransferBatch(null, null, null, null, null)
+            registry.filters.TransferBatch(null, null, null, null, null),
+            creationBlockNumber
         )
     ).filter((e) => e.ids.some((id: BigNumber) => id.eq(certificateId)));
 
     const transferBatchMultipleEvents = (
         await getEventsFromContract(
             registry,
-            registry.filters.TransferBatchMultiple(null, null, null, null, null)
+            registry.filters.TransferBatchMultiple(null, null, null, null, null),
+            creationBlockNumber
         )
     ).filter((e) => e.ids.some((id: BigNumber) => id.eq(certificateId)));
 
@@ -251,7 +255,8 @@ export const calculateOwnership = async (
 
 export const calculateClaims = async (
     certificateId: ICertificate['id'],
-    blockchainProperties: IBlockchainProperties
+    blockchainProperties: IBlockchainProperties,
+    creationBlockNumber = 0
 ): Promise<IShareInCertificate> => {
     const claimedShares: IShareInCertificate = {};
     const { registry } = blockchainProperties;
@@ -259,21 +264,24 @@ export const calculateClaims = async (
     const claimSingleEvents = (
         await getEventsFromContract(
             registry,
-            registry.filters.ClaimSingle(null, null, null, null, null, null)
+            registry.filters.ClaimSingle(null, null, null, null, null, null),
+            creationBlockNumber
         )
     ).filter((event) => event._id.eq(certificateId));
 
     const claimBatchEvents = (
         await getEventsFromContract(
             registry,
-            registry.filters.ClaimBatch(null, null, null, null, null, null)
+            registry.filters.ClaimBatch(null, null, null, null, null, null),
+            creationBlockNumber
         )
     ).filter((e) => e._ids.some((id: BigNumber) => id.eq(certificateId)));
 
     const claimBatchMultipleEvents = (
         await getEventsFromContract(
             registry,
-            registry.filters.ClaimBatchMultiple(null, null, null, null, null, null)
+            registry.filters.ClaimBatchMultiple(null, null, null, null, null, null),
+            creationBlockNumber
         )
     ).filter((e) => e._ids.some((id: BigNumber) => id.eq(certificateId)));
 

--- a/packages/traceability/issuer/src/utils/events.ts
+++ b/packages/traceability/issuer/src/utils/events.ts
@@ -10,11 +10,12 @@ export interface IBlockchainEvent {
 
 export const getEventsFromContract = async (
     contract: Contract,
-    eventFilter: EventFilter
+    eventFilter: EventFilter,
+    creationBlockNumber = 0
 ): Promise<IBlockchainEvent[]> => {
     const logs = await contract.provider.getLogs({
         ...eventFilter,
-        fromBlock: 0,
+        fromBlock: creationBlockNumber,
         toBlock: 'latest'
     });
 


### PR DESCRIPTION
I tried also to make getEvents accept more than one event type at once, but the impact on performance was almost not-relevant (and the solution was a bit complex and could make some issues), so I dropped it.

This solution looks like it mitigated the problem of increasing sync time the greater the ledger was.

Now I have almost constant re-sync time. I'm going to test it further (to see if time increases for more certificates) in a few days.