### PR TITLE
feat: allow generic claim data

### DIFF
--- a/packages/organizations/origin-organization-irec-api/src/irec/irec.service.ts
+++ b/packages/organizations/origin-organization-irec-api/src/irec/irec.service.ts
@@ -46,14 +46,16 @@ export interface ICreateBeneficiary {
     location: string;
 }
 
-export interface IClaimData {
+// This needs to be `type` - `interface` doesn't work due to
+// https://github.com/microsoft/TypeScript/issues/15300
+export type IClaimData = {
     beneficiary: string;
     location: string;
     countryCode: string;
     periodStartDate: string;
     periodEndDate: string;
     purpose: string;
-}
+};
 
 export interface IIrecService {
     getConnectionInfo(user: UserIdentifier): Promise<ConnectionDTO>;

--- a/packages/traceability/issuer-api/migrations/1633507266818-StoreTxHashInsteadBlock.ts
+++ b/packages/traceability/issuer-api/migrations/1633507266818-StoreTxHashInsteadBlock.ts
@@ -22,7 +22,7 @@ export class StoreTxHashInsteadBlock1633507266818 implements MigrationInterface 
                 this.getBlockchainProperties(blockchainProperties);
 
             const syncedCertificates = await Promise.all(
-                existingCertificates.map((cert: any) => new Certificate(cert.id, wrapped).sync)
+                existingCertificates.map((cert: any) => new Certificate(cert.id, wrapped, 1).sync())
             );
 
             syncedCertificates.forEach(async (cert: Certificate) => {

--- a/packages/traceability/issuer-api/migrations/1644231693035-AddSchemaVersionToCertificate.ts
+++ b/packages/traceability/issuer-api/migrations/1644231693035-AddSchemaVersionToCertificate.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSchemaVersionToCertificate1644231693035 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE issuer_certificate ADD COLUMN "schemaVersion" int4`);
+        await queryRunner.query(`UPDATE issuer_certificate SET "schemaVersion" = 1`);
+        await queryRunner.query(
+            `ALTER TABLE issuer_certificate ALTER COLUMN "schemaVersion" SET NOT NULL`
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE issuer_certificate DROP COLUMN "schemaVersion"`);
+    }
+}

--- a/packages/traceability/issuer-api/src/pods/certificate/certificate.entity.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/certificate.entity.ts
@@ -6,7 +6,7 @@ import {
     CreateDateColumn,
     UpdateDateColumn
 } from 'typeorm';
-import { IsBoolean, IsInt, IsPositive, IsString, Min } from 'class-validator';
+import { IsBoolean, IsInt, IsPositive, IsString, Min, IsNumber } from 'class-validator';
 import { CertificateUtils, IClaim, IOwnershipCommitmentProof } from '@energyweb/issuer';
 import { BlockchainProperties } from '../blockchain/blockchain-properties.entity';
 
