### PR TITLE
fix: origin packages build command tsconfig path

### DIFF
--- a/packages/api-clients/react-query/exchange-irec/package.json
+++ b/packages/api-clients/react-query/exchange-irec/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn clean && yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate",
         "clean": "rm -rf dist dist-shakeable && yarn client:clean",
         "client:generate": "rm -rf src/client && orval && barrelsby -d src/client",

--- a/packages/api-clients/react-query/exchange/package.json
+++ b/packages/api-clients/react-query/exchange/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn clean && yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate",
         "clean": "rm -rf dist dist-shakeable && yarn client:clean",
         "client:generate": "rm -rf src/client && orval && barrelsby -d src/client",

--- a/packages/api-clients/react-query/issuer-irec-api/package.json
+++ b/packages/api-clients/react-query/issuer-irec-api/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn clean && yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate",
         "clean": "rm -rf dist dist-shakeable && yarn client:clean",
         "client:generate": "rm -rf src/client && orval && barrelsby -d src/client",

--- a/packages/api-clients/react-query/origin-backend/package.json
+++ b/packages/api-clients/react-query/origin-backend/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn clean && yarn build:ts",
-        "build:ts": "yarn build:client && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate && yarn client:post-generation",
         "clean": "rm -rf dist dist-shakeable && yarn client:clean",
         "client:generate": "rm -rf src/client && orval && barrelsby -d src/client",

--- a/packages/api-clients/react-query/origin-device-registry-api/package.json
+++ b/packages/api-clients/react-query/origin-device-registry-api/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn clean && yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate",
         "clean": "rm -rf dist dist-shakeable && yarn client:clean",
         "client:generate": "rm -rf src/client && orval && barrelsby -d src/client",

--- a/packages/api-clients/react-query/origin-device-registry-irec-local-api/package.json
+++ b/packages/api-clients/react-query/origin-device-registry-irec-local-api/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn clean && yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate",
         "clean": "rm -rf dist dist-shakeable && yarn client:clean",
         "client:generate": "rm -rf src/client && orval && barrelsby -d src/client",

--- a/packages/api-clients/react-query/origin-energy-api/package.json
+++ b/packages/api-clients/react-query/origin-energy-api/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn clean && yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate",
         "clean": "rm -rf dist dist-shakeable && yarn client:clean",
         "client:generate": "rm -rf src/client && orval && barrelsby -d src/client",

--- a/packages/api-clients/react-query/origin-organization-irec-api/package.json
+++ b/packages/api-clients/react-query/origin-organization-irec-api/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn clean && yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate",
         "clean": "rm -rf dist dist-shakeable && yarn client:clean",
         "client:generate": "rm -rf src/client && orval && barrelsby -d src/client",

--- a/packages/apps/origin-backend-app/package.json
+++ b/packages/apps/origin-backend-app/package.json
@@ -10,7 +10,7 @@
         "start:prod": "node dist/main",
         "prebuild": "shx rm -rf dist",
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "clean": "shx rm -rf dist uploads",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" --quiet",

--- a/packages/apps/origin-backend-irec-app/package.json
+++ b/packages/apps/origin-backend-irec-app/package.json
@@ -10,7 +10,7 @@
         "start:prod": "node dist/main",
         "prebuild": "npx shx rm -rf dist",
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "clean": "npx shx rm -rf dist uploads",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" --quiet",

--- a/packages/devices/origin-device-registry-api-client/package.json
+++ b/packages/devices/origin-device-registry-api-client/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate && yarn client:clean",
         "clean": "shx rm -rf dist dist-shakeable",
         "client:generate": "openapi-generator-cli generate -g typescript-axios -i src/schema.yaml -o src --api-name-suffix Client --remove-operation-id-prefix",

--- a/packages/devices/origin-device-registry-api/package.json
+++ b/packages/devices/origin-device-registry-api/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet --no-error-on-unmatched-pattern",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet --fix --no-error-on-unmatched-pattern",

--- a/packages/devices/origin-device-registry-irec-form-api-client/package.json
+++ b/packages/devices/origin-device-registry-irec-form-api-client/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate && yarn client:clean",
         "clean": "shx rm -rf dist dist-shakeable",
         "client:generate": "openapi-generator-cli generate -g typescript-axios -i src/schema.yaml -o src --api-name-suffix Client --remove-operation-id-prefix",

--- a/packages/devices/origin-device-registry-irec-form-api/package.json
+++ b/packages/devices/origin-device-registry-irec-form-api/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet --fix",

--- a/packages/devices/origin-device-registry-irec-local-api-client/package.json
+++ b/packages/devices/origin-device-registry-irec-local-api-client/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate && yarn client:clean",
         "clean": "shx rm -rf dist dist-shakeable",
         "client:generate": "openapi-generator-cli generate -g typescript-axios -i src/schema.yaml -o src --api-name-suffix Client --remove-operation-id-prefix",

