### PR TITLE
feat(exchange): return all trades with additional data for admin

### DIFF
--- a/packages/trade/exchange-irec/src/trade/trade.controller.ts
+++ b/packages/trade/exchange-irec/src/trade/trade.controller.ts
@@ -1,4 +1,4 @@
-import { BaseTradeController } from '@energyweb/exchange';
+import { BaseTradeController, BaseTradeControllerGetAllResponse } from '@energyweb/exchange';
 import { ILoggedInUser } from '@energyweb/origin-backend-core';
 import {
     UserDecorator,
@@ -8,17 +8,16 @@ import {
 import {
     Controller,
     Get,
-    HttpStatus,
     UseGuards,
     UseInterceptors,
     UsePipes,
     ValidationPipe
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { ProductDTO, ProductFilterDTO } from '../product';
 
-import { TradeDTO } from './trade.dto';
+import { TradeDTO, TradeForAdminDTO } from './trade.dto';
 
 @ApiTags('trade')
 @ApiBearerAuth('access-token')
@@ -28,8 +27,10 @@ import { TradeDTO } from './trade.dto';
 export class TradeController extends BaseTradeController<ProductDTO, ProductFilterDTO> {
     @UseGuards(AuthGuard(), ActiveUserGuard)
     @Get()
-    @ApiResponse({ status: HttpStatus.OK, type: [TradeDTO], description: 'Get all trades' })
-    public async getAll(@UserDecorator() user: ILoggedInUser): Promise<TradeDTO[]> {
+    @BaseTradeControllerGetAllResponse(TradeDTO, TradeForAdminDTO)
+    public async getAll(
+        @UserDecorator() user: ILoggedInUser
+    ): Promise<(TradeDTO | TradeForAdminDTO)[]> {
         return super.getAll(user);
     }
 }

--- a/packages/trade/exchange-irec/src/trade/trade.dto.ts
+++ b/packages/trade/exchange-irec/src/trade/trade.dto.ts
@@ -1,9 +1,17 @@
-import { TradeDTO as BaseTradeDTO } from '@energyweb/exchange';
+import {
+    TradeDTO as BaseTradeDTO,
+    TradeForAdminDTO as BaseTradeForAdminDTO
+} from '@energyweb/exchange';
 import { ApiProperty } from '@nestjs/swagger';
 
 import { ProductDTO } from '../product/product.dto';
 
 export class TradeDTO extends BaseTradeDTO<ProductDTO> {
+    @ApiProperty({ type: () => ProductDTO })
+    public product: ProductDTO;
+}
+
+export class TradeForAdminDTO extends BaseTradeForAdminDTO<ProductDTO> {
     @ApiProperty({ type: () => ProductDTO })
     public product: ProductDTO;
 }

--- a/packages/trade/exchange/src/pods/trade/base-trade.controller.ts
+++ b/packages/trade/exchange/src/pods/trade/base-trade.controller.ts
@@ -1,4 +1,4 @@
-import { ILoggedInUser } from '@energyweb/origin-backend-core';
+import { ILoggedInUser, Role } from '@energyweb/origin-backend-core';
 import {
     UserDecorator,
     ActiveUserGuard,
@@ -14,10 +14,29 @@ import {
     ValidationPipe
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
-
-import { TradeDTO } from './trade.dto';
+import { ApiBearerAuth, ApiExtraModels, ApiResponse, ApiTags, refs } from '@nestjs/swagger';
+import { TradeDTO, TradeForAdminDTO } from './trade.dto';
 import { TradeService } from './trade.service';
+
+export const BaseTradeControllerGetAllResponse = (...models: Function[]) => {
+    return (
+        target: object,
+        key?: string | symbol,
+        descriptor?: TypedPropertyDescriptor<any>
+    ): any => {
+        ApiExtraModels(...models)(target, key, descriptor);
+        ApiResponse({
+            status: HttpStatus.OK,
+            schema: {
+                type: 'array',
+                items: {
+                    oneOf: refs(...models)
+                }
+            },
+            description: 'Get all trades'
+        })(target, key, descriptor);
+    };
+};
 
 @ApiTags('trade')
 @ApiBearerAuth('access-token')
@@ -29,16 +48,26 @@ export abstract class BaseTradeController<TProduct, TProductFilter> {
 
     @UseGuards(AuthGuard(), ActiveUserGuard)
     @Get()
-    @ApiResponse({ status: HttpStatus.OK, type: [TradeDTO], description: 'Get all trades' })
-    public async getAll(@UserDecorator() user: ILoggedInUser): Promise<TradeDTO<TProduct>[]> {
-        const trades = await this.tradeService.getAllByUser(user.ownerId, false);
+    @BaseTradeControllerGetAllResponse(TradeDTO, TradeForAdminDTO)
+    public async getAll(
+        @UserDecorator() user: ILoggedInUser
+    ): Promise<(TradeDTO<TProduct> | TradeForAdminDTO<TProduct>)[]> {
+        if (user.hasRole(Role.Admin)) {
+            const trades = await this.tradeService.getAll();
 
-        return trades.map((trade) =>
-            TradeDTO.fromTrade(
-                trade.withMaskedOrder(user.ownerId),
-                trade.ask.assetId,
-                trade.ask.product
-            )
-        );
+            return trades.map((trade) =>
+                TradeForAdminDTO.fromTradeForAdmin(trade, trade.ask.asset, trade.ask.product)
+            );
+        } else {
+            const trades = await this.tradeService.getAllByUser(user.ownerId, false);
+
+            return trades.map((trade) =>
+                TradeDTO.fromTrade(
+                    trade.withMaskedOrder(user.ownerId),
+                    trade.ask.assetId,
+                    trade.ask.product
+                )
+            );
+        }
     }
 }

--- a/packages/trade/exchange/src/pods/trade/trade.dto.ts
+++ b/packages/trade/exchange/src/pods/trade/trade.dto.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDateString, IsNotEmpty, IsNumber, IsUUID, Validate } from 'class-validator';
+import { IsDateString, IsNotEmpty, IsNumber, IsString, IsUUID, Validate } from 'class-validator';
 import { IntUnitsOfEnergy, PositiveBNStringValidator } from '@energyweb/origin-backend-utils';
 import { Trade } from './trade.entity';
+import { IAsset } from '../asset/asset.entity';
 
 export class TradeDTO<TProduct> {
     @ApiProperty({
@@ -60,6 +61,43 @@ export class TradeDTO<TProduct> {
             askId: trade.ask?.id,
             assetId,
             product
+        };
+    }
+}
+
+export class TradeForAdminDTO<TProduct> extends TradeDTO<TProduct> {
+    @ApiProperty({ type: String, example: '1' })
+    @IsNotEmpty()
+    @IsString()
+    tokenId: string;
+
+    @ApiProperty({ type: String })
+    @IsNotEmpty()
+    @IsString()
+    askUserId: string;
+
+    @ApiProperty({ type: String })
+    @IsNotEmpty()
+    @IsString()
+    bidUserId: string;
+
+    public static fromTradeForAdmin<TProduct>(
+        trade: Trade,
+        asset: IAsset,
+        product: TProduct
+    ): TradeForAdminDTO<TProduct> {
+        return {
+            id: trade.id,
+            created: trade.created.toISOString(),
+            price: trade.price,
+            volume: trade.volume.toString(10),
+            bidId: trade.bid?.id,
+            askId: trade.ask?.id,
+            assetId: asset.id,
+            product,
+            askUserId: trade.ask?.userId,
+            bidUserId: trade.bid?.userId,
+            tokenId: asset.tokenId
         };
     }
 }

--- a/packages/trade/exchange/src/pods/trade/trade.service.ts
+++ b/packages/trade/exchange/src/pods/trade/trade.service.ts
@@ -107,7 +107,7 @@ export class TradeService<TProduct, TProductFilter> implements OnModuleInit {
         });
     }
 
-    private async getAll() {
+    public async getAll() {
         return this.buildGetAllQuery().orderBy('trade.created', 'DESC').getMany();
     }
 

--- a/packages/trade/exchange/test/exchange.ts
+++ b/packages/trade/exchange/test/exchange.ts
@@ -34,11 +34,22 @@ const WEB3 = 'http://localhost:8580';
 const registryDeployer = '0xc4b87d68ea2b91f9d3de3fcb77c299ad962f006ffb8711900cb93d94afec3dc3';
 
 export const authenticatedUser = { id: 1, organization: { id: '1000' }, status: UserStatus.Active };
+export const adminUser = {
+    id: 2,
+    organization: { id: '2000' },
+    status: UserStatus.Active,
+    rights: 16
+};
 
 const authGuard: CanActivate = {
     canActivate: (context: ExecutionContext) => {
         const req = context.switchToHttp().getRequest();
-        req.user = authenticatedUser;
+
+        if (req.headers['as-user'] === 'admin') {
+            req.user = adminUser;
+        } else {
+            req.user = authenticatedUser;
+        }
 
         return true;
     }

--- a/packages/trade/exchange/test/trade/trade.controller.ts
+++ b/packages/trade/exchange/test/trade/trade.controller.ts
@@ -7,17 +7,19 @@ import {
 import {
     Controller,
     Get,
-    HttpStatus,
     UseGuards,
     UseInterceptors,
     UsePipes,
     ValidationPipe
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
-import { BaseTradeController } from '../../src/pods/trade/base-trade.controller';
-import { TradeDTO } from './trade.dto';
+import {
+    BaseTradeController,
+    BaseTradeControllerGetAllResponse
+} from '../../src/pods/trade/base-trade.controller';
+import { TradeDTO, TradeForAdminDTO } from './trade.dto';
 
 @ApiTags('trade')
 @ApiBearerAuth('access-token')
@@ -27,8 +29,10 @@ import { TradeDTO } from './trade.dto';
 export class TradeController extends BaseTradeController<string, string> {
     @UseGuards(AuthGuard(), ActiveUserGuard)
     @Get()
-    @ApiResponse({ status: HttpStatus.OK, type: [TradeDTO], description: 'Get all trades' })
-    public async getAll(@UserDecorator() user: ILoggedInUser): Promise<TradeDTO[]> {
+    @BaseTradeControllerGetAllResponse(TradeDTO, TradeForAdminDTO)
+    public async getAll(
+        @UserDecorator() user: ILoggedInUser
+    ): Promise<(TradeDTO | TradeForAdminDTO)[]> {
         return super.getAll(user);
     }
 }

--- a/packages/trade/exchange/test/trade/trade.dto.ts
+++ b/packages/trade/exchange/test/trade/trade.dto.ts
@@ -1,8 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { TradeDTO as BaseTradeDTO } from '../../src/pods/trade';
+import {
+    TradeDTO as BaseTradeDTO,
+    TradeForAdminDTO as BaseTradeForAdminDTO
+} from '../../src/pods/trade';
 
 export class TradeDTO extends BaseTradeDTO<string> {
+    @ApiProperty({ type: String })
+    public product: string;
+}
+
+export class TradeForAdminDTO extends BaseTradeForAdminDTO<string> {
     @ApiProperty({ type: String })
     public product: string;
 }


### PR DESCRIPTION
Issue: https://energyweb.atlassian.net/browse/OV-1261

So the idea is that Admin now will be able to see all trades (not his own only), and will receive more information about the trades as well (asset.tokenId, and seller/buyer ids)