@@ -50,8 +50,6 @@ export class Certificate {
     @Column('simple-json', { nullable: true })
     claims: IClaim[];
 
-    /* BLOCKCHAIN SPECIFIC */
-
     @ManyToOne(() => BlockchainProperties)
     blockchain: BlockchainProperties;
 
@@ -59,9 +57,8 @@ export class Certificate {
     @IsString()
     creationTransactionHash: string;
 
-    /* PRIVATE CERTIFICATES ONLY */
-
     @Column('simple-json', { nullable: true })
+    /* PRIVATE CERTIFICATES ONLY */
     latestCommitment: IOwnershipCommitmentProof;
 
     @Column()
@@ -73,4 +70,9 @@ export class Certificate {
 
     @UpdateDateColumn({ type: 'timestamptz' })
     updatedAt: Date;
+
+    @Column()
+    @IsNumber({ maxDecimalPlaces: 0 })
+    @IsPositive()
+    schemaVersion: number;
 }

--- a/packages/traceability/issuer-api/src/pods/certificate/certificate.entity.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/certificate.entity.ts
@@ -7,7 +7,12 @@ import {
     UpdateDateColumn
 } from 'typeorm';
 import { IsBoolean, IsInt, IsPositive, IsString, Min, IsNumber } from 'class-validator';
-import { CertificateUtils, IClaim, IOwnershipCommitmentProof } from '@energyweb/issuer';
+import {
+    CertificateSchemaVersion,
+    CertificateUtils,
+    IClaim,
+    IOwnershipCommitmentProof
+} from '@energyweb/issuer';
 import { BlockchainProperties } from '../blockchain/blockchain-properties.entity';
 
 export const CERTIFICATES_TABLE_NAME = 'issuer_certificate';
@@ -74,5 +79,5 @@ export class Certificate {
     @Column()
     @IsNumber({ maxDecimalPlaces: 0 })
     @IsPositive()
-    schemaVersion: number;
+    schemaVersion: CertificateSchemaVersion;
 }

--- a/packages/traceability/issuer-api/src/pods/certificate/commands/batch-claim-certificates.command.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/commands/batch-claim-certificates.command.ts
@@ -1,5 +1,10 @@
 import { CertificateBatchOperations } from '@energyweb/issuer';
 
 export class BatchClaimCertificatesCommand {
-    constructor(public readonly claims: CertificateBatchOperations.BatchCertificateClaim[]) {}
+    constructor(
+        public readonly claims: Omit<
+            CertificateBatchOperations.BatchCertificateClaim,
+            'schemaVersion'
+        >[]
+    ) {}
 }

--- a/packages/traceability/issuer-api/src/pods/certificate/commands/batch-transfer-certificates.command.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/commands/batch-transfer-certificates.command.ts
@@ -1,5 +1,10 @@
 import { CertificateBatchOperations } from '@energyweb/issuer';
 
 export class BatchTransferCertificatesCommand {
-    constructor(public readonly transfers: CertificateBatchOperations.BatchCertificateTransfer[]) {}
+    constructor(
+        public readonly transfers: Omit<
+            CertificateBatchOperations.BatchCertificateTransfer,
+            'schemaVersion'
+        >[]
+    ) {}
 }

--- a/packages/traceability/issuer-api/src/pods/certificate/dto/batch-certificate-claim.dto.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/dto/batch-certificate-claim.dto.ts
@@ -6,7 +6,7 @@ import { BatchCertificateTransferDTO } from './batch-certificate-transfer.dto';
 
 export class BatchCertificateClaimDTO
     extends OmitType(BatchCertificateTransferDTO, ['to'] as const)
-    implements Omit<CertificateBatchOperations.BatchCertificateClaim, 'amount'>
+    implements Omit<CertificateBatchOperations.BatchCertificateClaim, 'amount' | 'schemaVersion'>
 {
     @ApiProperty({ type: Object })
     @IsObject()

--- a/packages/traceability/issuer-api/src/pods/certificate/dto/batch-certificate-transfer.dto.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/dto/batch-certificate-transfer.dto.ts
@@ -8,7 +8,8 @@ import { CertificateDTO } from './certificate.dto';
 
 export class BatchCertificateTransferDTO
     extends PickType(CertificateDTO, ['id'] as const)
-    implements Omit<CertificateBatchOperations.BatchCertificateTransfer, 'amount'>
+    implements
+        Omit<CertificateBatchOperations.BatchCertificateTransfer, 'amount' | 'schemaVersion'>
 {
     @ApiProperty({
         type: String,

--- a/packages/traceability/issuer-api/src/pods/certificate/dto/claim-certificate.dto.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/dto/claim-certificate.dto.ts
@@ -1,6 +1,6 @@
 import { IntUnitsOfEnergy, PositiveBNStringValidator } from '@energyweb/origin-backend-utils';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, Validate, ValidateNested } from 'class-validator';
+import { IsOptional, Validate } from 'class-validator';
 
 import { ClaimDataDTO, IsClaimData } from './claim-data.dto';
 

--- a/packages/traceability/issuer-api/src/pods/certificate/dto/claim-certificate.dto.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/dto/claim-certificate.dto.ts
@@ -2,12 +2,19 @@ import { IntUnitsOfEnergy, PositiveBNStringValidator } from '@energyweb/origin-b
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsOptional, Validate, ValidateNested } from 'class-validator';
 
-import { ClaimDataDTO } from './claim-data.dto';
+import { ClaimDataDTO, IsClaimData } from './claim-data.dto';
 
 export class ClaimCertificateDTO {
-    @ApiPropertyOptional({ type: ClaimDataDTO })
     @IsOptional()
-    @ValidateNested()
+    @ApiPropertyOptional({
+        type: 'object',
+        additionalProperties: true,
+        description:
+            'Object containing nulls, string, numbers, and arrays or objects of these (recursive type)',
+        example:
+            '{ "location": "Some location", "beneficiaries": [1, 2], "metadata": { "claimerType": "Electric vehicle" } }'
+    })
+    @IsClaimData()
     claimData?: ClaimDataDTO;
 
     @ApiPropertyOptional({ type: String, example: '1000000' })

--- a/packages/traceability/issuer-api/src/pods/certificate/dto/claim-data.dto.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/dto/claim-data.dto.ts
@@ -1,29 +1,40 @@
-import { ApiProperty } from '@nestjs/swagger';
 import { IClaimData } from '@energyweb/issuer';
-import { IsDateString, IsString } from 'class-validator';
+import { registerDecorator, ValidationOptions } from 'class-validator';
 
-export class ClaimDataDTO implements IClaimData {
-    @ApiProperty({ type: String, example: 'Beneficiary One' })
-    @IsString()
-    beneficiary: string;
+export function IsClaimData(validationOptions?: ValidationOptions) {
+    return function (object: Object, propertyName: string) {
+        registerDecorator({
+            name: 'isClaimData',
+            target: object.constructor,
+            propertyName: propertyName,
+            options: validationOptions,
+            validator: {
+                validate(value: any) {
+                    const isPlainObject = (value: any) =>
+                        typeof value === 'object' && value !== null;
+                    const validate = (value: any): boolean => {
+                        if (Array.isArray(value)) {
+                            return value.every(validate);
+                        }
 
-    @ApiProperty({ type: String, example: '133 N. St, Orange County, CA 19444' })
-    @IsString()
-    location: string;
+                        if (isPlainObject(value)) {
+                            return Object.values(value).every(validate);
+                        }
 
-    @ApiProperty({ type: String, example: 'US' })
-    @IsString()
-    countryCode: string;
+                        return (
+                            typeof value === 'string' || typeof value === 'number' || value === null
+                        );
+                    };
 
-    @ApiProperty({ type: String, example: '2021-11-08T17:11:11.883Z', description: 'ISO String' })
-    @IsDateString()
-    periodStartDate: string;
-
-    @ApiProperty({ type: String, example: '2021-11-08T17:11:11.883Z', description: 'ISO String' })
-    @IsDateString()
-    periodEndDate: string;
-
-    @ApiProperty({ type: String, example: 'claiming' })
-    @IsString()
-    purpose: string;
+                    if (isPlainObject(value)) {
+                        return validate(value);
+                    } else {
+                        return false;
+                    }
+                }
+            }
+        });
+    };
 }
+
+export type ClaimDataDTO = IClaimData;

--- a/packages/traceability/issuer-api/src/pods/certificate/dto/claim.dto.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/dto/claim.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IClaim } from '@energyweb/issuer';
 import { Validate, IsInt, IsPositive, IsString, ValidateNested } from 'class-validator';
 import { IntUnitsOfEnergy } from '@energyweb/origin-backend-utils';
-import { ClaimDataDTO } from './claim-data.dto';
+import { ClaimDataDTO, IsClaimData } from './claim-data.dto';
 
 export class ClaimDTO implements IClaim {
     @ApiProperty({ type: Number, description: 'Certificate Id' })
@@ -34,7 +34,14 @@ export class ClaimDTO implements IClaim {
     @Validate(IntUnitsOfEnergy)
     value: string;
 
-    @ApiProperty({ type: ClaimDataDTO })
-    @ValidateNested()
+    @ApiProperty({
+        type: 'object',
+        additionalProperties: true,
+        description:
+            'Object containing nulls, string, numbers, and arrays or objects of these (recursive type)',
+        example:
+            '{ "location": "Some location", "beneficiaries": [1, 2], "metadata": { "claimerType": "Electric vehicle" } }'
+    })
+    @IsClaimData()
     claimData: ClaimDataDTO;
 }

--- a/packages/traceability/issuer-api/src/pods/certificate/dto/claim.dto.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/dto/claim.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IClaim } from '@energyweb/issuer';
-import { Validate, IsInt, IsPositive, IsString, ValidateNested } from 'class-validator';
+import { Validate, IsInt, IsPositive, IsString } from 'class-validator';
 import { IntUnitsOfEnergy } from '@energyweb/origin-backend-utils';
 import { ClaimDataDTO, IsClaimData } from './claim-data.dto';
 

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/batch-claim-certificates.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/batch-claim-certificates.handler.ts
@@ -32,12 +32,12 @@ export class BatchClaimCertificatesHandler
             throw new BadRequestException('Cannot process empty claims request');
         }
 
-        for (const { id, amount, from } of claims) {
-            if (!amount) {
-                continue;
-            }
+        const certificates = await this.repository.findByIds(claims.map((c) => c.id));
 
-            const cert = await this.repository.findOne(id);
+        const validatedClaims = claims.map((claim) => {
+            const { id, amount, from } = claim;
+
+            const cert = certificates.find((c) => c.id == id);
 
             if (!cert) {
                 throw new NotFoundException(
@@ -46,9 +46,10 @@ export class BatchClaimCertificatesHandler
             }
 
             if (
-                !cert.owners[from] ||
-                BigNumber.from(cert.owners[from] ?? 0).isZero() ||
-                BigNumber.from(cert.owners[from] ?? 0).lt(amount)
+                amount &&
+                (!cert.owners[from] ||
+                    BigNumber.from(cert.owners[from] ?? 0).isZero() ||
+                    BigNumber.from(cert.owners[from] ?? 0).lt(amount))
             ) {
                 throw new ForbiddenException(
                     `Requested claiming of certificate ${id} with amount ${amount.toString()}, but you only own ${
@@ -56,10 +57,18 @@ export class BatchClaimCertificatesHandler
                     }`
                 );
             }
-        }
+
+            return {
+                ...claim,
+                schemaVersion: cert.schemaVersion
+            };
+        });
 
         try {
-            return await CertificateBatchOperations.claimCertificates(claims, blockchainProperties);
+            return await CertificateBatchOperations.claimCertificates(
+                validatedClaims,
+                blockchainProperties
+            );
         } catch (error) {
             throw new HttpException(JSON.stringify(error), HttpStatus.FAILED_DEPENDENCY);
         }

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/certificates-created.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/certificates-created.handler.ts
@@ -2,7 +2,8 @@ import { EventBus, EventsHandler, IEventHandler } from '@nestjs/cqrs';
 import {
     Certificate as CertificateFacade,
     IOwnershipCommitmentProof,
-    PreciseProofUtils
+    PreciseProofUtils,
+    CertificateSchemaVersion
 } from '@energyweb/issuer';
 import { Connection, Repository, In } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -60,7 +61,11 @@ export class CertificatesCreatedHandler implements IEventHandler<CertificatesCre
         const newCertificates = await Promise.all(
             notExistingCertificates.map(async (id) => {
                 try {
-                    return await new CertificateFacade(id, blockchainProperties).sync();
+                    return await new CertificateFacade(
+                        id,
+                        blockchainProperties,
+                        CertificateSchemaVersion.Latest
+                    ).sync();
                 } catch (e) {
                     this.logger.error(e.message);
                     throw e;
@@ -97,7 +102,8 @@ export class CertificatesCreatedHandler implements IEventHandler<CertificatesCre
                     owners: cert.owners,
                     issuedPrivately: !!privateInfo || !!unminedCommitment,
                     latestCommitment: unminedCommitment ?? latestCommitment,
-                    metadata: cert.metadata
+                    metadata: cert.metadata,
+                    schemaVersion: cert.schemaVersion
                 })
             );
 

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/claim-certificate.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/claim-certificate.handler.ts
@@ -38,7 +38,11 @@ export class ClaimCertificateHandler implements ICommandHandler<ClaimCertificate
 
         const blockchainProperties = await this.blockchainPropertiesService.getWrapped();
 
-        const cert = await new CertificateFacade(certificate.id, blockchainProperties).sync();
+        const cert = await new CertificateFacade(
+            certificate.id,
+            blockchainProperties,
+            certificate.schemaVersion
+        ).sync();
 
         const claimerBalance = BigNumber.from(
             (certificate.issuedPrivately

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/sync-certificate.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/sync-certificate.handler.ts
@@ -38,7 +38,8 @@ export class SyncCertificateHandler implements IEventHandler<SyncCertificateEven
 
         const onChainCert = await new OnChainCertificate(
             certificate.id,
-            blockchainProperties
+            blockchainProperties,
+            certificate.schemaVersion
         ).sync();
 
         try {

--- a/packages/traceability/issuer-api/src/pods/certificate/handlers/transfer-certificate.handler.ts
+++ b/packages/traceability/issuer-api/src/pods/certificate/handlers/transfer-certificate.handler.ts
@@ -37,7 +37,8 @@ export class TransferCertificateHandler implements ICommandHandler<TransferCerti
 
         const onChainCert = await new CertificateFacade(
             certificate.id,
-            blockchainProperties
+            blockchainProperties,
+            certificate.schemaVersion
         ).sync();
 
         if (certificate.issuedPrivately) {

--- a/packages/traceability/issuer-irec-api/src/pods/certificate/certificate.controller.ts
+++ b/packages/traceability/issuer-irec-api/src/pods/certificate/certificate.controller.ts
@@ -19,7 +19,8 @@ import {
     ExceptionInterceptor,
     UserDecorator
 } from '@energyweb/origin-backend-utils';
-import { CertificateController, ClaimCertificateDTO, TxHashDTO } from '@energyweb/issuer-api';
+import { CertificateController, TxHashDTO } from '@energyweb/issuer-api';
+import { ClaimIrecCertificateDTO } from './dto/claim-irec-certificate.dto';
 import { ILoggedInUser } from '@energyweb/origin-backend-core';
 import { ClaimIRECCertificateCommand } from './command';
 
@@ -31,7 +32,7 @@ import { ClaimIRECCertificateCommand } from './command';
 export class IrecCertificateController extends CertificateController {
     @Put('/:id/claim')
     @UseGuards(AuthGuard(), ActiveUserGuard, BlockchainAccountGuard)
-    @ApiBody({ type: ClaimCertificateDTO })
+    @ApiBody({ type: ClaimIrecCertificateDTO })
     @ApiResponse({
         status: HttpStatus.OK,
         type: TxHashDTO,
@@ -40,7 +41,7 @@ export class IrecCertificateController extends CertificateController {
     public async claimIREC(
         @UserDecorator() user: ILoggedInUser,
         @Param('id', new ParseIntPipe()) certificateId: number,
-        @Body() dto: ClaimCertificateDTO
+        @Body() dto: ClaimIrecCertificateDTO
     ): Promise<TxHashDTO> {
         const tx = await this.commandBus.execute(
             new ClaimIRECCertificateCommand(user, certificateId, dto.claimData)

--- a/packages/traceability/issuer-irec-api/src/pods/certificate/command/claim-irec-certificate.command.ts
+++ b/packages/traceability/issuer-irec-api/src/pods/certificate/command/claim-irec-certificate.command.ts
@@ -1,5 +1,5 @@
 import { ILoggedInUser } from '@energyweb/origin-backend-core';
-import { IClaimData } from '@energyweb/issuer';
+import { IClaimData } from '@energyweb/origin-organization-irec-api';
 
 export class ClaimIRECCertificateCommand {
     constructor(

--- a/packages/traceability/issuer-irec-api/src/pods/certificate/dto/claim-irec-certificate.dto.ts
+++ b/packages/traceability/issuer-irec-api/src/pods/certificate/dto/claim-irec-certificate.dto.ts
@@ -1,16 +1,45 @@
-import { IsOptional } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, Validate, ValidateNested } from 'class-validator';
+import { IntUnitsOfEnergy, PositiveBNStringValidator } from '@energyweb/origin-backend-utils';
+
 import { ApiProperty } from '@nestjs/swagger';
-import { ClaimCertificateDTO } from '@energyweb/issuer-api';
-import { Expose } from 'class-transformer';
+import { IsDateString, IsString } from 'class-validator';
 
-export class ClaimIrecCertificateDTO extends ClaimCertificateDTO {
-    @ApiProperty({ type: String })
-    @IsOptional()
-    @Expose()
-    fromIrecAccountCode?: string;
+export class ClaimIrecDataDTO {
+    @ApiProperty({ type: String, example: 'Beneficiary One' })
+    @IsString()
+    beneficiary: string;
 
-    @ApiProperty({ type: String })
+    @ApiProperty({ type: String, example: '133 N. St, Orange County, CA 19444' })
+    @IsString()
+    location: string;
+
+    @ApiProperty({ type: String, example: 'US' })
+    @IsString()
+    countryCode: string;
+
+    @ApiProperty({ type: String, example: '2021-11-08T17:11:11.883Z', description: 'ISO String' })
+    @IsDateString()
+    periodStartDate: string;
+
+    @ApiProperty({ type: String, example: '2021-11-08T17:11:11.883Z', description: 'ISO String' })
+    @IsDateString()
+    periodEndDate: string;
+
+    @ApiProperty({ type: String, example: 'claiming' })
+    @IsString()
+    purpose: string;
+}
+
+export class ClaimIrecCertificateDTO {
+    @ApiPropertyOptional({ type: ClaimIrecDataDTO })
     @IsOptional()
-    @Expose()
-    toIrecAccountCode?: string;
+    @ValidateNested()
+    claimData?: ClaimIrecDataDTO;
+
+    @ApiPropertyOptional({ type: String, example: '1000000' })
+    @IsOptional()
+    @Validate(PositiveBNStringValidator)
+    @Validate(IntUnitsOfEnergy)
+    amount?: string;
 }

--- a/packages/traceability/issuer-irec-api/src/pods/certificate/handler/claim-irec-certificate.handler.ts
+++ b/packages/traceability/issuer-irec-api/src/pods/certificate/handler/claim-irec-certificate.handler.ts
@@ -3,6 +3,7 @@ import { CommandHandler, ICommandHandler, CommandBus } from '@nestjs/cqrs';
 import { Inject, InternalServerErrorException } from '@nestjs/common';
 import { IREC_SERVICE, IrecService } from '@energyweb/origin-organization-irec-api';
 import { ClaimCertificateCommand } from '@energyweb/issuer-api';
+import { IClaimData as IssuerClaimData } from '@energyweb/issuer';
 
 import { ClaimIRECCertificateCommand } from '../command';
 

--- a/packages/traceability/issuer-irec-api/src/pods/certificate/handler/claim-irec-certificate.handler.ts
+++ b/packages/traceability/issuer-irec-api/src/pods/certificate/handler/claim-irec-certificate.handler.ts
@@ -3,7 +3,6 @@ import { CommandHandler, ICommandHandler, CommandBus } from '@nestjs/cqrs';
 import { Inject, InternalServerErrorException } from '@nestjs/common';
 import { IREC_SERVICE, IrecService } from '@energyweb/origin-organization-irec-api';
 import { ClaimCertificateCommand } from '@energyweb/issuer-api';
-import { IClaimData as IssuerClaimData } from '@energyweb/issuer';
 
 import { ClaimIRECCertificateCommand } from '../command';
 

--- a/packages/traceability/issuer/test/Issuer.test.ts
+++ b/packages/traceability/issuer/test/Issuer.test.ts
@@ -7,7 +7,12 @@ import { getProviderWithFallback } from '@energyweb/utils-general';
 
 import { Wallet, BigNumber } from 'ethers';
 import { migrateIssuer, migratePrivateIssuer, migrateRegistry } from '../src/migrate';
-import { CertificationRequest, IBlockchainProperties, Certificate } from '../src';
+import {
+    CertificationRequest,
+    IBlockchainProperties,
+    Certificate,
+    CertificateSchemaVersion
+} from '../src';
 import { decodeData, encodeData } from '../src/blockchain-facade/CertificateUtils';
 
 describe('Issuer', () => {
@@ -188,7 +193,11 @@ describe('Issuer', () => {
 
         assert.exists(certificationRequest.issuedCertificateTokenId);
 
-        let certificate = await new Certificate(certificateId, blockchainProperties).sync();
+        let certificate = await new Certificate(
+            certificateId,
+            blockchainProperties,
+            CertificateSchemaVersion.Latest
+        ).sync();
 
         assert.equal(certificate.owners[deviceOwnerWallet.address], volume.toString());
 
@@ -214,7 +223,11 @@ describe('Issuer', () => {
         certificationRequest = await certificationRequest.sync();
         const certificateId = await certificationRequest.approve(volume);
 
-        let certificate = await new Certificate(certificateId, blockchainProperties).sync();
+        let certificate = await new Certificate(
+            certificateId,
+            blockchainProperties,
+            CertificateSchemaVersion.Latest
+        ).sync();
 
         const attackerIssuerContract = await migrateIssuer(
             provider,

--- a/packages/trade/exchange-io-erc1888/src/withdrawal-processor/withdrawal-processor.service.ts
+++ b/packages/trade/exchange-io-erc1888/src/withdrawal-processor/withdrawal-processor.service.ts
@@ -13,7 +13,12 @@ import {
     Transfer,
     TransferService
 } from '@energyweb/exchange';
-import { Certificate, Contracts, IBlockchainProperties } from '@energyweb/issuer';
+import {
+    Certificate,
+    Contracts,
+    IBlockchainProperties,
+    CertificateSchemaVersion
+} from '@energyweb/issuer';
 
 @Injectable()
 export class WithdrawalProcessorService implements OnModuleInit {
@@ -137,7 +142,8 @@ export class WithdrawalProcessorService implements OnModuleInit {
         try {
             const certificate = await new Certificate(
                 Number(transfer.asset.tokenId),
-                this.blockchainProperties
+                this.blockchainProperties,
+                CertificateSchemaVersion.V1
             ).sync();
 
             if (

--- a/packages/trade/exchange-io-erc1888/test/deposits-withdrawals.e2e-spec.ts
+++ b/packages/trade/exchange-io-erc1888/test/deposits-withdrawals.e2e-spec.ts
@@ -27,7 +27,7 @@ import { getProviderWithFallback } from '@energyweb/utils-general';
 import { RegistryExtended } from '@energyweb/issuer/dist/js/src/ethers/RegistryExtended';
 import { Issuer } from '@energyweb/issuer/dist/js/src/ethers/Issuer';
 import { ConfigService } from '@nestjs/config';
-import { Certificate } from '@energyweb/issuer';
+import { Certificate, CertificateSchemaVersion } from '@energyweb/issuer';
 import { ExchangeErc1888Module } from '../src';
 
 const web3 = 'http://localhost:8590';
@@ -322,11 +322,15 @@ describe('Deposits using deployed registry', () => {
 
         expect(claimedBalance.toString()).to.equal(tokenAmount);
 
-        const certificate = await new Certificate(Number(tokenId), {
-            registry,
-            issuer,
-            web3: getProviderWithFallback(web3)
-        }).sync();
+        const certificate = await new Certificate(
+            Number(tokenId),
+            {
+                registry,
+                issuer,
+                web3: getProviderWithFallback(web3)
+            },
+            CertificateSchemaVersion.V1
+        ).sync();
 
         const [claimDetails] = await certificate.getClaimedData();
         expect(claimDetails.claimData).to.deep.equal(claim.claimData);

--- a/packages/trade/exchange/src/pods/transfer/dto/claim-data.dto.ts
+++ b/packages/trade/exchange/src/pods/transfer/dto/claim-data.dto.ts
@@ -1,6 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IClaimData } from '@energyweb/issuer';
 import { IsDateString, IsString } from 'class-validator';
+
+export type IClaimData = {
+    beneficiary: string;
+    location: string;
+    countryCode: string;
+    periodStartDate: string;
+    periodEndDate: string;
+    purpose: string;
+};
 
 export class ClaimDataDTO implements IClaimData {
     @ApiProperty({ type: String, example: 'Beneficiary One' })

--- a/packages/trade/exchange/src/pods/transfer/transfer.entity.ts
+++ b/packages/trade/exchange/src/pods/transfer/transfer.entity.ts
@@ -1,9 +1,8 @@
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
 import { IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { IClaimData } from '@energyweb/issuer';
 import { ExtendedBaseEntity } from '@energyweb/origin-backend-utils';
-
+import { IClaimData } from '../transfer/dto/claim-data.dto';
 import { Asset } from '../asset';
 import { ClaimDataDTO } from './dto';
 import { DB_TABLE_PREFIX } from '../../utils';

--- a/packages/ui/libs/certificate/data/src/fetching/getBlockchainCertificate.ts
+++ b/packages/ui/libs/certificate/data/src/fetching/getBlockchainCertificate.ts
@@ -10,7 +10,10 @@ import { IBlockchainProperties } from '@energyweb/issuer';
 */
 import { RegistryExtended__factory as RegistryExtendedFactory } from '@energyweb/issuer/dist/js/src/ethers/factories/RegistryExtended__factory';
 import { Issuer__factory as IssuerFactory } from '@energyweb/issuer/dist/js/src/ethers/factories/Issuer__factory';
-import { Certificate } from '@energyweb/issuer/dist/js/src/blockchain-facade/Certificate';
+import {
+  Certificate,
+  CertificateSchemaVersion,
+} from '@energyweb/issuer/dist/js/src/blockchain-facade/Certificate';
 
 export const useGetBlockchainCertificateHandler = () => {
   const { data: blockchainProperties, isLoading } =
@@ -29,7 +32,11 @@ export const useGetBlockchainCertificateHandler = () => {
       activeUser: web3.getSigner(),
     };
 
-    const certificate = new Certificate(id, configuration);
+    const certificate = new Certificate(
+      id,
+      configuration,
+      CertificateSchemaVersion.V1
+    );
     await certificate.sync();
     return certificate;
   };


### PR DESCRIPTION
Reason: We want claim data to be generic, because enforcing specific fields does not apply to all applications

Solution:
1. Make claim data to be generic JSON-serializable fields
2. Add schema version to issuer - parsing claim data from contract will require this to understand, how it should be parsed (either backward compatible or not)
3. Adjust code in all origin applications, that import claim data interface from issuer
