### PR TITLE
fix: sync exchange deposit addresses in migration

### DIFF
--- a/packages/tools/migrations-irec/src/main.ts
+++ b/packages/tools/migrations-irec/src/main.ts
@@ -149,15 +149,13 @@ async function createExchangeDepositAddresses(client: Client) {
     const accountService = app.get(AccountService);
 
     for (const { id } of rows) {
-        await accountService
-            .create(String(id))
-            .then(() => logger.info(`Exchange deposit address created for orgId=${id}`))
-            .catch((e) =>
-                logger.error(`Unable to create exchange deposit address for ${id}: ${e.message}`)
-            );
+        try {
+            await accountService.createSynchronously(String(id));
+            logger.info(`Exchange deposit address created for orgId=${id}`);
+        } catch (err) {
+            logger.error(`Unable to create exchange deposit address for ${id}: ${err.message}`);
+        }
     }
-
-    await new Promise((r) => setTimeout(r, 3000));
 }
 
 function initEnv() {

--- a/packages/trade/exchange/src/pods/account/account.service.ts
+++ b/packages/trade/exchange/src/pods/account/account.service.ts
@@ -37,6 +37,11 @@ export class AccountService {
         this.requestQueue.next(userId);
     }
 
+    public async createSynchronously(userId: string) {
+        this.logger.debug(`User with userId=${userId} requesting account creation`);
+        await this.process(userId);
+    }
+
     private async process(userId: string) {
         this.logger.debug(`Processing account creation for user with userId=${userId}`);
         const accountExists = await this.repository.findOne(null, {


### PR DESCRIPTION
In current implementation the migrations will close before the accounts are deployed on blockchain and Exchange Deposit Addresses are actually **processed** and created in db, resulting in empty exchange_account table.

**AccountService.createSynchronously** was added to be used in migration and prevent that.

