### PR TITLE
fix(issuer-api): fix get all certs query

### DIFF
--- a/packages/traceability/issuer-api/src/pods/certificate/certificate.controller.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/certificate.controller.ts
@@ -115,31 +115,38 @@ export class CertificateController {
     })
     @ApiQuery({
         name: 'generationEndFrom',
-        description: 'Date-alike filter for `generationEnd` field (lower boundary)'
+        description: 'Date-alike filter for `generationEnd` field (lower boundary)',
+        required: false
     })
     @ApiQuery({
         name: 'generationEndTo',
-        description: 'Date-alike filter for `generationEnd` field (upper boundary)'
+        description: 'Date-alike filter for `generationEnd` field (upper boundary)',
+        required: false
+    })
+    @ApiQuery({
+        name: 'generationStartFrom',
+        description: 'Date-alike filter for `generationStart` field (upper boundary)',
+        required: false
     })
     @ApiQuery({
         name: 'generationStartTo',
-        description: 'Date-alike filter for `generationStart` field (upper boundary)'
+        description: 'Date-alike filter for `generationStart` field (upper boundary)',
+        required: false
     })
     @ApiQuery({
-        name: 'generationStartTo',
-        description: 'Date-alike filter for `generationStart` field (upper boundary)'
+        name: 'creationTimeFrom',
+        description: 'Date-alike filter for `creationTime` field (upper boundary)',
+        required: false
     })
     @ApiQuery({
         name: 'creationTimeTo',
-        description: 'Date-alike filter for `creationTime` field (upper boundary)'
-    })
-    @ApiQuery({
-        name: 'creationTimeTo',
-        description: 'Date-alike filter for `creationTime` field (upper boundary)'
+        description: 'Date-alike filter for `creationTime` field (upper boundary)',
+        required: false
     })
     @ApiQuery({
         name: 'deviceId',
-        description: 'Filter for deviceId field'
+        description: 'Filter for deviceId field',
+        required: false
     })
     public async getAll(
         @BlockchainAccountDecorator() blockchainAddress: string,

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/get-all-certificates.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/get-all-certificates.handler.ts
@@ -5,6 +5,8 @@ import { GetAllCertificatesQuery } from '../queries/get-all-certificates.query';
 import { Certificate } from '../certificate.entity';
 
 const dateToSeconds = (d: Date) => Math.floor(d.getTime() / 1000);
+const futureDate = new Date('2038-01-01T00:00:00.000Z'); // used for more elegant query, this is almost max date, that can be converted to postgres int4
+
 @QueryHandler(GetAllCertificatesQuery)
 export class GetAllCertificatesHandler implements IQueryHandler<GetAllCertificatesQuery> {
     constructor(
@@ -14,11 +16,25 @@ export class GetAllCertificatesHandler implements IQueryHandler<GetAllCertificat
 
     async execute({ options }: GetAllCertificatesQuery): Promise<Certificate[]> {
         const generationEndFrom = dateToSeconds(options.generationEndFrom ?? new Date(0));
-        const generationEndTo = dateToSeconds(options.generationEndTo ?? new Date());
+        const generationEndTo = dateToSeconds(options.generationEndTo ?? futureDate);
         const generationStartFrom = dateToSeconds(options.generationStartFrom ?? new Date(0));
-        const generationStartTo = dateToSeconds(options.generationStartTo ?? new Date());
+        const generationStartTo = dateToSeconds(options.generationStartTo ?? futureDate);
         const creationTimeFrom = dateToSeconds(options.creationTimeFrom ?? new Date(0));
-        const creationTimeTo = dateToSeconds(options.creationTimeTo ?? new Date());
+        const creationTimeTo = dateToSeconds(options.creationTimeTo ?? futureDate);
+
+        process.stdout.write(
+            JSON.stringify({
+                where: {
+                    generationEndTime: Between(generationEndFrom, generationEndTo),
+                    generationStartTime: Between(generationStartFrom, generationStartTo),
+                    creationTime: Between(creationTimeFrom, creationTimeTo),
+                    ...(options.deviceId ? { deviceId: options.deviceId } : {})
+                },
+                order: {
+                    id: 'ASC'
+                }
+            })
+        );
 
         return this.repository.find({
             where: {


### PR DESCRIPTION
Certificates can have time fields greater than `new Date()`. For such fields and no date query specified no certificate was returned.
Actually I still use the same solution (just 2038 year instead of `new Date()`), because this is the most elegant way for building a query.