--- a/packages/devices/origin-device-registry-irec-local-api/package.json
+++ b/packages/devices/origin-device-registry-irec-local-api/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet --fix",

--- a/packages/devices/origin-energy-api-client/package.json
+++ b/packages/devices/origin-energy-api-client/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate && yarn client:clean",
         "clean": "shx rm -rf dist dist-shakeable",
         "client:generate": "openapi-generator-cli generate -g typescript-axios -i src/schema.yaml -o src --api-name-suffix Client --remove-operation-id-prefix",

--- a/packages/devices/origin-energy-api/package.json
+++ b/packages/devices/origin-energy-api/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet --fix",

--- a/packages/organizations/origin-organization-irec-api-client/package.json
+++ b/packages/organizations/origin-organization-irec-api-client/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate && yarn client:clean",
         "clean": "shx rm -rf dist dist-shakeable",
         "client:generate": "openapi-generator-cli generate -g typescript-axios -i src/schema.yaml -o src --api-name-suffix Client --remove-operation-id-prefix",

--- a/packages/organizations/origin-organization-irec-api/package.json
+++ b/packages/organizations/origin-organization-irec-api/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet --fix",

--- a/packages/origin-backend-client/package.json
+++ b/packages/origin-backend-client/package.json
@@ -5,7 +5,7 @@
     "main": "dist/js/index.js",
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate && yarn client:post-generation && yarn client:clean",
         "clean": "shx rm -rf dist dist-shakeable",
         "client:generate": "openapi-generator-cli generate -g typescript-axios -i src/schema.yaml -o src --api-name-suffix Client --remove-operation-id-prefix",

--- a/packages/origin-backend-core/package.json
+++ b/packages/origin-backend-core/package.json
@@ -5,7 +5,7 @@
     "main": "dist/js/src/index.js",
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "clean": "shx rm -rf dist",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" --fix",

--- a/packages/origin-backend/package.json
+++ b/packages/origin-backend/package.json
@@ -12,7 +12,7 @@
         "start:prod": "node dist/main",
         "prebuild": "shx rm -rf dist",
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json && cp migrations/initial.sql dist/js/migrations/",
+        "build:ts": "tsc --project tsconfig.json && cp migrations/initial.sql dist/js/migrations/",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "test:e2e": "yarn typeorm:run && mocha -r ts-node/register test/*.e2e-spec.ts --timeout 60000 --exit",
         "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js --config ormconfig-dev.ts",

--- a/packages/tools/migrations-irec/package.json
+++ b/packages/tools/migrations-irec/package.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "build:container:canary": "make build-canary",
         "build:container:latest": "make build-stable",
         "start": "npx ts-node src/main.ts",

--- a/packages/tools/migrations/package.json
+++ b/packages/tools/migrations/package.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "start": "npx ts-node src/main.ts",
         "start:defaultConfigs": "yarn start -c ./config/demo-config.json -s ./config/seed.sql -e ../../../.env",
         "start-all": "concurrently --restart-tries 3 --restart-after 1500 -n eth,deploy \"yarn start-ganache\" \"wait-on tcp:8553 && yarn start:redeploy\"",

--- a/packages/traceability/issuer-api-client/package.json
+++ b/packages/traceability/issuer-api-client/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate && yarn client:clean",
         "clean": "shx rm -rf dist dist-shakeable",
         "client:generate": "openapi-generator-cli generate -g typescript-axios -i src/schema.yaml -o src --api-name-suffix Client --remove-operation-id-prefix",

--- a/packages/traceability/issuer-api/package.json
+++ b/packages/traceability/issuer-api/package.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet --fix",

--- a/packages/traceability/issuer-irec-api-client/package.json
+++ b/packages/traceability/issuer-irec-api-client/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "yarn build:client && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate && yarn client:clean",
         "clean": "shx rm -rf dist dist-shakeable",
         "client:generate": "openapi-generator-cli generate -g typescript-axios -i src/schema.yaml -o src --api-name-suffix Client --remove-operation-id-prefix",

--- a/packages/traceability/issuer-irec-api-wrapper/package.json
+++ b/packages/traceability/issuer-irec-api-wrapper/package.json
@@ -13,7 +13,7 @@
     "license": "MIT",
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "build:docs": "rm -Rf ../../../docs/sdk-reference/issuer-irec-api-wrapper && typedoc --plugin typedoc-plugin-markdown src/index.ts --out ../../../docs/sdk-reference/issuer-irec-api-wrapper",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" --fix",

--- a/packages/traceability/issuer-irec-api/package.json
+++ b/packages/traceability/issuer-irec-api/package.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet --fix",

