### PR TITLE
chore/webpack bundle analyzer

### DIFF
--- a/packages/ui/libs/certificate/data/src/fetching/getBlockchainCertificate.ts
+++ b/packages/ui/libs/certificate/data/src/fetching/getBlockchainCertificate.ts
@@ -1,11 +1,16 @@
 import { useBlockchainPropertiesControllerGet } from '@energyweb/issuer-irec-api-react-query-client';
 import { useWeb3 } from '@energyweb/origin-ui-web3';
-// This is the reason why Certificate App bundle weighs > 2mb
-import {
-  Certificate,
-  Contracts,
-  IBlockchainProperties,
-} from '@energyweb/issuer';
+import { IBlockchainProperties } from '@energyweb/issuer';
+/*
+  Using direct imports for now to lower the bundle size.
+  The reason for missing default tree-shaking of @energyweb/issuer is the partial
+  reliability of webpack tree-shaking in regards to CommonJS modules.
+  Could be fixed after the release of Typescript v4.5.0+ and repo version update.
+  It will introduce new "module" and "moduleResolution" options such as "node12" & "nodenext".
+*/
+import { RegistryExtended__factory as RegistryExtendedFactory } from '@energyweb/issuer/dist/js/src/ethers/factories/RegistryExtended__factory';
+import { Issuer__factory as IssuerFactory } from '@energyweb/issuer/dist/js/src/ethers/factories/Issuer__factory';
+import { Certificate } from '@energyweb/issuer/dist/js/src/blockchain-facade/Certificate';
 
 export const useGetBlockchainCertificateHandler = () => {
   const { data: blockchainProperties, isLoading } =
@@ -16,14 +21,11 @@ export const useGetBlockchainCertificateHandler = () => {
   const getBlockchainCertificate = async (id: number) => {
     const configuration: IBlockchainProperties = {
       web3,
-      registry: Contracts.factories.RegistryExtendedFactory.connect(
+      registry: RegistryExtendedFactory.connect(
         blockchainProperties?.registry,
         web3
       ),
-      issuer: Contracts.factories.IssuerFactory.connect(
-        blockchainProperties?.issuer,
-        web3
-      ),
+      issuer: IssuerFactory.connect(blockchainProperties?.issuer, web3),
       activeUser: web3.getSigner(),
     };
 

--- a/packages/ui/libs/certificate/data/src/handlers/retireCertificate.ts
+++ b/packages/ui/libs/certificate/data/src/handlers/retireCertificate.ts
@@ -1,4 +1,3 @@
-// This is the reason why Certificate App bundle weighs > 2mb
 import { IClaimData } from '@energyweb/issuer';
 import {
   CertificateDTO,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,7 +45,8 @@
     "update": "nx migrate latest",
     "workspace-generator": "nx workspace-generator",
     "dep-graph": "nx dep-graph",
-    "help": "nx help"
+    "help": "nx help",
+    "bundle-report": "webpack-bundle-analyzer dist/apps/origin-ui/stats.json"
   },
   "dependencies": {
     "@emotion/react": "11.5.0",

--- a/packages/ui/webpack.config.js
+++ b/packages/ui/webpack.config.js
@@ -1,5 +1,7 @@
 const nrwlConfig = require('@nrwl/react/plugins/webpack');
 const webpack = require('webpack');
+/* Enable when needed */
+// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 module.exports = (config) => {
   nrwlConfig(config);
@@ -23,6 +25,18 @@ module.exports = (config) => {
       new webpack.ProvidePlugin({
         process: 'process/browser',
       }),
+      /* Enable when needed. If enabled - starts the server on each build.
+
+      Currently generated stats.json file is incomplete, thus disallowing the usage of
+      { "analyzerMode": "disabled" } and serving it later via "bundle-report" script.
+
+      */
+
+      // new BundleAnalyzerPlugin({
+      //   analyzerMode: 'server',
+      //   generateStatsFile: true,
+      //   statsOptions: { source: false },
+      // }),
     ],
   };
 };


### PR DESCRIPTION
1. Set up webpack-bundle-analyzer for `origin-ui`
2. Investigate bundle size increase due to imports from `@energyweb/issuer`. Solution for now:
Using direct imports to lower the bundle size. 
The reason for missing default tree-shaking of @energyweb/issuer is the partial reliability of webpack tree-shaking in regards to CommonJS modules. 
Could be fixed after the release of Typescript v4.5.0+ and repo version update. It will introduce new `module` and `moduleResolution` options such as `node12` & `nodenext`.