--- a/packages/traceability/issuer/package.json
+++ b/packages/traceability/issuer/package.json
@@ -24,7 +24,7 @@
     "scripts": {
         "build": "yarn build:static && yarn build:ts && yarn generate:docs",
         "build:static": "yarn compile && yarn typechain:registry && yarn typechain:registry:extended && yarn typechain:issuer && yarn typechain:issuer:private",
-        "build:ts": "tsc -b tsconfig.json && yarn copy:declarations",
+        "build:ts": "tsc --project tsconfig.json && yarn copy:declarations",
         "copy:declarations": "shx cp src/ethers/*.d.ts dist/js/src/ethers && shx cp -rf contracts dist/",
         "typechain:registry": "typechain --target ethers-v5 --out-dir src/ethers './build/contracts/Registry.json'",
         "typechain:registry:extended": "typechain --target ethers-v5 --out-dir src/ethers './build/contracts/RegistryExtended.json'",

--- a/packages/trade/exchange-client/package.json
+++ b/packages/trade/exchange-client/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate && yarn client:clean",
         "clean": "shx rm -rf dist dist-shakeable",
         "client:generate": "openapi-generator-cli generate -g typescript-axios -i src/schema.yaml -o src --api-name-suffix Client --remove-operation-id-prefix",

--- a/packages/trade/exchange-core-irec/package.json
+++ b/packages/trade/exchange-core-irec/package.json
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" --fix",
         "test": "mocha -r ts-node/register test/*.test.ts --exit",

--- a/packages/trade/exchange-core/package.json
+++ b/packages/trade/exchange-core/package.json
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" --fix",
         "test": "mocha -r ts-node/register test/*.test.ts --exit",

--- a/packages/trade/exchange-io-erc1888/package.json
+++ b/packages/trade/exchange-io-erc1888/package.json
@@ -18,7 +18,7 @@
         "lint": "eslint \"src/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" --fix",
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "test": "yarn test:e2e",
         "start-ganache": "ganache-cli -m 'chalk park staff buzz chair purchase wise oak receive avoid avoid home' -l 8000000 -e 1000000 -a 20 -p 8590 -q",

--- a/packages/trade/exchange-irec-client/package.json
+++ b/packages/trade/exchange-irec-client/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc -b tsconfig.json",
+        "build:ts": "yarn build:client 1>/dev/null 2>/dev/null && tsc --project tsconfig.json",
         "build:client": "yarn client:generate:schema && yarn client:generate && yarn client:clean",
         "clean": "shx rm -rf dist dist-shakeable",
         "client:generate": "openapi-generator-cli generate -g typescript-axios -i src/schema.yaml -o src --api-name-suffix Client --remove-operation-id-prefix",

--- a/packages/trade/exchange-irec/package.json
+++ b/packages/trade/exchange-irec/package.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet --fix",

--- a/packages/trade/exchange-token-account/package.json
+++ b/packages/trade/exchange-token-account/package.json
@@ -21,7 +21,7 @@
         "build": "yarn build:static && yarn build:ts && yarn copy:declarations",
         "copy:declarations": "shx cp src/ethers/*.d.ts dist/js/src/ethers",
         "build:static": "yarn compile && yarn typechain:ethers",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "compile": "truffle compile",
         "lint": "solium -d contracts",
         "lint-fix": "solium -d contracts --fix && eslint \"src/**/*{.ts,.tsx}\" --fix",

--- a/packages/trade/exchange/package.json
+++ b/packages/trade/exchange/package.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json && cp migrations/initial.sql dist/js/migrations/",
+        "build:ts": "tsc --project tsconfig.json && cp migrations/initial.sql dist/js/migrations/",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" \"test/**/*{.ts,.tsx}\" --quiet --fix",

--- a/packages/utils/origin-backend-utils/package.json
+++ b/packages/utils/origin-backend-utils/package.json
@@ -5,7 +5,7 @@
     "main": "dist/js/index.js",
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "clean": "shx rm -rf dist",
         "lint": "eslint \"src/**/*{.ts,.tsx}\" --quiet",
         "lint-fix": "eslint \"src/**/*{.ts,.tsx}\" --fix",

--- a/packages/utils/utils-general/package.json
+++ b/packages/utils/utils-general/package.json
@@ -21,7 +21,7 @@
     },
     "scripts": {
         "build": "yarn build:ts",
-        "build:ts": "tsc -b tsconfig.json",
+        "build:ts": "tsc --project tsconfig.json",
         "prettier": "prettier --write --config-precedence file-override './src/**/*'",
         "test": "TS_NODE_PROJECT=\"tsconfig.json\" mocha -r ts-node/register src/test/*.test.ts --exit",
         "test:watch": "TS_NODE_PROJECT=\"tsconfig.json\" mocha -r ts-node/register src/test/*.test.ts --watch --watch-extensions ts",


### PR DESCRIPTION
Origin of change: `rush build` command fails on Windows (path not found error)

There should be `--project` to point `tsconfig.json` file.
The `-b` (`--build`) flag could be used if https://www.typescriptlang.org/docs/handbook/project-references.html was used

I'm not sure why this fails on Windows, and doesn't on Apple/Linux, but probably path resolution works differently, and on Apple/Linux it properly finds `tsconfig.json` file in package directory, while on Windows it tries to find `tsconfig.json` in root directory or something.